### PR TITLE
Send fix message before logging it

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -2512,16 +2512,17 @@ public class Session implements Closeable {
     }
 
     private boolean send(String messageString) {
-        getLog().onOutgoing(messageString);
-        Responder responder;
-        synchronized (responderLock) {
-            responder = this.responder;
-        }
-        if (responder == null) {
-            getLog().onEvent("No responder, not sending message: " + messageString);
+        Responder responder = this.responder;
+        if(null == responder) {
+            this.getLog().onEvent("No responder, not sending message: " + messageString);
             return false;
+        } else {
+            try {
+                return responder.send(messageString);
+            } finally {
+                getLog().onOutgoing(messageString);
+            }
         }
-        return responder.send(messageString);
     }
 
     private boolean isCorrectCompID(Message message) throws FieldNotFound {


### PR DESCRIPTION
Only updated the "boolean send(String messageString)" method.		
Do not wait for the logger to perform its task before sending a message.

-> As a side effect, the logged fix message may now appears after other messages from the network stack.

Avoid printing the fix message to send two time in case of error (no responder).
Removed the synchronization as it is contention prone, and not really needed : it should not really prevent synch issue with either setResponder(...) or disconnect(...) methods.
