### PR TITLE
removed incorrect disconnect command from duplicate identity acceptance tests

### DIFF
--- a/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/server/fix40/1b_DuplicateIdentity.def
+++ b/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/server/fix40/1b_DuplicateIdentity.def
@@ -13,4 +13,3 @@ I2,8=FIX.4.035=A34=149=TW52=<TIME>56=ISLD98=0108=30
 # wait for disconnect for second connection
 e2,DISCONNECT
 # force disconnect on first connection
-i1,DISCONNECT

--- a/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/server/fix41/1b_DuplicateIdentity.def
+++ b/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/server/fix41/1b_DuplicateIdentity.def
@@ -13,4 +13,3 @@ I2,8=FIX.4.135=A34=149=TW52=<TIME>56=ISLD98=0108=30
 # wait for disconnect for second connection
 e2,DISCONNECT
 # force disconnect on first connection
-i1,DISCONNECT

--- a/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/server/fix42/1b_DuplicateIdentity.def
+++ b/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/server/fix42/1b_DuplicateIdentity.def
@@ -13,4 +13,3 @@ I2,8=FIX.4.235=A34=149=TW52=<TIME>56=ISLD98=0108=30
 # wait for disconnect for second connection
 e2,DISCONNECT
 # force disconnect on first connection
-i1,DISCONNECT

--- a/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/server/fix43/1b_DuplicateIdentity.def
+++ b/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/server/fix43/1b_DuplicateIdentity.def
@@ -13,4 +13,3 @@ I2,8=FIX.4.335=A34=149=TW52=<TIME>56=ISLD98=0108=30
 # wait for disconnect for second connection
 e2,DISCONNECT
 # force disconnect on first connection
-i1,DISCONNECT

--- a/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/server/fix44/1b_DuplicateIdentity.def
+++ b/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/server/fix44/1b_DuplicateIdentity.def
@@ -13,4 +13,3 @@ I2,8=FIX.4.435=A34=149=TW52=<TIME>56=ISLD98=0108=30
 # wait for disconnect for second connection
 e2,DISCONNECT
 # force disconnect on first connection
-i1,DISCONNECT

--- a/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/server/fix50/1b_DuplicateIdentity.def
+++ b/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/server/fix50/1b_DuplicateIdentity.def
@@ -13,4 +13,3 @@ I2,8=FIXT.1.135=A34=149=TW52=<TIME>56=ISLD98=0108=301137=7
 # wait for disconnect for second connection
 e2,DISCONNECT
 # force disconnect on first connection
-i1,DISCONNECT


### PR DESCRIPTION
  - the tests will disconnect anyway when there are no more commands in the file