### PR TITLE
QFJ-917: multi-threaded disconnect fails to call onLogout (Take #2)

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -23,7 +23,37 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import quickfix.Message.Header;
 import quickfix.SessionState.ResendRange;
-import quickfix.field.*;
+import quickfix.field.ApplVerID;
+import quickfix.field.BeginSeqNo;
+import quickfix.field.BeginString;
+import quickfix.field.BusinessRejectReason;
+import quickfix.field.DefaultApplVerID;
+import quickfix.field.EncryptMethod;
+import quickfix.field.EndSeqNo;
+import quickfix.field.GapFillFlag;
+import quickfix.field.HeartBtInt;
+import quickfix.field.LastMsgSeqNumProcessed;
+import quickfix.field.MsgSeqNum;
+import quickfix.field.MsgType;
+import quickfix.field.NewSeqNo;
+import quickfix.field.NextExpectedMsgSeqNum;
+import quickfix.field.OrigSendingTime;
+import quickfix.field.PossDupFlag;
+import quickfix.field.RefMsgType;
+import quickfix.field.RefSeqNum;
+import quickfix.field.RefTagID;
+import quickfix.field.ResetSeqNumFlag;
+import quickfix.field.SenderCompID;
+import quickfix.field.SenderLocationID;
+import quickfix.field.SenderSubID;
+import quickfix.field.SendingTime;
+import quickfix.field.SessionRejectReason;
+import quickfix.field.SessionStatus;
+import quickfix.field.TargetCompID;
+import quickfix.field.TargetLocationID;
+import quickfix.field.TargetSubID;
+import quickfix.field.TestReqID;
+import quickfix.field.Text;
 import quickfix.mina.EventHandlingStrategy;
 
 import java.io.Closeable;
@@ -586,7 +616,7 @@ public class Session implements Closeable {
      * @throws SessionNotFound if session could not be located
      */
     public static boolean sendToTarget(Message message, String senderCompID, String targetCompID,
-                                       String qualifier) throws SessionNotFound {
+            String qualifier) throws SessionNotFound {
         try {
             return sendToTarget(message,
                     new SessionID(message.getHeader().getString(BeginString.FIELD), senderCompID,
@@ -1525,7 +1555,7 @@ public class Session implements Closeable {
     }
 
     private void setRejectReason(Message reject, int field, String reason,
-                                 boolean includeFieldInReason) {
+            boolean includeFieldInReason) {
         boolean isRejectMessage;
         try {
             isRejectMessage = MsgType.REJECT.equals(reject.getHeader().getString(MsgType.FIELD));

--- a/quickfixj-core/src/test/java/quickfix/PausableThreadPoolExecutor.java
+++ b/quickfixj-core/src/test/java/quickfix/PausableThreadPoolExecutor.java
@@ -1,0 +1,49 @@
+package quickfix;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+class PausableThreadPoolExecutor extends ThreadPoolExecutor {
+    private boolean isPaused;
+    private final ReentrantLock pauseLock = new ReentrantLock();
+    private final Condition unpaused = pauseLock.newCondition();
+
+    public PausableThreadPoolExecutor() {
+        super(2, 2, 20, TimeUnit.SECONDS, new ArrayBlockingQueue<>(10000));
+    }
+
+    protected void beforeExecute(Thread t, Runnable r) {
+        super.beforeExecute(t, r);
+        pauseLock.lock();
+        try {
+            while (isPaused)
+                unpaused.await();
+        } catch (InterruptedException ie) {
+            t.interrupt();
+        } finally {
+            pauseLock.unlock();
+        }
+    }
+
+    public void pause() {
+        pauseLock.lock();
+        try {
+            isPaused = true;
+        } finally {
+            pauseLock.unlock();
+        }
+    }
+
+    public void resume() {
+        pauseLock.lock();
+        try {
+            isPaused = false;
+            unpaused.signalAll();
+        } finally {
+            pauseLock.unlock();
+        }
+    }
+}

--- a/quickfixj-core/src/test/java/quickfix/SessionDisconnectConcurrentlyTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionDisconnectConcurrentlyTest.java
@@ -312,6 +312,10 @@ public class SessionDisconnectConcurrentlyTest extends TestCase {
         }
 
         public void disconnect() {
+            try {
+                Thread.sleep(10);
+            } catch (Exception e) {
+            }
         }
 
         public void onConnect() {

--- a/quickfixj-core/src/test/java/quickfix/SessionDisconnectConcurrentlyTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionDisconnectConcurrentlyTest.java
@@ -21,7 +21,15 @@ package quickfix;
 
 import junit.framework.TestCase;
 import org.junit.Test;
-import quickfix.field.*;
+import quickfix.field.BeginString;
+import quickfix.field.EncryptMethod;
+import quickfix.field.HeartBtInt;
+import quickfix.field.MsgSeqNum;
+import quickfix.field.MsgType;
+import quickfix.field.SenderCompID;
+import quickfix.field.SendingTime;
+import quickfix.field.TargetCompID;
+import quickfix.field.TestReqID;
 import quickfix.fix42.TestRequest;
 import quickfix.mina.ProtocolFactory;
 

--- a/quickfixj-core/src/test/java/quickfix/SessionResetTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionResetTest.java
@@ -1,30 +1,16 @@
 package quickfix;
 
 import org.junit.Test;
-import quickfix.field.BeginString;
-import quickfix.field.EncryptMethod;
-import quickfix.field.HeartBtInt;
-import quickfix.field.MsgSeqNum;
-import quickfix.field.MsgType;
-import quickfix.field.SenderCompID;
-import quickfix.field.SendingTime;
-import quickfix.field.TargetCompID;
-import quickfix.field.TestReqID;
+import quickfix.field.*;
 import quickfix.fix44.TestRequest;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 import java.util.Date;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.ReentrantLock;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class SessionResetTest {
 
@@ -138,45 +124,4 @@ public class SessionResetTest {
         }
     }
 
-    private class PausableThreadPoolExecutor extends ThreadPoolExecutor {
-        private boolean isPaused;
-        private final ReentrantLock pauseLock = new ReentrantLock();
-        private final Condition unpaused = pauseLock.newCondition();
-
-        public PausableThreadPoolExecutor() {
-            super(2, 2, 20, TimeUnit.SECONDS, new ArrayBlockingQueue<>(10000));
-        }
-
-        protected void beforeExecute(Thread t, Runnable r) {
-            super.beforeExecute(t, r);
-            pauseLock.lock();
-            try {
-                while (isPaused)
-                    unpaused.await();
-            } catch (InterruptedException ie) {
-                t.interrupt();
-            } finally {
-                pauseLock.unlock();
-            }
-        }
-
-        public void pause() {
-            pauseLock.lock();
-            try {
-                isPaused = true;
-            } finally {
-                pauseLock.unlock();
-            }
-        }
-
-        public void resume() {
-            pauseLock.lock();
-            try {
-                isPaused = false;
-                unpaused.signalAll();
-            } finally {
-                pauseLock.unlock();
-            }
-        }
-    }
 }

--- a/quickfixj-core/src/test/java/quickfix/SessionResetTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionResetTest.java
@@ -1,7 +1,15 @@
 package quickfix;
 
 import org.junit.Test;
-import quickfix.field.*;
+import quickfix.field.BeginString;
+import quickfix.field.EncryptMethod;
+import quickfix.field.HeartBtInt;
+import quickfix.field.MsgSeqNum;
+import quickfix.field.MsgType;
+import quickfix.field.SenderCompID;
+import quickfix.field.SendingTime;
+import quickfix.field.TargetCompID;
+import quickfix.field.TestReqID;
 import quickfix.fix44.TestRequest;
 
 import java.io.IOException;
@@ -10,7 +18,9 @@ import java.lang.management.ThreadMXBean;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class SessionResetTest {
 


### PR DESCRIPTION
This is a variation of upchuck's pull request with a unit test to verify that the issue is fixed.

The gist of this pull request:
1.  Move logonReceived and logonSent local variables in Session.disconnect(String,boolean) to top of method
2.  Pull up PausableThreadPoolExecutor into its own top level class that can be leveraged by other test classes.
3.  Create unit test in SessionDisconnectConcurrentlyTest.  In order to get this problem to come out sometimes I have to bombard the disconnect method with a thousand threads while in the context of a for loop.



