### PR TITLE
Apache mina-core bump to 2.0.9

### DIFF
--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>org.apache.mina</groupId>
 			<artifactId>mina-core</artifactId>
-			<version>2.0.7</version>
+			<version>2.0.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
This should had been included in my previous bump deps branch, or I just noticed such version was available on Maven central.