### PR TITLE
Add a reset() method in Message

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/FieldMap.java
+++ b/quickfixj-core/src/main/java/quickfix/FieldMap.java
@@ -75,6 +75,15 @@ public abstract class FieldMap implements Serializable {
         groups.clear();
     }
 
+    public void reset() {
+        fields.clear();
+        for(List<Group> groupList : groups.values()) {
+            for(Group group : groupList)
+                group.reset();
+        }
+        groups.clear();
+    }
+
     public boolean isEmpty() {
         return fields.isEmpty();
     }

--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -350,6 +350,12 @@ public class Message extends FieldMap {
         position = 0;
     }
 
+    @Override
+    public void reset() {
+        super.reset();
+        this.position = 0;
+    }
+
     public static class Header extends FieldMap {
         static final long serialVersionUID = -3193357271891865972L;
         private static final int[] EXCLUDED_HEADER_FIELDS = { BeginString.FIELD, BodyLength.FIELD,


### PR DESCRIPTION
The clear() method is public but its purpose is not explained.
It does not allows to reuse a message because it removes the header & trailers content of a message.
This reset() method can be used to reuse a message.

It would be much efficient to reuse messages if we have List instead of TreeMap in FieldMap class, to store fields and groups. Because TreeMap allocate a bucket for each entry, and they cannot be recycled.
