### PR TITLE
Fixes QFJ-895 SSL exception caused by patch.

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
@@ -158,9 +158,9 @@ public class IoSessionInitiator {
         }
 
         private void connect() {
+            lastReconnectAttemptTime = SystemTime.currentTimeMillis();
+            SocketAddress nextSocketAddress = getNextSocketAddress();
             try {
-                lastReconnectAttemptTime = SystemTime.currentTimeMillis();
-                SocketAddress nextSocketAddress = getNextSocketAddress();
                 if (localAddress == null) {
                     connectFuture = ioConnector.connect(nextSocketAddress);
                 } else {


### PR DESCRIPTION
@chrjohn this fixed the SSL exception for 1.7.x, see if it also fixes it for 1.6.x, it would be nice if the author of the patch could come by and comment ;-)