### PR TITLE
Bump Maven plugins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,11 @@
 			<plugins>
 				<plugin>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>2.6</version>
+					<version>2.7</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.1</version>
+					<version>3.2</version>
 					<configuration>
 						<source>${jdkLevel}</source>
 						<target>${jdkLevel}</target>
@@ -62,7 +62,7 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.4</version>
+					<version>2.6</version>
 					<configuration>
 						<archive>
 							<manifest>
@@ -74,18 +74,18 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.16</version>
+					<version>2.18.1</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-pmd-plugin</artifactId>
-					<version>3.0.1</version>
+					<version>3.4</version>
 					<configuration>
 						<targetJdk>${jdkLevel}</targetJdk>
 					</configuration>
 				</plugin>
 				<plugin>
 					<artifactId>maven-source-plugin</artifactId>
-					<version>2.2.1</version>
+					<version>2.4</version>
 					<executions>
 						<execution>
 							<id>attach-sources</id>
@@ -102,7 +102,7 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-assembly-plugin</artifactId>
-					<version>2.4</version>
+					<version>2.5.2</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -112,7 +112,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.4.0</version>
+				<version>2.5.3</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>

--- a/quickfixj-codegenerator/pom.xml
+++ b/quickfixj-codegenerator/pom.xml
@@ -25,12 +25,12 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>2.0</version>
+			<version>3.2.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-project</artifactId>
-			<version>2.0</version>
+			<version>2.2.1</version>
 		</dependency>
 	</dependencies>
 

--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -308,7 +308,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>2.16</version>
+				<version>2.18.1</version>
 				<reportSets/>
 				<configuration>
 					<showSuccess>true</showSuccess>
@@ -316,11 +316,11 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
+				<version>2.10.1</version>
 			</plugin>
 			<plugin>
 				<artifactId>maven-jxr-plugin</artifactId>
-				<version>2.4</version>
+				<version>2.5</version>
 			</plugin>
 		</plugins>
 	</reporting>

--- a/quickfixj-distribution/pom.xml
+++ b/quickfixj-distribution/pom.xml
@@ -128,7 +128,7 @@
 			<!-- generate javadocs into apidocs folder -->
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
+				<version>2.10.1</version>
 				<executions>
 					<execution>
 						<id>javadoc-jar</id>


### PR DESCRIPTION
Bump Maven plugins version, except for `maven-assembly-plugin` which latest version 2.5.3 has a bug and hence was bumped only to 2.5.2, bug described below:

https://jira.codehaus.org/browse/MASSEMBLY-747