### PR TITLE
Mina-core to 2.0.13

### DIFF
--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>org.apache.mina</groupId>
 			<artifactId>mina-core</artifactId>
-			<version>2.0.12</version>
+			<version>2.0.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
From https://mina.apache.org/mina-project/index.html

MINA 2.0.13 released posted on February, 16, 2016

Another release to fix a critical SSL bug ( a race condition which could lead to a deadlock in some corner cases).

We urge you to switch to this version if you were using MINA 2.0.12.

Bugs :

DIRMINA-1019 SslHandler flushScheduledEvents race condition
DIRMINA-1027 SSLHandler writes corrupt messages under heavy load