### PR TITLE
Moving the setLogoutReceived flag to before we generate a logout response

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -1294,6 +1294,8 @@ public class Session implements Closeable {
             return;
         }
 
+        state.setLogoutReceived(true);
+
         String msg;
         if (!state.isLogoutSent()) {
             msg = "Received logout request";
@@ -1307,8 +1309,6 @@ public class Session implements Closeable {
             msg = "Received logout response";
             getLog().onEvent(msg);
         }
-
-        state.setLogoutReceived(true);
 
         // QFJ-750
         if (getExpectedTargetNum() == logout.getHeader().getInt(MsgSeqNum.FIELD)) {


### PR DESCRIPTION
 This means we can query this flag in the toAdmin callback.