### PR TITLE
Fixed tags with incorrect types .. Capitalization issues and problems wi...

### DIFF
--- a/quickfixj-messages/quickfixj-messages-fix43/src/main/resources/FIX43.xml
+++ b/quickfixj-messages/quickfixj-messages-fix43/src/main/resources/FIX43.xml
@@ -2874,7 +2874,7 @@
       <value enum="VRDN" description="VARIABLE_RATE_DEMAND_NOTE" />
       <value enum="WAR" description="WARRANT" />
       <value enum="MF" description="MUTUAL_FUND" />
-      <value enum="MLEG" description="MULTILEG_INSTRUMENT" />
+      <value enum="MLEG" description="MULTI_LEG_INSTRUMENT" />
       <value enum="NONE" description="NO_SECURITY_TYPE" />
       <value description="WILDCARD" enum="?" />
     </field>

--- a/quickfixj-messages/quickfixj-messages-fix44/src/main/resources/FIX44.modified.xml
+++ b/quickfixj-messages/quickfixj-messages-fix44/src/main/resources/FIX44.modified.xml
@@ -4619,7 +4619,7 @@
       <value enum="MBS" description="MORTGAGE_BACKED_SECURITIES"/>
       <value enum="MF" description="MUTUAL_FUND"/>
       <value enum="MIO" description="MORTGAGE_INTEREST_ONLY"/>
-      <value enum="MLEG" description="MULTILEG_INSTRUMENT"/>
+      <value enum="MLEG" description="MULTI_LEG_INSTRUMENT"/>
       <value enum="MPO" description="MORTGAGE_PRINCIPAL_ONLY"/>
       <value enum="MPP" description="MORTGAGE_PRIVATE_PLACEMENT"/>
       <value enum="MPT" description="MISCELLANEOUS_PASS_THROUGH"/>

--- a/quickfixj-messages/quickfixj-messages-fix44/src/main/resources/FIX44.xml
+++ b/quickfixj-messages/quickfixj-messages-fix44/src/main/resources/FIX44.xml
@@ -4616,7 +4616,7 @@
       <value enum="MBS" description="MORTGAGE_BACKED_SECURITIES"/>
       <value enum="MF" description="MUTUAL_FUND"/>
       <value enum="MIO" description="MORTGAGE_INTEREST_ONLY"/>
-      <value enum="MLEG" description="MULTILEG_INSTRUMENT"/>
+      <value enum="MLEG" description="MULTI_LEG_INSTRUMENT"/>
       <value enum="MPO" description="MORTGAGE_PRINCIPAL_ONLY"/>
       <value enum="MPP" description="MORTGAGE_PRIVATE_PLACEMENT"/>
       <value enum="MPT" description="MISCELLANEOUS_PASS_THROUGH"/>

--- a/quickfixj-messages/quickfixj-messages-fix50/src/main/resources/FIX50.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50/src/main/resources/FIX50.xml
@@ -5114,7 +5114,7 @@
       <value enum="MBS" description="MORTGAGE_BACKED_SECURITIES"/>
       <value enum="MF" description="MUTUAL_FUND"/>
       <value enum="MIO" description="MORTGAGE_INTEREST_ONLY"/>
-      <value enum="MLEG" description="MULTILEG_INSTRUMENT"/>
+      <value enum="MLEG" description="MULTI_LEG_INSTRUMENT"/>
       <value enum="MPO" description="MORTGAGE_PRINCIPAL_ONLY"/>
       <value enum="MPP" description="MORTGAGE_PRIVATE_PLACEMENT"/>
       <value enum="MPT" description="MISCELLANEOUS_PASS_THROUGH"/>

--- a/quickfixj-messages/quickfixj-messages-fix50sp1/src/main/resources/FIX50SP1.modified.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50sp1/src/main/resources/FIX50SP1.modified.xml
@@ -5830,7 +5830,7 @@
       <value enum="BDN" description="BANK_DEPOSITORY_NOTE"/>
       <value enum="CMB" description="CANADIAN_MORTGAGE_BONDS"/>
       <value enum="COFO" description="CERTIFICATE_OF_OBLIGATION"/>
-      <value enum="MLEG" description="MULTILEG_INSTRUMENT"/>
+      <value enum="MLEG" description="MULTI_LEG_INSTRUMENT"/>
       <value enum="FADN" description="FEDERAL_AGENCY_DISCOUNT_NOTE"/>
       <value enum="CB" description="CONVERTIBLE_BOND"/>
       <value enum="OPT" description="OPTION"/>

--- a/quickfixj-messages/quickfixj-messages-fix50sp1/src/main/resources/FIX50SP1.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50sp1/src/main/resources/FIX50SP1.xml
@@ -5824,7 +5824,7 @@
       <value enum="BDN" description="BANK_DEPOSITORY_NOTE"/>
       <value enum="CMB" description="CANADIAN_MORTGAGE_BONDS"/>
       <value enum="COFO" description="CERTIFICATE_OF_OBLIGATION"/>
-      <value enum="MLEG" description="MULTILEG_INSTRUMENT"/>
+      <value enum="MLEG" description="MULTI_LEG_INSTRUMENT"/>
       <value enum="FADN" description="FEDERAL_AGENCY_DISCOUNT_NOTE"/>
       <value enum="CB" description="CONVERTIBLE_BOND"/>
       <value enum="OPT" description="OPTION"/>

--- a/quickfixj-messages/quickfixj-messages-fix50sp2/src/main/resources/FIX50SP2.modified.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50sp2/src/main/resources/FIX50SP2.modified.xml
@@ -6068,7 +6068,7 @@
       <value enum="BDN" description="BANK_DEPOSITORY_NOTE"/>
       <value enum="CMB" description="CANADIAN_MORTGAGE_BONDS"/>
       <value enum="COFO" description="CERTIFICATE_OF_OBLIGATION"/>
-      <value enum="MLEG" description="MULTILEG_INSTRUMENT"/>
+      <value enum="MLEG" description="MULTI_LEG_INSTRUMENT"/>
       <value enum="FXNDF" description="NON_DELIVERABLE_FORWARD"/>
       <value enum="FADN" description="FEDERAL_AGENCY_DISCOUNT_NOTE"/>
       <value enum="CB" description="CONVERTIBLE_BOND"/>

--- a/quickfixj-messages/quickfixj-messages-fix50sp2/src/main/resources/FIX50SP2.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50sp2/src/main/resources/FIX50SP2.xml
@@ -6058,7 +6058,7 @@
       <value enum="BDN" description="BANK_DEPOSITORY_NOTE"/>
       <value enum="CMB" description="CANADIAN_MORTGAGE_BONDS"/>
       <value enum="COFO" description="CERTIFICATE_OF_OBLIGATION"/>
-      <value enum="MLEG" description="MULTILEG_INSTRUMENT"/>
+      <value enum="MLEG" description="MULTI_LEG_INSTRUMENT"/>
       <value enum="FXNDF" description="NON_DELIVERABLE_FORWARD"/>
       <value enum="FADN" description="FEDERAL_AGENCY_DISCOUNT_NOTE"/>
       <value enum="CB" description="CONVERTIBLE_BOND"/>


### PR DESCRIPTION
...th MULTI_LEG rather than MULTILEG causing problems with backward compatibility with 1.5.3. Should add test case to illustrate runtime problem during method resolution when type is int rather than string but still working out an elegant means of doing this and cannot include code that breaks as its not public.
