### PR TITLE
Bump Slf4J and few other dependencies and .gitignore entries for IntelliJ.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ target/
 .project
 .classpath
 .settings
-
-
+# ignore IntelliJ configuration files
+.idea/
+*.iml
+*.ipr
+*.iws

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<jdkLevel>1.6</jdkLevel>
+		<slf4j.version>1.7.10</slf4j.version>
 		<mainClass/>
 	</properties>
 

--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
-			<version>1.8.0.1</version>
+			<version>1.8.0.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-jdk14</artifactId>
-			<version>1.6.3</version>
+			<version>${slf4j.version}</version>
 		    <scope>test</scope>
 		</dependency>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.6.3</version>
+			<version>${slf4j.version}</version>
 		</dependency>
 
 		<dependency>
@@ -89,7 +89,7 @@
 		    <!-- slf4j facade for JCL which is required by proxool -->
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
-			<version>1.6.3</version>
+			<version>${slf4j.version}</version>
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>

--- a/quickfixj-dictgenerator/pom.xml
+++ b/quickfixj-dictgenerator/pom.xml
@@ -40,7 +40,7 @@
 			<!-- required by dom4j at runtime -->
 			<groupId>jaxen</groupId>
 			<artifactId>jaxen</artifactId>
-			<version>1.1.1</version>
+			<version>1.1.4</version>
 			<scope>runtime</scope>
 			<!-- we don't need any of the transient dependencies -->
 			<exclusions>

--- a/quickfixj-examples/pom.xml
+++ b/quickfixj-examples/pom.xml
@@ -34,12 +34,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.6.3</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.6.3</version>
+            <version>${slf4j.version}</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
* Bump Slf4J to 1.7.10 (1.7.5 is the recommended version for Java 6+ which has improvements for getting logger instances faster)
* Bump few other non relevant dependencies like HSQL and Jaxen (Minor fixes)
* Added entries to .gitignore file for IntelliJ.