### PR TITLE
Updates to allow for custom dictionary provider in DefaultSessionFactory

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/DefaultDataDictionaryProvider.java
+++ b/quickfixj-core/src/main/java/quickfix/DefaultDataDictionaryProvider.java
@@ -25,7 +25,7 @@ import quickfix.field.ApplVerID;
 
 import static quickfix.MessageUtils.toBeginString;
 
-public class DefaultDataDictionaryProvider implements DataDictionaryProvider {
+public class DefaultDataDictionaryProvider implements EditableDataDictionaryProvider {
     private final SimpleCache<String, DataDictionary> transportDictionaries;
     private final SimpleCache<ApplVerID, DataDictionary> applicationDictionaries;
 

--- a/quickfixj-core/src/main/java/quickfix/DefaultSessionFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/DefaultSessionFactory.java
@@ -47,6 +47,7 @@ public class DefaultSessionFactory implements SessionFactory {
     private final LogFactory logFactory;
     private final MessageFactory messageFactory;
     private final SessionScheduleFactory sessionScheduleFactory;
+    private final EditableDataDictionaryProvider editableDataDictionaryProvider;
 
     public DefaultSessionFactory(Application application, MessageStoreFactory messageStoreFactory,
             LogFactory logFactory) {
@@ -55,6 +56,7 @@ public class DefaultSessionFactory implements SessionFactory {
         this.logFactory = logFactory;
         this.messageFactory = new DefaultMessageFactory();
         this.sessionScheduleFactory = new DefaultSessionScheduleFactory();
+        this.editableDataDictionaryProvider = new DefaultDataDictionaryProvider();
     }
 
     public DefaultSessionFactory(Application application, MessageStoreFactory messageStoreFactory,
@@ -64,6 +66,7 @@ public class DefaultSessionFactory implements SessionFactory {
         this.logFactory = logFactory;
         this.messageFactory = messageFactory;
         this.sessionScheduleFactory = new DefaultSessionScheduleFactory();
+        this.editableDataDictionaryProvider = new DefaultDataDictionaryProvider();
     }
 
     public DefaultSessionFactory(Application application, MessageStoreFactory messageStoreFactory,
@@ -74,6 +77,19 @@ public class DefaultSessionFactory implements SessionFactory {
         this.logFactory = logFactory;
         this.messageFactory = messageFactory;
         this.sessionScheduleFactory = sessionScheduleFactory;
+        this.editableDataDictionaryProvider = new DefaultDataDictionaryProvider();
+    }
+
+    public DefaultSessionFactory(Application application, MessageStoreFactory messageStoreFactory,
+                                 LogFactory logFactory, MessageFactory messageFactory,
+                                 SessionScheduleFactory sessionScheduleFactory,
+                                 EditableDataDictionaryProvider editableDataDictionaryProvider) {
+        this.application = application;
+        this.messageStoreFactory = messageStoreFactory;
+        this.logFactory = logFactory;
+        this.messageFactory = messageFactory;
+        this.sessionScheduleFactory = sessionScheduleFactory;
+        this.editableDataDictionaryProvider = editableDataDictionaryProvider;
     }
 
     public Session create(SessionID sessionID, SessionSettings settings) throws ConfigError {
@@ -131,9 +147,9 @@ public class DefaultSessionFactory implements SessionFactory {
                         .getBool(sessionID, Session.SETTING_USE_DATA_DICTIONARY);
             }
 
-            DefaultDataDictionaryProvider dataDictionaryProvider = null;
+            EditableDataDictionaryProvider dataDictionaryProvider = null;
             if (useDataDictionary) {
-                dataDictionaryProvider = new DefaultDataDictionaryProvider();
+                dataDictionaryProvider = editableDataDictionaryProvider;
                 if (sessionID.isFIXT()) {
                     processFixtDataDictionaries(sessionID, settings, dataDictionaryProvider);
                 } else {
@@ -234,7 +250,7 @@ public class DefaultSessionFactory implements SessionFactory {
     }
 
     private void processPreFixtDataDictionary(SessionID sessionID, SessionSettings settings,
-            DefaultDataDictionaryProvider dataDictionaryProvider) throws ConfigError,
+            EditableDataDictionaryProvider dataDictionaryProvider) throws ConfigError,
             FieldConvertError {
         final DataDictionary dataDictionary = createDataDictionary(sessionID, settings,
                 Session.SETTING_DATA_DICTIONARY, sessionID.getBeginString());
@@ -276,8 +292,8 @@ public class DefaultSessionFactory implements SessionFactory {
         return dataDictionary;
     }
 
-    private void processFixtDataDictionaries(SessionID sessionID, SessionSettings settings,
-            DefaultDataDictionaryProvider dataDictionaryProvider) throws ConfigError,
+    private void processFixtDataDictionaries(SessionID sessionID, SessionSettings settings, 
+                 EditableDataDictionaryProvider dataDictionaryProvider) throws ConfigError,
             FieldConvertError {
         dataDictionaryProvider.addTransportDictionary(
                 sessionID.getBeginString(),

--- a/quickfixj-core/src/main/java/quickfix/DefaultSessionFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/DefaultSessionFactory.java
@@ -56,7 +56,7 @@ public class DefaultSessionFactory implements SessionFactory {
         this.logFactory = logFactory;
         this.messageFactory = new DefaultMessageFactory();
         this.sessionScheduleFactory = new DefaultSessionScheduleFactory();
-        this.editableDataDictionaryProvider = new DefaultDataDictionaryProvider();
+        this.editableDataDictionaryProvider = null;
     }
 
     public DefaultSessionFactory(Application application, MessageStoreFactory messageStoreFactory,
@@ -66,7 +66,7 @@ public class DefaultSessionFactory implements SessionFactory {
         this.logFactory = logFactory;
         this.messageFactory = messageFactory;
         this.sessionScheduleFactory = new DefaultSessionScheduleFactory();
-        this.editableDataDictionaryProvider = new DefaultDataDictionaryProvider();
+        this.editableDataDictionaryProvider = null;
     }
 
     public DefaultSessionFactory(Application application, MessageStoreFactory messageStoreFactory,
@@ -77,7 +77,7 @@ public class DefaultSessionFactory implements SessionFactory {
         this.logFactory = logFactory;
         this.messageFactory = messageFactory;
         this.sessionScheduleFactory = sessionScheduleFactory;
-        this.editableDataDictionaryProvider = new DefaultDataDictionaryProvider();
+        this.editableDataDictionaryProvider = null;
     }
 
     public DefaultSessionFactory(Application application, MessageStoreFactory messageStoreFactory,
@@ -149,7 +149,11 @@ public class DefaultSessionFactory implements SessionFactory {
 
             EditableDataDictionaryProvider dataDictionaryProvider = null;
             if (useDataDictionary) {
-                dataDictionaryProvider = editableDataDictionaryProvider;
+                if(editableDataDictionaryProvider == null) {
+                    dataDictionaryProvider = new DefaultDataDictionaryProvider();
+                } else {
+                    dataDictionaryProvider = editableDataDictionaryProvider;
+                }
                 if (sessionID.isFIXT()) {
                     processFixtDataDictionaries(sessionID, settings, dataDictionaryProvider);
                 } else {

--- a/quickfixj-core/src/main/java/quickfix/EditableDataDictionaryProvider.java
+++ b/quickfixj-core/src/main/java/quickfix/EditableDataDictionaryProvider.java
@@ -1,0 +1,13 @@
+package quickfix;
+
+
+import quickfix.field.ApplVerID;
+
+/**
+ * Editable dictionary provider used by the DefaultSessionFactory
+ */
+public interface EditableDataDictionaryProvider extends DataDictionaryProvider {
+    void addTransportDictionary(String beginString, DataDictionary dataDictionary);
+
+    void addApplicationDictionary(ApplVerID applVerID, DataDictionary dd);
+}


### PR DESCRIPTION
Good morning, small update here that allows for custom dictionary providers to be used with the DefaultSessionFactory.  If you're running a custom codegen from an altered XML file, it makes it easy to use a custom DictionaryProvider that can refer to the altered XML file directly.  Any thoughts greatly appreciated.

Regards,

- monica