### PR TITLE
Allow a custom SessionSchedule

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/DefaultSessionFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/DefaultSessionFactory.java
@@ -46,6 +46,7 @@ public class DefaultSessionFactory implements SessionFactory {
     private final MessageStoreFactory messageStoreFactory;
     private final LogFactory logFactory;
     private final MessageFactory messageFactory;
+    private final SessionScheduleFactory sessionScheduleFactory;
 
     public DefaultSessionFactory(Application application, MessageStoreFactory messageStoreFactory,
             LogFactory logFactory) {
@@ -53,6 +54,7 @@ public class DefaultSessionFactory implements SessionFactory {
         this.messageStoreFactory = messageStoreFactory;
         this.logFactory = logFactory;
         this.messageFactory = new DefaultMessageFactory();
+        this.sessionScheduleFactory = new DefaultSessionScheduleFactory();
     }
 
     public DefaultSessionFactory(Application application, MessageStoreFactory messageStoreFactory,
@@ -61,6 +63,17 @@ public class DefaultSessionFactory implements SessionFactory {
         this.messageStoreFactory = messageStoreFactory;
         this.logFactory = logFactory;
         this.messageFactory = messageFactory;
+        this.sessionScheduleFactory = new DefaultSessionScheduleFactory();
+    }
+
+    public DefaultSessionFactory(Application application, MessageStoreFactory messageStoreFactory,
+                                 LogFactory logFactory, MessageFactory messageFactory,
+                                 SessionScheduleFactory sessionScheduleFactory) {
+        this.application = application;
+        this.messageStoreFactory = messageStoreFactory;
+        this.logFactory = logFactory;
+        this.messageFactory = messageFactory;
+        this.sessionScheduleFactory = sessionScheduleFactory;
     }
 
     public Session create(SessionID sessionID, SessionSettings settings) throws ConfigError {
@@ -187,8 +200,10 @@ public class DefaultSessionFactory implements SessionFactory {
             final int[] logonIntervals = getLogonIntervalsInSeconds(settings, sessionID);
             final Set<InetAddress> allowedRemoteAddresses = getInetAddresses(settings, sessionID);
 
+            final SessionSchedule sessionSchedule = sessionScheduleFactory.create(sessionID, settings);
+
             final Session session = new Session(application, messageStoreFactory, sessionID,
-                    dataDictionaryProvider, new SessionSchedule(settings, sessionID), logFactory,
+                    dataDictionaryProvider, sessionSchedule, logFactory,
                     messageFactory, heartbeatInterval, checkLatency, maxLatency, millisInTimestamp,
                     resetOnLogon, resetOnLogout, resetOnDisconnect, refreshAtLogon, checkCompID,
                     redundantResentRequestAllowed, persistMessages, useClosedIntervalForResend,

--- a/quickfixj-core/src/main/java/quickfix/DefaultSessionSchedule.java
+++ b/quickfixj-core/src/main/java/quickfix/DefaultSessionSchedule.java
@@ -19,27 +19,27 @@
 
 package quickfix;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Corresponds to SessionTime in C++ code
  */
-public class SessionSchedule {
+public class DefaultSessionSchedule implements SessionSchedule {
     private static final int NOT_SET = -1;
     private static final Pattern TIME_PATTERN = Pattern.compile("(\\d{2}):(\\d{2}):(\\d{2})(.*)");
     private final TimeEndPoint startTime;
     private final TimeEndPoint endTime;
     private final boolean nonStopSession;
-    protected final static Logger log = LoggerFactory.getLogger(SessionSchedule.class);
+    protected final static Logger log = LoggerFactory.getLogger(DefaultSessionSchedule.class);
 
-    public SessionSchedule(SessionSettings settings, SessionID sessionID) throws ConfigError,
+    public DefaultSessionSchedule(SessionSettings settings, SessionID sessionID) throws ConfigError,
             FieldConvertError {
 
         nonStopSession = settings.isSetting(sessionID, Session.SETTING_NON_STOP_SESSION) && settings.getBool(sessionID, Session.SETTING_NON_STOP_SESSION);
@@ -66,7 +66,7 @@ public class SessionSchedule {
     }
 
     private TimeEndPoint getTimeEndPoint(SessionSettings settings, SessionID sessionID,
-            TimeZone defaultTimeZone, String timeSetting, String daySetting) throws ConfigError,
+                                         TimeZone defaultTimeZone, String timeSetting, String daySetting) throws ConfigError,
             FieldConvertError {
 
         Matcher matcher = TIME_PATTERN.matcher(settings.getString(sessionID, timeSetting));
@@ -138,7 +138,7 @@ public class SessionSchedule {
                 final SimpleDateFormat utc = new SimpleDateFormat("HH:mm:ss");
                 utc.setTimeZone(TimeZone.getTimeZone("UTC"));
                 return (isSet(weekDay) ? DayConverter.toString(weekDay) + "," : "")
-                    + utc.format(calendar.getTime()) + "-" + utc.getTimeZone().getID();
+                        + utc.format(calendar.getTime()) + "-" + utc.getTimeZone().getID();
             } catch (ConfigError e) {
                 return "ERROR: " + e;
             }
@@ -300,7 +300,7 @@ public class SessionSchedule {
     }
 
     private void formatTimeInterval(StringBuilder buf, TimeInterval timeInterval,
-            SimpleDateFormat timeFormat, boolean local) {
+                                    SimpleDateFormat timeFormat, boolean local) {
         if (!isDailySession()) {
             buf.append("weekly, ");
             formatDayOfWeek(buf, startTime.getDay());

--- a/quickfixj-core/src/main/java/quickfix/DefaultSessionScheduleFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/DefaultSessionScheduleFactory.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) quickfixengine.org  All rights reserved.
+ *
+ * This file is part of the QuickFIX FIX Engine
+ *
+ * This file may be distributed under the terms of the quickfixengine.org
+ * license as defined by quickfixengine.org and appearing in the file
+ * LICENSE included in the packaging of this file.
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING
+ * THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * See http://www.quickfixengine.org/LICENSE for licensing information.
+ *
+ * Contact ask@quickfixengine.org if any conditions of this licensing
+ * are not clear to you.
+ ******************************************************************************/
+
+package quickfix;
+
+/**
+ * Factory for creating default session schedules.
+ */
+public class DefaultSessionScheduleFactory implements SessionScheduleFactory {
+
+    public SessionSchedule create(SessionID sessionID, SessionSettings settings) throws ConfigError
+    {
+        try {
+            return new DefaultSessionSchedule(settings, sessionID);
+        } catch (final FieldConvertError e) {
+            throw new ConfigError(e.getMessage());
+        }
+    }
+}

--- a/quickfixj-core/src/main/java/quickfix/SessionSchedule.java
+++ b/quickfixj-core/src/main/java/quickfix/SessionSchedule.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) quickfixengine.org  All rights reserved.
+ *
+ * This file is part of the QuickFIX FIX Engine
+ *
+ * This file may be distributed under the terms of the quickfixengine.org
+ * license as defined by quickfixengine.org and appearing in the file
+ * LICENSE included in the packaging of this file.
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING
+ * THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * See http://www.quickfixengine.org/LICENSE for licensing information.
+ *
+ * Contact ask@quickfixengine.org if any conditions of this licensing
+ * are not clear to you.
+ ******************************************************************************/
+
+package quickfix;
+
+import java.util.Calendar;
+
+/**
+ * Used to decide when to login and out of FIX sessions
+ */
+public interface SessionSchedule {
+
+    boolean isSameSession(Calendar time1, Calendar time2);
+
+    boolean isNonStopSession();
+
+    boolean isSessionTime();
+}

--- a/quickfixj-core/src/main/java/quickfix/SessionScheduleFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/SessionScheduleFactory.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) quickfixengine.org  All rights reserved.
+ *
+ * This file is part of the QuickFIX FIX Engine
+ *
+ * This file may be distributed under the terms of the quickfixengine.org
+ * license as defined by quickfixengine.org and appearing in the file
+ * LICENSE included in the packaging of this file.
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING
+ * THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * See http://www.quickfixengine.org/LICENSE for licensing information.
+ *
+ * Contact ask@quickfixengine.org if any conditions of this licensing
+ * are not clear to you.
+ ******************************************************************************/
+
+package quickfix;
+
+/**
+ * Creates a SessionSchedule based on the specified settings.
+ */
+public interface SessionScheduleFactory {
+    SessionSchedule create(SessionID sessionID, SessionSettings settings) throws ConfigError;
+}

--- a/quickfixj-core/src/test/java/quickfix/LogUtilTest.java
+++ b/quickfixj-core/src/test/java/quickfix/LogUtilTest.java
@@ -48,7 +48,7 @@ public class LogUtilTest extends TestCase {
         settings.setString(Session.SETTING_START_TIME, "16:00:00");
         settings.setString(Session.SETTING_END_TIME, "13:00:00");
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
         Session session = new Session(null, sessionID1 -> {
             try {
                 return new MemoryStore() {

--- a/quickfixj-core/src/test/java/quickfix/SessionScheduleTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionScheduleTest.java
@@ -92,7 +92,7 @@ public class SessionScheduleTest {
                 false));
         settings.setString(Session.SETTING_END_TIME, UtcTimeOnlyConverter.convert(endTime, false));
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        return new SessionSchedule(settings, sessionID);
+        return new DefaultSessionSchedule(settings, sessionID);
     }
 
     @Test
@@ -156,7 +156,7 @@ public class SessionScheduleTest {
         settings.setString(Session.SETTING_START_TIME, "01:00:00");
         settings.setString(Session.SETTING_END_TIME, "15:00:00");
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
         assertEquals("schedule is wrong", expectedInSession, schedule.isSessionTime());
     }
 
@@ -165,7 +165,7 @@ public class SessionScheduleTest {
             int second, String timeZoneID) throws ConfigError, FieldConvertError {
         mockSystemTimeSource.setTime(getTimeStamp(year, month, day, hour, minute, second, TimeZone
                 .getTimeZone(timeZoneID)));
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
         assertEquals("schedule is wrong", expectedInSession, schedule.isSessionTime());
     }
 
@@ -350,7 +350,7 @@ public class SessionScheduleTest {
         settings.setString(Session.SETTING_START_TIME, "01:00:00 ");
         settings.setString(Session.SETTING_END_TIME, " 05:00:00");
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
         doIsSessionTimeTest(schedule, false, 2002, 5, 5, 0, 30, 0);
         doIsSessionTimeTest(schedule, true, 2002, 7, 5, 1, 30, 0);
         doIsSessionTimeTest(schedule, false, 2003, 5, 5, 6, 30, 0);
@@ -364,7 +364,7 @@ public class SessionScheduleTest {
         settings.setString(Session.SETTING_END_DAY, DayConverter.toString(Calendar.FRIDAY));
         settings.setString(Session.SETTING_END_TIME, "05:00:00");
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
         doIsSessionTimeTest(schedule, false, 2006, 1, 27, 0, 30, 0);
         doIsSessionTimeTest(schedule, false, 2006, 1, 27, 1, 30, 0);
         doIsSessionTimeTest(schedule, true, 2006, 1, 28, 1, 30, 0);
@@ -383,7 +383,7 @@ public class SessionScheduleTest {
         settings.setString(Session.SETTING_END_DAY, DayConverter.toString(Calendar.FRIDAY));
         settings.setString(Session.SETTING_END_TIME, "19:30:00");
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
         doIsSessionTimeTest(schedule, true, 2007, Calendar.AUGUST, 23, 0, 25, 0,
                 TimeZone.getTimeZone("America/Chicago"));
     }
@@ -395,7 +395,7 @@ public class SessionScheduleTest {
         settings.setString(Session.SETTING_START_TIME, "01:00:00");
         settings.setString(Session.SETTING_END_TIME, "15:00:00");
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
         TimeZone tz = TimeZone.getTimeZone("US/Eastern");
         doIsSessionTimeTest(schedule, false, 2002, 5, 5, 0, 59, 0, tz);
         doIsSessionTimeTest(schedule, true, 2002, 7, 5, 14, 30, 0, tz);
@@ -414,7 +414,7 @@ public class SessionScheduleTest {
         settings.setString(Session.SETTING_START_TIME, "01:00:00 US/Eastern");
         settings.setString(Session.SETTING_END_TIME, "15:00:00 US/Central");
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
         doIsSessionTimeTest(schedule, false, 2002, 5, 5, 0, 59, 0, tz);
         doIsSessionTimeTest(schedule, true, 2002, 7, 5, 14, 30, 0, tz);
 
@@ -546,7 +546,7 @@ public class SessionScheduleTest {
         settings.setString(Session.SETTING_END_TIME, "15:00:00");
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
         try {
-            new SessionSchedule(settings, sessionID);
+            new DefaultSessionSchedule(settings, sessionID);
             fail("no exception");
         } catch (ConfigError e) {
             assertTrue(e.getMessage().contains("invalid format"));
@@ -562,7 +562,7 @@ public class SessionScheduleTest {
         try {
             settings.setString(Session.SETTING_START_TIME, "01:xx:00");
             settings.setString(Session.SETTING_END_TIME, "15:00:00");
-            new SessionSchedule(settings, sessionID);
+            new DefaultSessionSchedule(settings, sessionID);
             fail("no exception");
         } catch (ConfigError e) {
             assertTrue(e.getMessage().contains("could not parse"));
@@ -571,7 +571,7 @@ public class SessionScheduleTest {
         try {
             settings.setString(Session.SETTING_START_TIME, "01:00:00");
             settings.setString(Session.SETTING_END_TIME, "15:00:yy");
-            new SessionSchedule(settings, sessionID);
+            new DefaultSessionSchedule(settings, sessionID);
             fail("no exception");
         } catch (ConfigError e) {
             assertTrue(e.getMessage().contains("could not parse"));
@@ -590,7 +590,7 @@ public class SessionScheduleTest {
 
         try {
             settings.setString(sessionID, Session.SETTING_START_DAY, dayNames[1]);
-            new SessionSchedule(settings, sessionID);
+            new DefaultSessionSchedule(settings, sessionID);
             fail("no exception");
         } catch (ConfigError e) {
             assertTrue(e.getMessage().contains("without EndDay"));
@@ -599,7 +599,7 @@ public class SessionScheduleTest {
         try {
             settings.removeSetting(sessionID, Session.SETTING_START_DAY);
             settings.setString(Session.SETTING_END_DAY, dayNames[1]);
-            new SessionSchedule(settings, sessionID);
+            new DefaultSessionSchedule(settings, sessionID);
             fail("no exception");
         } catch (ConfigError e) {
             assertTrue(e.getMessage().contains("without StartDay"));
@@ -615,7 +615,7 @@ public class SessionScheduleTest {
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
 
         try {
-            new SessionSchedule(settings, sessionID);
+            new DefaultSessionSchedule(settings, sessionID);
             fail("no exception");
         } catch (ConfigError e) {
             assertTrue(e.getMessage().contains("Unrecognized time zone"));
@@ -632,7 +632,7 @@ public class SessionScheduleTest {
         settings.setString(Session.SETTING_END_DAY, DayConverter.toString(Calendar.FRIDAY));
         settings.setString(Session.SETTING_END_TIME, "15:00:00");
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
         assertNotNull(schedule.toString());
     }
 
@@ -644,7 +644,7 @@ public class SessionScheduleTest {
         settings.setString(Session.SETTING_START_TIME, "01:00:00");
         settings.setString(Session.SETTING_END_TIME, "15:00:00");
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
         assertNotNull(schedule.toString());
     }
 
@@ -656,7 +656,7 @@ public class SessionScheduleTest {
         settings.setString(Session.SETTING_END_DAY, DayConverter.toString(Calendar.FRIDAY));
         settings.setString(Session.SETTING_END_TIME, "13:00:00");
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
         Calendar c = SystemTime.getUtcCalendar();
         c.set(Calendar.DAY_OF_WEEK, Calendar.FRIDAY);
         c.set(Calendar.HOUR_OF_DAY, 15);
@@ -710,14 +710,14 @@ public class SessionScheduleTest {
         settings.setString(Session.SETTING_END_TIME, "03:15:00");
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
         //
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
         doIsSessionTimeTest(schedule, false, 2012, Calendar.OCTOBER, 20, 1, 29, 0, TimeZone.getTimeZone("Europe/Zurich"));
         doIsSessionTimeTest(schedule, true, 2012, Calendar.OCTOBER, 20, 1, 31, 0, TimeZone.getTimeZone("Europe/Zurich"));
         doIsSessionTimeTest(schedule, true, 2012, Calendar.OCTOBER, 20, 2, 16, 0, TimeZone.getTimeZone("Europe/Zurich"));
         doIsSessionTimeTest(schedule, true, 2012, Calendar.OCTOBER, 20, 3, 14, 0, TimeZone.getTimeZone("Europe/Zurich"));
         doIsSessionTimeTest(schedule, false, 2012, Calendar.OCTOBER, 20, 3, 16, 0, TimeZone.getTimeZone("Europe/Zurich"));
         //
-        schedule = new SessionSchedule(settings, sessionID);
+        schedule = new DefaultSessionSchedule(settings, sessionID);
         doIsSessionTimeTest(schedule, false, 2012, Calendar.OCTOBER, 27, 1, 29, 0, TimeZone.getTimeZone("Europe/Zurich"));
         doIsSessionTimeTest(schedule, true, 2012, Calendar.OCTOBER, 27, 1, 31, 0, TimeZone.getTimeZone("Europe/Zurich"));
         doIsSessionTimeTest(schedule, true, 2012, Calendar.OCTOBER, 27, 2, 16, 0, TimeZone.getTimeZone("Europe/Zurich"));
@@ -736,7 +736,7 @@ public class SessionScheduleTest {
         doIsSessionTimeTest(schedule, true, 2012, Calendar.OCTOBER, 29, 3, 14, 0, TimeZone.getTimeZone("Europe/Zurich"));
         doIsSessionTimeTest(schedule, false, 2012, Calendar.OCTOBER, 29, 3, 16, 0, TimeZone.getTimeZone("Europe/Zurich"));
         //
-        schedule = new SessionSchedule(settings, sessionID);
+        schedule = new DefaultSessionSchedule(settings, sessionID);
         doIsSessionTimeTest(schedule, false, 2013, Calendar.MARCH, 30, 1, 29, 0, TimeZone.getTimeZone("Europe/Zurich"));
         doIsSessionTimeTest(schedule, true, 2013, Calendar.MARCH, 30, 1, 31, 0, TimeZone.getTimeZone("Europe/Zurich"));
         doIsSessionTimeTest(schedule, true, 2013, Calendar.MARCH, 30, 2, 16, 0, TimeZone.getTimeZone("Europe/Zurich"));
@@ -766,7 +766,7 @@ public class SessionScheduleTest {
         settings.setString(Session.SETTING_END_TIME, "17:00:00");
 
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
 
         //System.out.println(schedule);
 
@@ -790,7 +790,7 @@ public class SessionScheduleTest {
         mockSystemTimeSource.setTime(getTimeStamp(2008, Calendar.NOVEMBER, 2, 18, 0, 0, TimeZone.getTimeZone("America/New_York")));
 
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
 
         //System.out.println(schedule);
 
@@ -808,7 +808,7 @@ public class SessionScheduleTest {
         SessionSettings settings = new SessionSettings();
         settings.setString(Session.SETTING_NON_STOP_SESSION, "Y");
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
         assertTrue(schedule.isSameSession(null, null));
     }
 
@@ -825,7 +825,7 @@ public class SessionScheduleTest {
         settings.setString(Session.SETTING_END_DAY, endDay);
         settings.setString(Session.SETTING_END_TIME, endTimeString);
         SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
-        SessionSchedule schedule = new SessionSchedule(settings, sessionID);
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
 
         Calendar sessionCreateTime = SystemTime.getUtcCalendar();
 

--- a/quickfixj-core/src/test/java/quickfix/SessionTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionTest.java
@@ -2156,7 +2156,7 @@ public class SessionTest {
             SessionID sessionID) throws NoSuchFieldException,
             IllegalAccessException, ConfigError, FieldConvertError, IOException {
 
-        final SessionSchedule sessionSchedule = new SessionSchedule(settings,
+        final SessionSchedule sessionSchedule = new DefaultSessionSchedule(settings,
                 sessionID);
         final Session session = SessionFactoryTestSupport
                 .createFileStoreSession(sessionID, application, isInitiator,


### PR DESCRIPTION
Currently the scheduling options are weekly or daily or to use an external scheduler.

This allows a custom scheduler to be defined by the user by implementing the SessionSchedule interface.

