### PR TITLE
QFJ-917: multi-threaded disconnect fails to call onLogout

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -1939,6 +1939,8 @@ public class Session implements Closeable {
      */
     public void disconnect(String reason, boolean logError) throws IOException {
         try {
+            boolean logonReceived = state.isLogonReceived();
+            boolean logonSent = state.isLogonSent();
             synchronized (responderLock) {
                 if (!hasResponder()) {
                     if (!ENCOUNTERED_END_OF_STREAM.equals(reason)) {
@@ -1954,10 +1956,10 @@ public class Session implements Closeable {
                 }
                 responder.disconnect();
                 setResponder(null);
+                logonReceived = state.isLogonReceived();
+                logonSent = state.isLogonSent();
             }
 
-            final boolean logonReceived = state.isLogonReceived();
-            final boolean logonSent = state.isLogonSent();
             if (logonReceived || logonSent) {
                 try {
                     application.onLogout(sessionID);

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -1939,8 +1939,8 @@ public class Session implements Closeable {
      */
     public void disconnect(String reason, boolean logError) throws IOException {
         try {
-            boolean logonReceived = state.isLogonReceived();
-            boolean logonSent = state.isLogonSent();
+            boolean logonReceived = false;
+            boolean logonSent = false;
             synchronized (responderLock) {
                 if (!hasResponder()) {
                     if (!ENCOUNTERED_END_OF_STREAM.equals(reason)) {


### PR DESCRIPTION
If multiple threads call disconnect, the logonReceived/logonSent can be updated by multiple threads.  The first thread might never call onLogout if the thread was interrupted after releasing the lock and before caching the state.