### PR TITLE
Message length & checksum optimization

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -129,6 +129,19 @@ public class Message extends FieldMap {
         return message;
     }
 
+    private static final class Context {
+        private final BodyLength bodyLength = new BodyLength(100);
+        private final CheckSum checkSum = new CheckSum("000");
+        private final StringBuilder stringBuilder = new StringBuilder(1024);
+    }
+
+    private static final ThreadLocal<Context> stringContexts = new ThreadLocal<Context>() {
+        @Override
+        protected Context initialValue() {
+            return new Context();
+        }
+    };
+
     /**
      * Do not call this method concurrently while modifying the contents of the message.
      * This is likely to produce unexpected results or will fail with a ConcurrentModificationException
@@ -136,16 +149,111 @@ public class Message extends FieldMap {
      */
     @Override
     public String toString() {
-        final int bodyLength = bodyLength();
-        header.setInt(BodyLength.FIELD, bodyLength);
-        trailer.setString(CheckSum.FIELD, checksum());
+        Context context = stringContexts.get();
+        header.setField(context.bodyLength);
+        trailer.setField(context.checkSum);
+        StringBuilder stringBuilder = context.stringBuilder;
+        try {
+            header.calculateString(stringBuilder, null, null);
+            calculateString(stringBuilder, null, null);
+            trailer.calculateString(stringBuilder, null, null);
+            setBodyLength(stringBuilder);
+            setChecksum(stringBuilder);
+            return stringBuilder.toString();
+        } finally {
+            stringBuilder.setLength(0);
+        }
+    }
 
-        final StringBuilder sb = new StringBuilder(bodyLength);
-        header.calculateString(sb, null, null);
-        calculateString(sb, null, null);
-        trailer.calculateString(sb, null, null);
+    private static final String beginStringField = String.valueOf(BeginString.FIELD);
+    private static final String separatorFix = String.valueOf('\001');
+    private static final String bodyLengthField = separatorFix + String.valueOf(BodyLength.FIELD) + '=';
+    private static final String checkSumField = separatorFix + String.valueOf(CheckSum.FIELD) + '=';
 
