### PR TITLE
Maven plugins updated and compiler fork=true option removed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 	</licenses>
 
 	<prerequisites>
-		<maven>3.2.5</maven>
+		<maven>3.3.3</maven>
 	</prerequisites>
 
 	<modules>
@@ -56,7 +56,6 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.3</version>
 					<configuration>
-					    <fork>true</fork>
 						<meminitial>128m</meminitial>
 						<maxmem>512m</maxmem>
 						<source>${jdkLevel}</source>
@@ -105,7 +104,7 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-assembly-plugin</artifactId>
-					<version>2.5.2</version>
+					<version>2.5.4</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/quickfixj-codegenerator/pom.xml
+++ b/quickfixj-codegenerator/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>3.2.5</version>
+			<version>3.3.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>

--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -323,7 +323,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.1</version>
+				<version>2.10.3</version>
 			</plugin>
 			<plugin>
 				<artifactId>maven-jxr-plugin</artifactId>

--- a/quickfixj-distribution/pom.xml
+++ b/quickfixj-distribution/pom.xml
@@ -128,7 +128,7 @@
 			<!-- generate javadocs into apidocs folder -->
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.1</version>
+				<version>2.10.3</version>
 				<executions>
 					<execution>
 						<id>javadoc-jar</id>


### PR DESCRIPTION
Maven plugins updated and compiler `fork=true` option removed because it breaks the build, also, Maven prerequisite updated to latest 3.3.3 to keep default plugins at latest required versions.

All other pending pull requests should build properly after this one is merged, excluding Travis which should be set to Oracle JDK 7 which won't interfere with JDK 6 requirement of the project but will build faster due to JDK 7 performance vs JDK 6.

**Note:** Apache Felix bundle plugin makes build fail if updated to 2.5.4, so I left it at 2.5.3