### PR TITLE
Allocations optimization for sfl4j logs

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/SLF4JLog.java
+++ b/quickfixj-core/src/main/java/quickfix/SLF4JLog.java
@@ -47,26 +47,24 @@ public class SLF4JLog extends AbstractLog {
 
     private final Logger outgoingMsgLog;
 
-    private final String logPrefix;
-
     private final String callerFQCN;
 
     public SLF4JLog(SessionID sessionID, String eventCategory, String errorEventCategory,
-            String incomingMsgCategory, String outgoingMsgCategory, boolean prependSessionID,
-            boolean logHeartbeats, String inCallerFQCN) {
+                    String incomingMsgCategory, String outgoingMsgCategory, boolean prependSessionID,
+                    boolean logHeartbeats, String inCallerFQCN) {
         setLogHeartbeats(logHeartbeats);
-        logPrefix = prependSessionID ? (sessionID + ": ") : null;
-        eventLog = getLogger(sessionID, eventCategory, DEFAULT_EVENT_CATEGORY);
-        errorEventLog = getLogger(sessionID, errorEventCategory, DEFAULT_ERROR_EVENT_CATEGORY);
-        incomingMsgLog = getLogger(sessionID, incomingMsgCategory, DEFAULT_INCOMING_MSG_CATEGORY);
-        outgoingMsgLog = getLogger(sessionID, outgoingMsgCategory, DEFAULT_OUTGOING_MSG_CATEGORY);
+        String logPrefix = prependSessionID ? (sessionID + ": ") : "";
+        eventLog = getLogger(sessionID, eventCategory, DEFAULT_EVENT_CATEGORY, logPrefix);
+        errorEventLog = getLogger(sessionID, errorEventCategory, DEFAULT_ERROR_EVENT_CATEGORY, logPrefix);
+        incomingMsgLog = getLogger(sessionID, incomingMsgCategory, DEFAULT_INCOMING_MSG_CATEGORY, logPrefix);
+        outgoingMsgLog = getLogger(sessionID, outgoingMsgCategory, DEFAULT_OUTGOING_MSG_CATEGORY, logPrefix);
         callerFQCN = inCallerFQCN;
     }
 
-    private Logger getLogger(SessionID sessionID, String category, String defaultCategory) {
-        return LoggerFactory.getLogger(category != null
+    private Logger getLogger(SessionID sessionID, String category, String defaultCategory, String logPrefix) {
+        return LoggerFactory.getLogger((category != null
                 ? substituteVariables(sessionID, category)
-                : defaultCategory);
+                : defaultCategory) + logPrefix);
     }
 
     private static final String FIX_MAJOR_VERSION_VAR = "\\$\\{fixMajorVersion}";
@@ -134,23 +132,23 @@ public class SLF4JLog extends AbstractLog {
      */
     protected void log(org.slf4j.Logger log, String text) {
         if (log.isInfoEnabled()) {
-            final String message = logPrefix != null ? (logPrefix + text) : text;
             if (log instanceof LocationAwareLogger) {
                 final LocationAwareLogger la = (LocationAwareLogger) log;
-                la.log(null, callerFQCN, LocationAwareLogger.INFO_INT, message, null, null);
+                la.log(null, callerFQCN, LocationAwareLogger.INFO_INT, text, null, null);
             } else {
-                log.info(message);
+                log.info(text);
             }
         }
     }
 
     protected void logError(org.slf4j.Logger log, String text) {
-        final String message = logPrefix != null ? (logPrefix + text) : text;
-        log.error(message);
+        log.error(text);
     }
 
+    private final String clearString = "Log clear operation is not supported: " + getClass().getName();
+
     public void clear() {
-        onEvent("Log clear operation is not supported: " + getClass().getName());
+        onEvent(clearString);
     }
 
 }


### PR DESCRIPTION
Setup the logger with the session id log prefix when requestes, instead of building a new string on each log message.