### PR TITLE
QFJ-912: Support use of externally supplied ThreadPools.

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/ExecutorFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/ExecutorFactory.java
@@ -1,0 +1,32 @@
+package quickfix;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * <p>
+ * Two Executors are required. The {@link #getLongLivedExecutor()} is used for message processing and the
+ * {@link #getShortLivedExecutor()} is used for timer tasks. They can both be the same underlying Executor if desired.
+ * Separating them allows for additional control such as with a ResourceAdapter WorkManager where the WorkManager
+ * differentiates between short and long lived Work.
+ * </p>
+ * <p>
+ * By way of example, a single {@link Executors#newCachedThreadPool()} satisfies the requirements but really adds
+ * nothing over the default behavior.
+ * </p>
+ */
+public interface ExecutorFactory {
+
+	/**
+	 * The message processing activities are long-lived so this Executor must have sufficient distinct Threads available
+	 * to handle all your Sessions. The exact number will depend on how many concurrent Sessions you will have and
+	 * whether you are using the Threaded or non-Threaded SocketAcceptors/Initiators.
+	 */
+	Executor getLongLivedExecutor();
+
+	/**
+	 * The timer tasks are short-lived and only require one Thread (calls are serialized).
+	 */
+	Executor getShortLivedExecutor();
+
+}

--- a/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
@@ -83,6 +83,7 @@ public class SocketAcceptor extends AbstractSocketAcceptor {
     private void initialize(boolean blockInThread) throws ConfigError {
         synchronized (lock) {
             if (isStarted.equals(Boolean.FALSE)) {
+            	eventHandlingStrategy.setExecutor(longLivedExecutor);
                 startAcceptingConnections();
                 if (blockInThread) {
                     eventHandlingStrategy.blockInThread();

--- a/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
@@ -111,6 +111,7 @@ public class SocketInitiator extends AbstractSocketInitiator {
     private void initialize(boolean blockInThread) throws ConfigError {
         synchronized (lock) {
             if (isStarted.equals(Boolean.FALSE)) {
+            	eventHandlingStrategy.setExecutor(longLivedExecutor);
                 createSessionInitiators();
                 for (Session session : getSessionMap().values()) {
                     Session.registerSession(session);

--- a/quickfixj-core/src/main/java/quickfix/ThreadedSocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/ThreadedSocketAcceptor.java
@@ -70,6 +70,7 @@ public class ThreadedSocketAcceptor extends AbstractSocketAcceptor {
     }
 
     public void start() throws ConfigError, RuntimeError {
+    	eventHandlingStrategy.setExecutor(longLivedExecutor);
         startAcceptingConnections();
     }
 

--- a/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
@@ -72,6 +72,7 @@ public class ThreadedSocketInitiator extends AbstractSocketInitiator {
     }
 
     public void start() throws ConfigError, RuntimeError {
+    	eventHandlingStrategy.setExecutor(longLivedExecutor);
         createSessionInitiators();
         startInitiators();
     }

--- a/quickfixj-core/src/main/java/quickfix/mina/SingleThreadedEventHandlingStrategy.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/SingleThreadedEventHandlingStrategy.java
@@ -211,7 +211,7 @@ public class SingleThreadedEventHandlingStrategy implements EventHandlingStrateg
 		}
 
 		public void setDaemon(boolean b) {
-			/* No-Op. Already set for SimpleThreadExecutor. Not relevant for externally supplied Executors. */
+			/* No-Op. Already set for DedicatedThreadExecutor. Not relevant for externally supplied Executors. */
 		}
 
 		public boolean isAlive() {

--- a/quickfixj-core/src/main/java/quickfix/mina/SingleThreadedEventHandlingStrategy.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/SingleThreadedEventHandlingStrategy.java
@@ -29,6 +29,8 @@ import quickfix.SystemTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -39,8 +41,9 @@ public class SingleThreadedEventHandlingStrategy implements EventHandlingStrateg
     public static final String MESSAGE_PROCESSOR_THREAD_NAME = "QFJ Message Processor";
     private final BlockingQueue<SessionMessageEvent> eventQueue;
     private final SessionConnector sessionConnector;
-    private volatile Thread messageProcessingThread;
+    private volatile ThreadAdapter messageProcessingThread;
     private volatile boolean isStopped;
+    private Executor executor;
     private long stopTime = 0L;
 
     public SingleThreadedEventHandlingStrategy(SessionConnector connector, int queueCapacity) {
@@ -48,7 +51,11 @@ public class SingleThreadedEventHandlingStrategy implements EventHandlingStrateg
         eventQueue = new LinkedBlockingQueue<>(queueCapacity);
     }
 
-    @Override
+    public void setExecutor(Executor executor) {
+		this.executor = executor;
+	}
+
+	@Override
     public void onMessage(Session quickfixSession, Message message) {
         if (message == END_OF_STREAM && isStopped) {
             return;
@@ -121,14 +128,14 @@ public class SingleThreadedEventHandlingStrategy implements EventHandlingStrateg
         }
 
         startHandlingMessages();
-        messageProcessingThread = new Thread(new Runnable() {
+        messageProcessingThread = new ThreadAdapter(new Runnable() {
             @Override
             public void run() {
                 sessionConnector.log.info("Started " + MESSAGE_PROCESSOR_THREAD_NAME);
                 block();
                 sessionConnector.log.info("Stopped " + MESSAGE_PROCESSOR_THREAD_NAME);
             }
-        }, MESSAGE_PROCESSOR_THREAD_NAME);
+		}, MESSAGE_PROCESSOR_THREAD_NAME, executor);
         messageProcessingThread.setDaemon(true);
         messageProcessingThread.start();
     }
@@ -184,5 +191,97 @@ public class SingleThreadedEventHandlingStrategy implements EventHandlingStrateg
         // we only have one queue for all sessions
         return getQueueSize();
     }
+
+	/**
+	 * A stand-in for the Thread class that delegates to an Executor.
+	 * Implements all the API required by pre-existing QFJ code.
+	 */
+	static final class ThreadAdapter {
+
+		private final Executor executor;
+		private final RunnableWrapper wrapper;
+
+		ThreadAdapter(Runnable command, String name, Executor executor) {
+			wrapper = new RunnableWrapper(command, name);
+			this.executor = executor != null ? executor : new DedicatedThreadExecutor(name);
+		}
+
+		public void join() throws InterruptedException {
+			wrapper.join();
+		}
+
+		public void setDaemon(boolean b) {
+			/* No-Op. Already set for SimpleThreadExecutor. Not relevant for externally supplied Executors. */
+		}
+
+		public boolean isAlive() {
+			return wrapper.isAlive();
+		}
+
+		public void start() {
+			executor.execute(wrapper);
+		}
+
+		/**
+		 * Provides the Thread::join and Thread::isAlive semantics on the nested Runnable.
+		 */
+		static final class RunnableWrapper implements Runnable {
+
+			private final CountDownLatch latch = new CountDownLatch(1);
+			private final Runnable command;
+			private final String name;
+
+			public RunnableWrapper(Runnable command, String name) {
+				this.command = command;
+				this.name = name;
+			}
+
+			@Override
+			public void run() {
+				Thread currentThread = Thread.currentThread();
+				String threadName = currentThread.getName();
+				try {
+					if (!name.equals(threadName)) {
+						currentThread.setName(name + " (" + threadName + ")");
+					}
+					command.run();
+				} finally {
+					latch.countDown();
+					currentThread.setName(threadName);
+				}
+			}
+
+			public void join() throws InterruptedException {
+				latch.await();
+			}
+
+			public boolean isAlive() {
+				return latch.getCount() > 0;
+			}
+
+		}
+
+		/**
+		 * An Executor that uses it's own dedicated Thread.
+		 * Provides equivalent behavior to the prior non-Executor approach.
+		 */
+		static final class DedicatedThreadExecutor implements Executor {
+
+			private final String name;
+			
+			DedicatedThreadExecutor(String name) {
+				this.name = name;
+			}
+
+			@Override
+			public void execute(Runnable command) {
+				Thread thread = new Thread(command, name);
+				thread.setDaemon(true);
+				thread.start();
+			}
+
+		}
+
+	}
 
 }

--- a/quickfixj-core/src/main/java/quickfix/mina/ThreadPerSessionEventHandlingStrategy.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/ThreadPerSessionEventHandlingStrategy.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -43,17 +44,22 @@ public class ThreadPerSessionEventHandlingStrategy implements EventHandlingStrat
     private final ConcurrentMap<SessionID, MessageDispatchingThread> dispatchers = new ConcurrentHashMap<>();
     private final SessionConnector sessionConnector;
     private final int queueCapacity;
+    private volatile Executor executor;
 
     public ThreadPerSessionEventHandlingStrategy(SessionConnector connector, int queueCapacity) {
         sessionConnector = connector;
         this.queueCapacity = queueCapacity;
     }
 
+    public void setExecutor(Executor executor) {
+		this.executor = executor;
+	}
+
     @Override
     public void onMessage(Session quickfixSession, Message message) {
         MessageDispatchingThread dispatcher = dispatchers.get(quickfixSession.getSessionID());
         if (dispatcher == null) {
-            final MessageDispatchingThread temp = new MessageDispatchingThread(quickfixSession, queueCapacity);
+            final MessageDispatchingThread temp = new MessageDispatchingThread(quickfixSession, queueCapacity, executor);
             dispatcher = dispatchers.putIfAbsent(quickfixSession.getSessionID(), temp);
             if (dispatcher == null) {
                 dispatcher = temp;
@@ -105,14 +111,69 @@ public class ThreadPerSessionEventHandlingStrategy implements EventHandlingStrat
         }
     }
 
-    protected class MessageDispatchingThread extends Thread {
+	/**
+	 * A stand-in for the Thread class that delegates to an Executor.
+	 * Implements all the API required by pre-existing QFJ code.
+	 */
+	protected static abstract class ThreadAdapter implements Runnable {
+
+		private final Executor executor;
+		private final String name;
+
+		public ThreadAdapter(String name, Executor executor) {
+			this.name = name;
+			this.executor = executor != null ? executor : new DedicatedThreadExecutor(name);
+		}
+
+		public void start() {
+			executor.execute(this);
+		}
+
+		@Override
+		public final void run() {
+			Thread currentThread = Thread.currentThread();
+			String threadName = currentThread.getName();
+			try {
+				if (!name.equals(threadName)) {
+					currentThread.setName(name + " (" + threadName + ")");
+				}
+				doRun();
+			} finally {
+				currentThread.setName(threadName);
+			}
+		}
+
+		abstract void doRun();
+
+		/**
+		 * An Executor that uses it's own dedicated Thread.
+		 * Provides equivalent behavior to the prior non-Executor approach.
+		 */
+		static final class DedicatedThreadExecutor implements Executor {
+
+			private final String name;
+			
+			DedicatedThreadExecutor(String name) {
+				this.name = name;
+			}
+
+			@Override
+			public void execute(Runnable command) {
+				new Thread(command, name).start();
+			}
+
+		}
+
+	}
+
+	protected class MessageDispatchingThread extends ThreadAdapter {
         private final Session quickfixSession;
         private final BlockingQueue<Message> messages;
         private volatile boolean stopped;
         private volatile boolean stopping;
 
-        private MessageDispatchingThread(Session session, int queueCapacity) {
-            super("QF/J Session dispatcher: " + session.getSessionID());
+        private MessageDispatchingThread(Session session, int queueCapacity, Executor executor) {
+            super("QF/J Session dispatcher: " + session.getSessionID(), executor);
             quickfixSession = session;
             messages = new LinkedBlockingQueue<>(queueCapacity);
         }
@@ -133,7 +194,7 @@ public class ThreadPerSessionEventHandlingStrategy implements EventHandlingStrat
         }
 
         @Override
-        public void run() {
+        void doRun() {
             while (!stopping) {
                 try {
                     final Message message = getNextMessage(messages);


### PR DESCRIPTION
**Purpose:**

To provide a mechanism for using externally supplied ThreadPools/Executors instead of the internal QFJ managed Threads.  Expected use case is for ResourceAdapter authors to inject the WorkManager (wrapped as an Executor).

**Solution:**

Defines a new quickfix.ExecutoryFactory interface and adds SessionConnector#setExecutorFactory(...) so that externally supplied Executors can be used.  One Executor is for the timer tasks and one for the message processing.

The Acceptors/Initiators pass the message processing Executor through to their EventHandlingStrategy.  The EventHandlingStrategy classes have been adapted to support the external Executor or fallback to the old behavior if no Executor is supplied.

**Compatibility:**

- There are no API breakages, only new optional API.
- The message processing and timer Thread names are different when running with the Executors.  They start with the same name but are suffixed with the original thread-pool supplied name.