### PR TITLE
Treating CumQty as a double value in Banzai

### DIFF
--- a/quickfixj-examples/banzai/src/main/java/quickfix/examples/banzai/BanzaiApplication.java
+++ b/quickfixj-examples/banzai/src/main/java/quickfix/examples/banzai/BanzaiApplication.java
@@ -218,7 +218,7 @@ public class BanzaiApplication implements Application {
 
         if (fillSize.compareTo(BigDecimal.ZERO) > 0) {
             order.setOpen(order.getOpen() - (int) Double.parseDouble(fillSize.toPlainString()));
-            order.setExecuted(Integer.parseInt(message.getString(CumQty.FIELD)));
+            order.setExecuted(Double.parseDouble(message.getString(CumQty.FIELD)));
             order.setAvgPx(Double.parseDouble(message.getString(AvgPx.FIELD)));
         }
 

--- a/quickfixj-examples/banzai/src/main/java/quickfix/examples/banzai/Order.java
+++ b/quickfixj-examples/banzai/src/main/java/quickfix/examples/banzai/Order.java
@@ -26,7 +26,7 @@ public class Order implements Cloneable {
     private String symbol = null;
     private int quantity = 0;
     private int open = 0;
-    private int executed = 0;
+    private double executed = 0;
     private OrderSide side = OrderSide.BUY;
     private OrderType type = OrderType.MARKET;
     private OrderTIF tif = OrderTIF.DAY;
@@ -95,13 +95,11 @@ public class Order implements Cloneable {
         this.open = open;
     }
 
-    public int getExecuted() {
+    public double getExecuted() {
         return executed;
     }
 
-    public void setExecuted(int executed) {
-        this.executed = executed;
-    }
+    public void setExecuted(double executed) { this.executed = executed; }
 
     public OrderSide getSide() {
         return side;

--- a/quickfixj-examples/banzai/src/main/java/quickfix/examples/banzai/ui/OrderTable.java
+++ b/quickfixj-examples/banzai/src/main/java/quickfix/examples/banzai/ui/OrderTable.java
@@ -41,7 +41,7 @@ public class OrderTable extends JTable implements MouseListener {
         Order order = ((OrderTableModel) dataModel).getOrder(row);
 
         int open = order.getOpen();
-        int executed = order.getExecuted();
+        double executed = order.getExecuted();
         boolean rejected = order.getRejected();
         boolean canceled = order.getCanceled();
 
@@ -52,7 +52,7 @@ public class OrderTable extends JTable implements MouseListener {
             r.setBackground(Color.red);
         else if (canceled)
             r.setBackground(Color.white);
-        else if (open == 0 && executed == 0)
+        else if (open == 0 && executed == 0.0)
             r.setBackground(Color.yellow);
         else if (open > 0)
             r.setBackground(Color.green);


### PR DESCRIPTION
The type of `CumQty<14>` changed from `int` to `float` since FIX.4.2.
The banzai-example client assumes that `CumQty<14>` is an integer, leading to exceptions when the value has a fractional part:

    <20170617-18:23:04, FIX.4.4:BANZAI->XXX, incoming> (8=FIX.4.4|9=147|35=8|49=XXX|56=BANZAI|34=2|43=N|52=20170617-18:23:04.033|55=USD|37=1497723783942|11=1497723783942|17=Test|150=B|39=0|54=1|151=0.0|14=0.0|6=0.0|10=153|)
    java.lang.NumberFormatException: For input string: "0.0"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.parseInt(Integer.java:615)
	at quickfix.examples.banzai.BanzaiApplication.executionReport(BanzaiApplication.java:221)
	at quickfix.examples.banzai.BanzaiApplication.access$600(BanzaiApplication.java:74)
	at quickfix.examples.banzai.BanzaiApplication$MessageProcessor.run(BanzaiApplication.java:144)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.awt.EventQueue$3.run(EventQueue.java:703)
	at java.security.AccessController.doPrivileged(Native Method)
	at  java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
 
