### PR TITLE
Update Maven plugins, Slf4j & Mina core which fixes some SSL bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 	</licenses>
 
 	<prerequisites>
-		<maven>3.3.3</maven>
+		<maven>3.3.9</maven>
 	</prerequisites>
 
 	<modules>
@@ -41,7 +41,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<jdkLevel>1.6</jdkLevel>
-		<slf4j.version>1.7.12</slf4j.version>
+		<slf4j.version>1.7.13</slf4j.version>
 		<mainClass/>
 	</properties>
 
@@ -75,11 +75,11 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.18.1</version>
+					<version>2.19</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-pmd-plugin</artifactId>
-					<version>3.4</version>
+					<version>3.6</version>
 					<configuration>
 						<targetJdk>${jdkLevel}</targetJdk>
 					</configuration>
@@ -99,11 +99,11 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>2.3</version>
+					<version>2.4.2</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-assembly-plugin</artifactId>
-					<version>2.5.4</version>
+					<version>2.6</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -113,7 +113,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.5.3</version>
+				<version>3.0.1</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>

--- a/quickfixj-codegenerator/pom.xml
+++ b/quickfixj-codegenerator/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>3.3.3</version>
+			<version>3.3.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>

--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>org.apache.mina</groupId>
 			<artifactId>mina-core</artifactId>
-			<version>2.0.9</version>
+			<version>2.0.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -315,7 +315,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>2.18.1</version>
+				<version>2.19</version>
 				<reportSets/>
 				<configuration>
 					<showSuccess>true</showSuccess>


### PR DESCRIPTION
Updated Maven plugins, Slf4j & Mina core which fixes some SSL bugs.
It might fix the QFJ SSL bugs, look at Mina core release notes at https://mina.apache.org/mina-project/index.html

Listed below for the lazy:

```
Bugs :

DIRMINA-992 - NioSocketConnector.newHandle throws the wrong exception
DIRMINA-994 - The ConnectionRequest.cancel() method is inconsistent wrt concurrent access
DIRMINA-995 - Deadlock when using SSL and proxy
DIRMINA-1013 -Threading model is supressed by ProtocolCodecFilter
DIRMINA-1016 - Regression with 2.0.9: Missing javax.net.ssl import in manifest
DIRMINA-1017 - SSLEngine BUFFER_OVERFLOW (unwrap)
DIRMINA-1019 - SslHandler flushScheduledEvents race condition

Improvements :

DIRMINA-1018 - fetchAppBuffer shrink
DIRMINA-1020 - Change minimum version for slf4j in MANIFEST
```