### PR TITLE
removed '(optional)' qualifier for TargetCompID from configuration docs

### DIFF
--- a/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
+++ b/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
@@ -121,21 +121,21 @@
   </TR>
   <TR ALIGN="left" VALIGN="middle">
     <TD> <I>TargetCompID</I> </TD>
-    <TD> (Optional) counterparty's compID as associated with this FIX session </TD>
+    <TD> Counterparty's compID as associated with this FIX session </TD>
     <TD> case-sensitive alpha-numeric string </TD>
 
     <TD>&nbsp; </TD>
   </TR>
   <TR ALIGN="left" VALIGN="middle">
     <TD> <I>TargetSubID</I> </TD>
-    <TD> (Optional)  counterparty's subID as associated with this FIX session </TD>
+    <TD> (Optional)  Counterparty's subID as associated with this FIX session </TD>
     <TD> case-sensitive alpha-numeric string </TD>
 
     <TD>&nbsp; </TD>
   </TR>
   <TR ALIGN="left" VALIGN="middle">
     <TD> <I>TargetLocationID</I> </TD>
-    <TD> (Optional) counterparty's locationID as associated with this FIX session </TD>
+    <TD> (Optional) Counterparty's locationID as associated with this FIX session </TD>
     <TD> case-sensitive alpha-numeric string </TD>
 
     <TD>&nbsp; </TD>


### PR DESCRIPTION
TargetCompIDs are required and should not have an (optional) qualifier in the docs, here: http://www.quickfixj.org/quickfixj/usermanual/1.5.0/usage/configuration.html