### PR TITLE
Whitespace removed from field number=276 (QuoteCondition)

### DIFF
--- a/quickfixj-messages/quickfixj-messages-fix50sp1/src/main/resources/FIX50SP1.modified.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50sp1/src/main/resources/FIX50SP1.modified.xml
@@ -6255,7 +6255,7 @@
       <value enum="c" description="REGULAR_ETH"/>
       <value enum="d" description="AUTOMATIC_EXECUTION"/>
       <value enum="e" description="AUTOMATIC_EXECUTION_ETH"/>
-      <value enum="f " description="FAST_MARKET_ETH"/>
+      <value enum="f" description="FAST_MARKET_ETH"/>
       <value enum="g" description="INACTIVE_ETH"/>
       <value enum="h" description="ROTATION"/>
       <value enum="i" description="ROTATION_ETH"/>

--- a/quickfixj-messages/quickfixj-messages-fix50sp1/src/main/resources/FIX50SP1.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50sp1/src/main/resources/FIX50SP1.xml
@@ -6249,7 +6249,7 @@
       <value enum="c" description="REGULAR_ETH"/>
       <value enum="d" description="AUTOMATIC_EXECUTION"/>
       <value enum="e" description="AUTOMATIC_EXECUTION_ETH"/>
-      <value enum="f " description="FAST_MARKET_ETH"/>
+      <value enum="f" description="FAST_MARKET_ETH"/>
       <value enum="g" description="INACTIVE_ETH"/>
       <value enum="h" description="ROTATION"/>
       <value enum="i" description="ROTATION_ETH"/>

--- a/quickfixj-messages/quickfixj-messages-fix50sp2/src/main/resources/FIX50SP2.modified.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50sp2/src/main/resources/FIX50SP2.modified.xml
@@ -6498,7 +6498,7 @@
       <value enum="c" description="REGULAR_ETH"/>
       <value enum="d" description="AUTOMATIC_EXECUTION"/>
       <value enum="e" description="AUTOMATIC_EXECUTION_ETH"/>
-      <value enum="f " description="FAST_MARKET_ETH"/>
+      <value enum="f" description="FAST_MARKET_ETH"/>
       <value enum="g" description="INACTIVE_ETH"/>
       <value enum="h" description="ROTATION"/>
       <value enum="i" description="ROTATION_ETH"/>

--- a/quickfixj-messages/quickfixj-messages-fix50sp2/src/main/resources/FIX50SP2.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50sp2/src/main/resources/FIX50SP2.xml
@@ -6492,7 +6492,7 @@
       <value enum="c" description="REGULAR_ETH"/>
       <value enum="d" description="AUTOMATIC_EXECUTION"/>
       <value enum="e" description="AUTOMATIC_EXECUTION_ETH"/>
-      <value enum="f " description="FAST_MARKET_ETH"/>
+      <value enum="f" description="FAST_MARKET_ETH"/>
       <value enum="g" description="INACTIVE_ETH"/>
       <value enum="h" description="ROTATION"/>
       <value enum="i" description="ROTATION_ETH"/>


### PR DESCRIPTION
Affected files: FIX50SP1.modified.xml, FIX50SP2.modified.xml, FIX50SP1.xml, FIX50SP2.xml.
Affected value: <value enum=**"f "** description="FAST_MARKET_ETH"/>

I guess this whitespace is a typo.