### PR TITLE
Fixes QFJ-895 for 1.7.x and bump plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,13 @@
 		<junit.version>4.12</junit.version>
 		<mainClass/>
 
-		<maven-resources-plugin-version>2.7</maven-resources-plugin-version>
+		<maven-resources-plugin-version>3.0.1</maven-resources-plugin-version>
 		<maven-compiler-plugin-version>3.5.1</maven-compiler-plugin-version>
-		<maven-jar-plugin-version>2.6</maven-jar-plugin-version>
+		<maven-jar-plugin-version>3.0.1</maven-jar-plugin-version>
 		<maven-surefire-plugin-version>2.19.1</maven-surefire-plugin-version>
 		<maven-pmd-plugin-version>3.6</maven-pmd-plugin-version>
 		<maven-source-plugin-version>3.0.0</maven-source-plugin-version>
-		<maven-javadoc-plugin-version>2.10.3</maven-javadoc-plugin-version>
+		<maven-javadoc-plugin-version>2.10.4</maven-javadoc-plugin-version>
 		<maven-shade-plugin-version>2.4.3</maven-shade-plugin-version>
 		<maven-assembly-plugin-version>2.6</maven-assembly-plugin-version>
 		<maven-bundle-plugin-version>3.0.1</maven-bundle-plugin-version>

--- a/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
@@ -81,8 +81,8 @@ public class ThreadedSocketInitiator extends AbstractSocketInitiator {
     }
 
     public void stop(boolean forceDisconnect) {
+        stopInitiators();
         logoutAllSessions(forceDisconnect);
-        stopSessionTimer();
         if (!forceDisconnect) {
             waitForLogout();
         }

--- a/quickfixj-core/src/main/java/quickfix/mina/AbstractIoHandler.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/AbstractIoHandler.java
@@ -19,23 +19,18 @@
 
 package quickfix.mina;
 
-import static quickfix.MessageUtils.parse;
-
-import java.io.IOException;
-
 import org.apache.mina.core.service.IoHandlerAdapter;
 import org.apache.mina.core.session.IoSession;
 import org.apache.mina.filter.codec.ProtocolCodecException;
 import org.apache.mina.filter.codec.ProtocolDecoderException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import quickfix.InvalidMessage;
-import quickfix.Message;
-import quickfix.MessageUtils;
-import quickfix.Session;
-import quickfix.SessionID;
+import quickfix.*;
 import quickfix.field.MsgType;
+
+import java.io.IOException;
+
+import static quickfix.MessageUtils.parse;
 
 /**
  * Abstract class used for acceptor and initiator IO handlers.
@@ -57,6 +52,15 @@ public abstract class AbstractIoHandler extends IoHandlerAdapter {
         Throwable realCause = cause;
         if (cause instanceof ProtocolDecoderException && cause.getCause() != null) {
             realCause = cause.getCause();
+        } else {
+            Throwable chain = cause;
+            while (chain != null && chain.getCause() != null) {
+                chain = chain.getCause();
+                if (chain instanceof IOException) {
+                    realCause = chain;
+                    break;
+                }
+            }
         }
         String reason;
         if (realCause instanceof IOException) {
@@ -75,11 +79,15 @@ public abstract class AbstractIoHandler extends IoHandlerAdapter {
             reason = cause.toString();
         }
         if (disconnectNeeded) {
-            if (quickFixSession != null) {
-                quickFixSession.disconnect(reason, true);
-            } else {
-                log.error(reason, cause);
-                ioSession.closeNow();
+            try {
+                if (quickFixSession != null) {
+                    quickFixSession.disconnect(reason, true);
+                } else {
+                    log.error(reason, cause);
+                    ioSession.closeNow();
+                }
+            } finally {
+                ioSession.setAttribute("QFJ_RESET_IO_CONNECTOR", Boolean.TRUE);
             }
         } else {
             log.error(reason, cause);
@@ -97,7 +105,7 @@ public abstract class AbstractIoHandler extends IoHandlerAdapter {
         try {
             Session quickFixSession = findQFSession(ioSession);
             if (quickFixSession != null) {
-                eventHandlingStrategy.onMessage(quickFixSession, EventHandlingStrategy.END_OF_STREAM );
+                eventHandlingStrategy.onMessage(quickFixSession, EventHandlingStrategy.END_OF_STREAM);
                 ioSession.removeAttribute(SessionConnector.QF_SESSION);
             }
             ioSession.closeNow();

--- a/quickfixj-core/src/main/java/quickfix/mina/IoSessionResponder.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/IoSessionResponder.java
@@ -19,16 +19,15 @@
 
 package quickfix.mina;
 
-import java.io.IOException;
-import java.net.SocketAddress;
-import quickfix.Session;
-
 import org.apache.mina.core.future.WriteFuture;
 import org.apache.mina.core.session.IoSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import quickfix.Responder;
+import quickfix.Session;
+
+import java.io.IOException;
+import java.net.SocketAddress;
 
 /**
  * The class that partially integrates the QuickFIX/J Session to
@@ -85,6 +84,7 @@ public class IoSessionResponder implements Responder {
         // close event from being processed by this thread (if
         // this thread is the MINA IO processor thread.
         ioSession.closeNow();
+        ioSession.setAttribute("QFJ_RESET_IO_CONNECTOR", Boolean.TRUE);
     }
 
     private void waitForScheduleMessagesToBeWritten() {

--- a/quickfixj-core/src/test/java/quickfix/mina/IoSessionResponderTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/IoSessionResponderTest.java
@@ -19,14 +19,13 @@
 
 package quickfix.mina;
 
-import static org.mockito.Mockito.*;
+import junit.framework.TestCase;
+import org.apache.mina.core.future.WriteFuture;
+import org.apache.mina.core.session.IoSession;
 
 import java.net.InetSocketAddress;
 
-import junit.framework.TestCase;
-
-import org.apache.mina.core.session.IoSession;
-import org.apache.mina.core.future.WriteFuture;
+import static org.mockito.Mockito.*;
 
 public class IoSessionResponderTest extends TestCase {
     public void testAsynchronousSend() throws Exception {
@@ -107,9 +106,10 @@ public class IoSessionResponderTest extends TestCase {
 
         verify(mockProtocolSession).getScheduledWriteMessages();
         verify(mockProtocolSession).closeNow();
+        verify(mockProtocolSession).setAttribute("QFJ_RESET_IO_CONNECTOR", Boolean.TRUE);
 
         verifyNoMoreInteractions(mockProtocolSession);
-}
+    }
 
     public void testGetRemoteSocketAddress() throws Exception {
         IoSession mockProtocolSession = mock(IoSession.class);


### PR DESCRIPTION
Bump plugin versions, all tests passed, everything generated pretty fast which makes me think `javadoc-plugin` got better, or maybe just a placebo effect.