### PR TITLE
Maven -Dgenerator.decimal=true will generate classes using BigDecimal

### DIFF
--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -156,6 +156,7 @@
 							<dictFile>../quickfixj-messages/quickfixj-messages-fixt11/src/main/resources/FIXT11.xml</dictFile>
 							<packaging>quickfix.fixt11</packaging>
 							<fieldPackage>quickfix.field</fieldPackage>
+							<decimal>${generator.decimal}</decimal>
 						</configuration>
 					</execution>
 					<execution>
@@ -167,6 +168,7 @@
 							<dictFile>../quickfixj-messages/quickfixj-messages-fix50/src/main/resources/FIX50.xml</dictFile>
 							<packaging>quickfix.fix50</packaging>
 							<fieldPackage>quickfix.field</fieldPackage>
+							<decimal>${generator.decimal}</decimal>
 						</configuration>
 					</execution>
 					<execution>
@@ -178,6 +180,7 @@
 							<dictFile>../quickfixj-messages/quickfixj-messages-fix44/src/main/resources/FIX44.xml</dictFile>
 							<packaging>quickfix.fix44</packaging>
 							<fieldPackage>quickfix.field</fieldPackage>
+							<decimal>${generator.decimal}</decimal>
 						</configuration>
 					</execution>
 					<execution>
@@ -189,6 +192,7 @@
 							<dictFile>../quickfixj-messages/quickfixj-messages-fix43/src/main/resources/FIX43.xml</dictFile>
 							<packaging>quickfix.fix43</packaging>
 							<fieldPackage>quickfix.field</fieldPackage>
+							<decimal>${generator.decimal}</decimal>
 						</configuration>
 					</execution>
 					<execution>
@@ -200,6 +204,7 @@
 							<dictFile>../quickfixj-messages/quickfixj-messages-fix42/src/main/resources/FIX42.xml</dictFile>
 							<packaging>quickfix.fix42</packaging>
 							<fieldPackage>quickfix.field</fieldPackage>
+							<decimal>${generator.decimal}</decimal>
 						</configuration>
 					</execution>
 					<execution>
@@ -211,6 +216,7 @@
 							<dictFile>../quickfixj-messages/quickfixj-messages-fix41/src/main/resources/FIX41.xml</dictFile>
 							<packaging>quickfix.fix41</packaging>
 							<fieldPackage>quickfix.field</fieldPackage>
+							<decimal>${generator.decimal}</decimal>
 						</configuration>
 					</execution>
 					<execution>
@@ -222,6 +228,7 @@
 							<dictFile>../quickfixj-messages/quickfixj-messages-fix40/src/main/resources/FIX40.xml</dictFile>
 							<packaging>quickfix.fix40</packaging>
 							<fieldPackage>quickfix.field</fieldPackage>
+							<decimal>${generator.decimal}</decimal>
 						</configuration>
 					</execution>
 				</executions>

--- a/quickfixj-messages/pom.xml
+++ b/quickfixj-messages/pom.xml
@@ -52,6 +52,7 @@
 								<dictFile>src/main/resources/${fix.spec}</dictFile>
 								<packaging>quickfix.${fix.name}</packaging>
 								<fieldPackage>quickfix.field</fieldPackage>
+								<decimal>${generator.decimal}</decimal>
 							</configuration>
 						</execution>
 					</executions>


### PR DESCRIPTION
Maven -Dgenerator.decimal=true will generate classes using BigDecimal.

@chrjohn The other 2 pull requests I sent I can assure you they are harmless and a good thing, for example, IntelliJ has done its best effort to migrate specific classes to use proper Java 6 which is the minimum requirement for QuickFixJ 1.6+

And forcing maven to 3.2.5 is not a bad thing either, Maven 3.3.1 was released so that would be the latest 3.2.x as requirement which does a better job than 3.0.x or 3.1.x

Is there any other parameter that needs to be fixed that isn't working when the project was migrated from Ant to Maven?

As for BigDecimal, in this branch it keeps the default value which is false but this is something that nobody would recommend for financial applications.