-        return sb.toString();
+    private static void setBodyLength(StringBuilder stringBuilder) {
+        int index = indexOf(stringBuilder, beginStringField, 0);
+        if(index != 0)
+            throw new IllegalArgumentException("Malformed FIX message");
+        int bodyLengthIndex = getIndex(stringBuilder, bodyLengthField, 0);
+        index = getIndex(stringBuilder, separatorFix, bodyLengthIndex + 1);
+        int checkSumIndex = lastIndexOf(stringBuilder, checkSumField);
+        if(checkSumIndex < 0)
+            throw new IllegalArgumentException("Malformed FIX message");
+        int length = checkSumIndex - index;
+        bodyLengthIndex += bodyLengthField.length();
+        stringBuilder.replace(bodyLengthIndex, bodyLengthIndex + 3, NumbersCache.get(length));
+    }
+
+    private static void setChecksum(StringBuilder stringBuilder) {
+        int checkSumIndex = lastIndexOf(stringBuilder, checkSumField);
+        int checkSum = 0;
+        for(int i = checkSumIndex; i-- != 0;)
+            checkSum += stringBuilder.charAt(i);
+        String checkSumValue = NumbersCache.get((checkSum + 1) % 256);
+        checkSumIndex += checkSumField.length();
+        stringBuilder.replace(checkSumIndex + (3 - checkSumValue.length()), checkSumIndex + 3, checkSumValue);
+    }
+
+    private static int getIndex(StringBuilder stringBuilder, String value, int fromIndex) {
+        int index = indexOf(stringBuilder, value, fromIndex);
+        if(index < 0)
+            throw new IllegalArgumentException("Malformed FIX message");
+        return index;
+    }
+
+    // return index of a string in a stringbuilder without performing allocations
+    private static int indexOf(StringBuilder source, String target, int fromIndex) {
+        if (fromIndex >= source.length())
+            return (target.length() == 0 ? source.length() : -1);
+        if (fromIndex < 0)
+            fromIndex = 0;
+        if (target.length() == 0)
+            return fromIndex;
+        char first = target.charAt(0);
+        int max = source.length() - target.length();
+        for (int i = fromIndex; i <= max; i++) {
+            if (source.charAt(i) != first)
+                while (++i <= max && source.charAt(i) != first);
+            if (i <= max) {
+                int j = i + 1;
+                int end = j + target.length() - 1;
+                for (int k = 1; j < end && source.charAt(j)
+                                           == target.charAt(k); j++, k++);
+                if (j == end)
+                    return i;
+            }
+        }
+        return -1;
+    }
+
+    // return last index of a string in a stringbuilder without performing allocations
+    static int lastIndexOf(StringBuilder source, String target) {
+        int rightIndex = source.length() - target.length();
+        int fromIndex = source.length();
+        if (fromIndex > rightIndex)
+            fromIndex = rightIndex;
+        if (target.length() == 0)
+            return fromIndex;
+        int strLastIndex = target.length() - 1;
+        char strLastChar = target.charAt(strLastIndex);
+        int min = target.length() - 1;
+        int i = min + fromIndex;
+        startSearchForLastChar:
+        while (true) {
+            while (i >= min && source.charAt(i) != strLastChar)
+                i--;
+            if (i < min)
+                return -1;
+            int j = i - 1;
+            int start = j - (target.length() - 1);
+            int k = strLastIndex - 1;
+            while (j > start)
+                if (source.charAt(j--) != target.charAt(k--)) {
+                    i--;
+                    continue startSearchForLastChar;
+                }
+            return start + 1;
+        }
     }
 
     public int bodyLength() {

--- a/quickfixj-core/src/main/java/quickfix/NumbersCache.java
+++ b/quickfixj-core/src/main/java/quickfix/NumbersCache.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) quickfixengine.org  All rights reserved.
+ *
+ * This file is part of the QuickFIX FIX Engine
+ *
+ * This file may be distributed under the terms of the quickfixengine.org
+ * license as defined by quickfixengine.org and appearing in the file
+ * LICENSE included in the packaging of this file.
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING
+ * THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * See http://www.quickfixengine.org/LICENSE for licensing information.
+ *
+ * Contact ask@quickfixengine.org if any conditions of this licensing
+ * are not clear to you.
+ ******************************************************************************/
+
+package quickfix;
+
+import java.util.ArrayList;
+
+/**
+ * A cache for commonly used string representing numbers.
+ * Hold values from 0 to 999999 and from 1000 to 200 000 000 by step of 1000
+ */
+public final class NumbersCache {
+
+    private static final int littleNumbersLength = 1000000;
+    private static final int bigNumbersLength = 200000;
+    private static final int bigNumbersOffset = 1000;
+    private static final int bigNumbersMax = bigNumbersLength * bigNumbersOffset;
+
+    public static final ArrayList<String> littleNumbers;
+    public static final ArrayList<String> bigNumbers;
+
+    static {
+        littleNumbers = new ArrayList<String>(littleNumbersLength);
+        bigNumbers = new ArrayList<String>(bigNumbersLength);
+        for (int i = 0; i < littleNumbersLength; i++)
+            littleNumbers.add(Integer.toString(i));
+        for (long i = 0; i < bigNumbersLength;)
+            bigNumbers.add(Long.toString(++i * bigNumbersOffset));
+
+    }
+
+    /**
+     * Get the string representing the given number
+     *
+     * @param i the long to convert
+     * @return the String representing the long
+     */
+    public static String get(long i) {
+        if (i < littleNumbersLength)
+            return littleNumbers.get((int)i);
+        if (i <= bigNumbersMax && i % bigNumbersOffset == 0)
+            return bigNumbers.get((int)(i/bigNumbersOffset)-1);
+        return String.valueOf(i);
+    }
+
+    /**
+     * Get the string representing the given double if it's an integer
+     *
+     * @param d the double to convert
+     * @return the String representing the double or null if the double is not an integer
+     */
+    public static String get(double d) {
+        long l = (long)d;
+        if (d == (double)l)
+            return get(l);
+        return null;
+    }
+}


### PR DESCRIPTION
Use a thread local to reuse the string builder used to generate the fix message.
Perform message length & checksum calculation after the message has been build, this avoid to iterate over the fields multiple time, and avoid the allocation of some strings many times too.

This is the most important optimization for allocations.

When the charset used to send fix message is not string equivalent to the default jvm one, this optimization is not active. (But the code to compute length & checksum in this case will be optimized in a next pull request).
