### PR TITLE
Maven bundle plugin downgraded to 2.5.3 for JDK6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.0.1</version>
+				<version>2.5.3</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Maven bundle set to 2.5.3 for JDK6 support, branch based on 1.6.x