### PR TITLE
QFJ-885 Send logout message before stopping initiators

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
@@ -105,7 +105,7 @@ public class SocketAcceptor extends AbstractSocketAcceptor {
 
     @Override
     public void stop(boolean forceDisconnect) {
-        eventHandlingStrategy.stop();
+        eventHandlingStrategy.stopHandlingMessages();
         synchronized (lock) {
             try {
                 try {
@@ -115,7 +115,6 @@ public class SocketAcceptor extends AbstractSocketAcceptor {
                 }
                 logoutAllSessions(forceDisconnect);
                 stopSessionTimer();
-                eventHandlingStrategy.stopHandlingMessages();
             } finally {
                 Session.unregisterSessions(getSessions());
                 isStarted = Boolean.FALSE;

--- a/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
@@ -105,7 +105,7 @@ public class SocketAcceptor extends AbstractSocketAcceptor {
 
     @Override
     public void stop(boolean forceDisconnect) {
-        eventHandlingStrategy.stopHandlingMessages();
+        eventHandlingStrategy.stop();
         synchronized (lock) {
             try {
                 try {
@@ -115,6 +115,7 @@ public class SocketAcceptor extends AbstractSocketAcceptor {
                 }
                 logoutAllSessions(forceDisconnect);
                 stopSessionTimer();
+                eventHandlingStrategy.stopHandlingMessages();
             } finally {
                 Session.unregisterSessions(getSessions());
                 isStarted = Boolean.FALSE;

--- a/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
@@ -96,13 +96,14 @@ public class SocketInitiator extends AbstractSocketInitiator {
 
     @Override
     public void stop(boolean forceDisconnect) {
-        // stopHandlingMessages should be called logoutAllSession
-        // doing so would cause deadlock when the initiator cannot connect to an acceptor
-        eventHandlingStrategy.stopHandlingMessages();
+        // eventHandlingStrategy.stop() sets isStopped=true, which allows the block loop to exit
+        eventHandlingStrategy.stop();
         synchronized (lock) {
             try {
                 logoutAllSessions(forceDisconnect);
                 stopInitiators();
+                // stopHandlingMessages sends the END_OF_STREAM message disconnecting the session
+                eventHandlingStrategy.stopHandlingMessages();
             } finally {
                 Session.unregisterSessions(getSessions());
                 isStarted = Boolean.FALSE;

--- a/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
@@ -96,10 +96,10 @@ public class SocketInitiator extends AbstractSocketInitiator {
 
     @Override
     public void stop(boolean forceDisconnect) {
-        eventHandlingStrategy.stopHandlingMessages();
         synchronized (lock) {
             try {
                 logoutAllSessions(forceDisconnect);
+                eventHandlingStrategy.stopHandlingMessages();
                 stopInitiators();
             } finally {
                 Session.unregisterSessions(getSessions());

--- a/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
@@ -96,10 +96,12 @@ public class SocketInitiator extends AbstractSocketInitiator {
 
     @Override
     public void stop(boolean forceDisconnect) {
+        // stopHandlingMessages should be called logoutAllSession
+        // doing so would cause deadlock when the initiator cannot connect to an acceptor
+        eventHandlingStrategy.stopHandlingMessages();
         synchronized (lock) {
             try {
                 logoutAllSessions(forceDisconnect);
-                eventHandlingStrategy.stopHandlingMessages();
                 stopInitiators();
             } finally {
                 Session.unregisterSessions(getSessions());

--- a/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
@@ -82,11 +82,12 @@ public class ThreadedSocketInitiator extends AbstractSocketInitiator {
     }
 
     public void stop(boolean forceDisconnect) {
-        stopInitiators();
         logoutAllSessions(forceDisconnect);
+        stopSessionTimer();
         if (!forceDisconnect) {
             waitForLogout();
         }
+        stopInitiators();
         eventHandlingStrategy.stopDispatcherThreads();
         Session.unregisterSessions(getSessions());
     }

--- a/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
@@ -83,10 +83,6 @@ public class ThreadedSocketInitiator extends AbstractSocketInitiator {
 
     public void stop(boolean forceDisconnect) {
         logoutAllSessions(forceDisconnect);
-        stopSessionTimer();
-        if (!forceDisconnect) {
-            waitForLogout();
-        }
         stopInitiators();
         eventHandlingStrategy.stopDispatcherThreads();
         Session.unregisterSessions(getSessions());

--- a/quickfixj-core/src/main/java/quickfix/mina/SessionConnector.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/SessionConnector.java
@@ -218,20 +218,21 @@ public abstract class SessionConnector implements Connector {
             }
         }
 
-        if (forceDisconnect && isLoggedOn()) {
-            for (Session session : sessions.values()) {
-                try {
-                    if (session.isLoggedOn()) {
-                        session.disconnect("Forcibly disconnecting session", false);
+        if (isLoggedOn()) {
+            if (forceDisconnect) {
+                for (Session session : sessions.values()) {
+                    try {
+                        if (session.isLoggedOn()) {
+                            session.disconnect("Forcibly disconnecting session", false);
+                        }
+                    } catch (Throwable e) {
+                        logError(session.getSessionID(), null, "Error during disconnect", e);
                     }
-                } catch (Throwable e) {
-                    logError(session.getSessionID(), null, "Error during disconnect", e);
                 }
+            } else {
+                // Only need to wait for logout if previously logged in
+                waitForLogout();
             }
-        }
-
-        if (!forceDisconnect) {
-            waitForLogout();
         }
     }
 

--- a/quickfixj-core/src/main/java/quickfix/mina/SingleThreadedEventHandlingStrategy.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/SingleThreadedEventHandlingStrategy.java
@@ -169,16 +169,6 @@ public class SingleThreadedEventHandlingStrategy implements EventHandlingStrateg
         isStopped = true;
     }
 
-    /**
-     * Provide current state of message processing.
-     * @return {@code true} if stop has been called. This indicates the message processing loop will
-     * terminate once the sessionConnector is logged out or 5 seconds has elapsed.
-     */
-    public boolean isStopped() {
-        // isStopped is volatile, so does not require synchronization.
-        return isStopped;
-    }
-
     private synchronized void startHandlingMessages() {
         isStopped = false;
     }

--- a/quickfixj-core/src/test/java/quickfix/SocketAcceptorTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SocketAcceptorTest.java
@@ -168,7 +168,7 @@ public class SocketAcceptorTest {
 
         public void waitForLogon() {
             try {
-                logonLatch.await(10, TimeUnit.SECONDS);
+                assertTrue("Logon timed out", logonLatch.await(10, TimeUnit.SECONDS));
             } catch (InterruptedException e) {
                 fail(e.getMessage());
             }

--- a/quickfixj-core/src/test/java/quickfix/SocketInitiatorTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SocketInitiatorTest.java
@@ -151,6 +151,17 @@ public class SocketInitiatorTest {
     }
 
     @Test
+    public void testInitiatorStop() throws Exception {
+        SessionID clientSessionID = new SessionID(FixVersions.BEGINSTRING_FIX42, "TW", "ISLD");
+        SessionSettings settings = getClientSessionSettings(clientSessionID);
+        ClientApplication clientApplication = new ClientApplication();
+        Initiator initiator = new SocketInitiator(clientApplication, new MemoryStoreFactory(),
+            settings, new DefaultMessageFactory());
+
+        doTestOfStop(clientSessionID, clientApplication, initiator);
+    }
+
+    @Test
     public void testInitiatorStopStartFileLog() throws Exception {
         File messageLog = new File(getTempDirectory() + File.separatorChar
                 + "FIX.4.2-TW-ISLD.messages.log");

--- a/quickfixj-core/src/test/java/quickfix/SocketInitiatorTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SocketInitiatorTest.java
@@ -151,17 +151,6 @@ public class SocketInitiatorTest {
     }
 
     @Test
-    public void testInitiatorStop() throws Exception {
-        SessionID clientSessionID = new SessionID(FixVersions.BEGINSTRING_FIX42, "TW", "ISLD");
-        SessionSettings settings = getClientSessionSettings(clientSessionID);
-        ClientApplication clientApplication = new ClientApplication();
-        Initiator initiator = new SocketInitiator(clientApplication, new MemoryStoreFactory(),
-            settings, new DefaultMessageFactory());
-
-        doTestOfStop(clientSessionID, clientApplication, initiator);
-    }
-
-    @Test
     public void testInitiatorStopStartFileLog() throws Exception {
         File messageLog = new File(getTempDirectory() + File.separatorChar
                 + "FIX.4.2-TW-ISLD.messages.log");


### PR DESCRIPTION
Because logout sets a flag indicating we should logout, we rely on another thread to send the logout message.

If we stop the initiators first that doesn't happen.

See JIRA: (QFJ-885)[http://www.quickfixj.org/jira/browse/QFJ-885]