### PR TITLE
Fix for QFJ-822: Reset cached DNS resolution information after a connection failure.

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
@@ -185,6 +185,7 @@ public class IoSessionInitiator {
 
         private void handleConnectException(Throwable e) {
             ++connectionFailureCount;
+            unresolveCurrentSocketAddress();
             while (e.getCause() != null) {
                 e = e.getCause();
             }
@@ -211,6 +212,17 @@ public class IoSessionInitiator {
             }
             nextSocketAddressIndex = (nextSocketAddressIndex + 1) % socketAddresses.length;
             return socketAddress;
+        }
+
+        // QFJ-822 Reset cached DNS resolution information on connection failure.
+        private void unresolveCurrentSocketAddress() {
+            int currentSocketAddress = (nextSocketAddressIndex + socketAddresses.length - 1) % socketAddresses.length;
+            SocketAddress socketAddress = socketAddresses[currentSocketAddress];
+            if (socketAddress instanceof InetSocketAddress) {
+                InetSocketAddress inetAddr = (InetSocketAddress) socketAddress;
+                socketAddresses[currentSocketAddress] = InetSocketAddress.createUnresolved(
+                    inetAddr.getHostName(), inetAddr.getPort());
+            }
         }
 
         private boolean shouldReconnect() {


### PR DESCRIPTION
This is a minor rework of a pull request submitted last January (https://github.com/quickfix-j/quickfixj/pull/7)  

The January request was originally merged but had to be reverted since it would not compile under jdk1.6.

I've done a (very minor) rework and it should build with Java 6 now.

Thanks
