### PR TITLE
Bump JUnit and Mockito dependencies.

### DIFF
--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -22,13 +22,13 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.5</version>
+			<version>4.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
-			<version>1.4</version>
+			<version>1.10.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
* JUnit upgraded to 4.10, can't do 4.11+ for now due to order of execution for Java 7+, which can be fixed by annotating each test class though it is tedious to do so now, might be done later when I have more time.
* Mockito upgraded to latest stable which made me gain some tests performace; used to take almost 13 minutes on my laptop to do `mvn clean test` and now it is taking a little bit less than 12 minutes.