### PR TITLE
Bump Maven version to 3.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 	</licenses>
 
 	<prerequisites>
-		<maven>3.0.4</maven>
+		<maven>3.2.5</maven>
 	</prerequisites>
 
 	<modules>


### PR DESCRIPTION
Update pre-requisite to latest Maven, this will force contributors to use latest Maven which could be a hassle to update but the benefit is that it will also inherit newer plugins overall, also less whole system overload while building QuickFixJ.