### PR TITLE
QFJ-169 / QFJ-791: support unknown tags in repeating groups

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/DataDictionary.java
+++ b/quickfixj-core/src/main/java/quickfix/DataDictionary.java
@@ -518,11 +518,6 @@ public class DataDictionary {
     private void copyFrom(DataDictionary rhs) {
         hasVersion = rhs.hasVersion;
         beginString = rhs.beginString;
-        checkFieldsOutOfOrder = rhs.checkFieldsOutOfOrder;
-        checkFieldsHaveValues = rhs.checkFieldsHaveValues;
-        checkUserDefinedFields = rhs.checkUserDefinedFields;
-        checkUnorderedGroupFields = rhs.checkUnorderedGroupFields;
-        allowUnknownMessageFields = rhs.allowUnknownMessageFields;
 
         copyMap(messageFields, rhs.messageFields);
         copyMap(requiredFields, rhs.requiredFields);
@@ -533,8 +528,14 @@ public class DataDictionary {
         copyMap(fieldNames, rhs.fieldNames);
         copyMap(names, rhs.names);
         copyMap(valueNames, rhs.valueNames);
-        copyMap(groups, rhs.groups);
+        copyGroups(groups, rhs.groups);
         copyMap(components, rhs.components);
+
+        setCheckFieldsOutOfOrder(rhs.checkFieldsOutOfOrder);
+        setCheckFieldsHaveValues(rhs.checkFieldsHaveValues);
+        setCheckUserDefinedFields(rhs.checkUserDefinedFields);
+        setCheckUnorderedGroupFields(rhs.checkUnorderedGroupFields);
+        setAllowUnknownMessageFields(rhs.allowUnknownMessageFields);
     }
 
     @SuppressWarnings("unchecked")
@@ -558,13 +559,26 @@ public class DataDictionary {
         }
     }
 
+    /** copy groups including their data dictionaries and validation settings
+     * 
+     * @param lhs target
+     * @param rhs source
+     */
+    private static void copyGroups(Map<IntStringPair, GroupInfo> lhs, Map<IntStringPair, GroupInfo> rhs) {
+        lhs.clear();
+        for (Map.Entry<IntStringPair, GroupInfo> entry : rhs.entrySet()) {
+            GroupInfo value = new GroupInfo(entry.getValue().getDelimiterField(), new DataDictionary(entry.getValue().getDataDictionary()));
+            lhs.put(entry.getKey(), value);
+        }
+    }
+
     private static <V> void copyCollection(Collection<V> lhs, Collection<V> rhs) {
         lhs.clear();
         lhs.addAll(rhs);
     }
 
     /**
-     * Validate a mesasge, including the header and trailer fields.
+     * Validate a message, including the header and trailer fields.
      *
      * @param message the message
      * @throws IncorrectTagValue if a field value is not valid

--- a/quickfixj-core/src/main/java/quickfix/DataDictionary.java
+++ b/quickfixj-core/src/main/java/quickfix/DataDictionary.java
@@ -65,7 +65,7 @@ public class DataDictionary {
     private static final String MESSAGE_CATEGORY_ADMIN = "admin".intern();
     private static final String MESSAGE_CATEGORY_APP = "app".intern();
 
-    static final int USER_DEFINED_TAG_MIN = 5000;
+    private static final int USER_DEFINED_TAG_MIN = 5000;
     private static final String NO = "N";
     private boolean hasVersion = false;
     private boolean checkFieldsOutOfOrder = true;
@@ -688,21 +688,25 @@ public class DataDictionary {
     void checkField(Field<?> field, String msgType, boolean message) {
         // use different validation for groups and messages
         boolean messageField = message ? isMsgField(msgType, field.getField()) : fields.contains(field.getField());
-        boolean fail;
-
-        if (field.getField() < USER_DEFINED_TAG_MIN) {
-            fail = !messageField && !allowUnknownMessageFields;
-        } else {
-            fail = !messageField && checkUserDefinedFields;
-        }
+        boolean fail = checkFieldFailure(field.getField(), messageField);
 
         if (fail) {
-            if (fields.contains(field.getTag())) {
+            if (fields.contains(field.getField())) {
                 throw new FieldException(SessionRejectReason.TAG_NOT_DEFINED_FOR_THIS_MESSAGE_TYPE, field.getField());
             } else {
                 throw new FieldException(SessionRejectReason.INVALID_TAG_NUMBER, field.getField());
             }
         }
+    }
+
+    boolean checkFieldFailure(int field, boolean messageField) {
+        boolean fail;
+        if (field < USER_DEFINED_TAG_MIN) {
+            fail = !messageField && !allowUnknownMessageFields;
+        } else {
+            fail = !messageField && checkUserDefinedFields;
+        }
+        return fail;
     }
 
     private void checkValidFormat(StringField field) throws IncorrectDataFormat {

--- a/quickfixj-core/src/main/java/quickfix/DataDictionary.java
+++ b/quickfixj-core/src/main/java/quickfix/DataDictionary.java
@@ -65,7 +65,7 @@ public class DataDictionary {
     private static final String MESSAGE_CATEGORY_ADMIN = "admin".intern();
     private static final String MESSAGE_CATEGORY_APP = "app".intern();
 
-    private static final int USER_DEFINED_TAG_MIN = 5000;
+    static final int USER_DEFINED_TAG_MIN = 5000;
     private static final String NO = "N";
     private boolean hasVersion = false;
     private boolean checkFieldsOutOfOrder = true;

--- a/quickfixj-core/src/test/java/quickfix/DataDictionaryTest.java
+++ b/quickfixj-core/src/test/java/quickfix/DataDictionaryTest.java
@@ -43,6 +43,7 @@ import quickfix.field.LastMkt;
 import quickfix.field.MsgSeqNum;
 import quickfix.field.MsgType;
 import quickfix.field.NoHops;
+import quickfix.field.NoPartyIDs;
 import quickfix.field.NoRelatedSym;
 import quickfix.field.OrdType;
 import quickfix.field.OrderQty;
@@ -476,6 +477,16 @@ public class DataDictionaryTest {
         assertEquals(ddCopy.isCheckUnorderedGroupFields(),dataDictionary.isCheckUnorderedGroupFields());
         assertEquals(ddCopy.isCheckUserDefinedFields(),dataDictionary.isCheckUserDefinedFields());
 
+        DataDictionary.GroupInfo groupFromDDCopy = ddCopy.getGroup(NewOrderSingle.MSGTYPE, NoPartyIDs.FIELD);
+        assertTrue(groupFromDDCopy.getDataDictionary().isAllowUnknownMessageFields());
+        // set to false on ORIGINAL DD
+        dataDictionary.setAllowUnknownMessageFields(false);
+        assertFalse(dataDictionary.isAllowUnknownMessageFields());
+        assertFalse(dataDictionary.getGroup(NewOrderSingle.MSGTYPE, NoPartyIDs.FIELD).getDataDictionary().isAllowUnknownMessageFields());
+        // should be still true on COPIED DD and its group
+        assertTrue(ddCopy.isAllowUnknownMessageFields());
+        groupFromDDCopy = ddCopy.getGroup(NewOrderSingle.MSGTYPE, NoPartyIDs.FIELD);
+        assertTrue(groupFromDDCopy.getDataDictionary().isAllowUnknownMessageFields());
     }
 
     /**


### PR DESCRIPTION
 - extended Message.parseGroup() to accept unknown fields in repeating groups
  - if validation is disabled (either completely or depending on ValidateUserDefinedFields or AllowUnknownMsgFields)
  - if the field encountered is not a trailer or message field
  - moreover, if validation is enabled, the incorrect field will be reported (not the next field that is encountered)
 - added unit tests from QFJ issues
 - removed synchronization from FieldException in Message since it seemed unnecessary