### PR TITLE
QFJ-318 / QFJ-677 regression (FileLog thread safety)

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/FileLog.java
+++ b/quickfixj-core/src/main/java/quickfix/FileLog.java
@@ -90,16 +90,18 @@ public class FileLog extends AbstractLog {
         writeMessage(messages, message, false);
     }
 
-    private synchronized void writeMessage(FileOutputStream stream, String message, boolean forceTimestamp) {
+    private void writeMessage(FileOutputStream stream, String message, boolean forceTimestamp) {
         try {
-            if (forceTimestamp || includeTimestampForMessages) {
-                writeTimeStamp(stream);
-            }
-            stream.write(message.getBytes(CharsetSupport.getCharset()));
-            stream.write('\n');
-            stream.flush();
-            if (syncAfterWrite) {
-                stream.getFD().sync();
+            synchronized(stream) {
+                if (forceTimestamp || includeTimestampForMessages) {
+                    writeTimeStamp(stream);
+                }
+                stream.write(message.getBytes(CharsetSupport.getCharset()));
+                stream.write('\n');
+                stream.flush();
+                if (syncAfterWrite) {
+                    stream.getFD().sync();
+                }
             }
         } catch (IOException e) {
             // QFJ-459: no point trying to log the error in the file if we had an IOException

--- a/quickfixj-core/src/main/java/quickfix/FileLog.java
+++ b/quickfixj-core/src/main/java/quickfix/FileLog.java
@@ -90,7 +90,7 @@ public class FileLog extends AbstractLog {
         writeMessage(messages, message, false);
     }
 
-    private void writeMessage(FileOutputStream stream, String message, boolean forceTimestamp) {
+    private synchronized void writeMessage(FileOutputStream stream, String message, boolean forceTimestamp) {
         try {
             if (forceTimestamp || includeTimestampForMessages) {
                 writeTimeStamp(stream);

--- a/quickfixj-core/src/main/java/quickfix/FileLog.java
+++ b/quickfixj-core/src/main/java/quickfix/FileLog.java
@@ -50,6 +50,8 @@ public class FileLog extends AbstractLog {
     private final String messagesFileName;
     private final String eventFileName;
     private boolean syncAfterWrite;
+    private final Object messagesLock = new Object();
+    private final Object eventsLock = new Object();
 
     private FileOutputStream messages;
     private FileOutputStream events;
@@ -83,16 +85,16 @@ public class FileLog extends AbstractLog {
     }
 
     protected void logIncoming(String message) {
-        writeMessage(messages, message, false);
+        writeMessage(messages, messagesLock, message, false);
     }
 
     protected void logOutgoing(String message) {
-        writeMessage(messages, message, false);
+        writeMessage(messages, messagesLock, message, false);
     }
 
-    private void writeMessage(FileOutputStream stream, String message, boolean forceTimestamp) {
+    private void writeMessage(FileOutputStream stream, Object lock, String message, boolean forceTimestamp) {
         try {
-            synchronized(stream) {
+            synchronized(lock) {
                 if (forceTimestamp || includeTimestampForMessages) {
                     writeTimeStamp(stream);
                 }
@@ -112,11 +114,11 @@ public class FileLog extends AbstractLog {
     }
 
     public void onEvent(String message) {
-        writeMessage(events, message, true);
+        writeMessage(events, eventsLock, message, true);
     }
 
     public void onErrorEvent(String message) {
-        writeMessage(events, message, true);
+        writeMessage(events, eventsLock, message, true);
     }
 
     private void writeTimeStamp(OutputStream out) throws IOException {


### PR DESCRIPTION
Fixes thread race condition regression in http://www.quickfixj.org/jira/browse/QFJ-318. 1.4.0 seems to be the last released version with this fix.

See also: https://sourceforge.net/p/quickfixj/code/826/
