### PR TITLE
Support data dictionaries with verbose descriptions

### DIFF
--- a/quickfixj-codegenerator/pom.xml
+++ b/quickfixj-codegenerator/pom.xml
@@ -32,6 +32,11 @@
 			<artifactId>maven-project</artifactId>
 			<version>2.2.1</version>
 		</dependency>
+		<dependency>
+		    <groupId>net.sf.saxon</groupId>
+		    <artifactId>Saxon-HE</artifactId>
+		    <version>9.8.0-2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/quickfixj-codegenerator/src/main/java/org/quickfixj/codegenerator/MessageCodeGenerator.java
+++ b/quickfixj-codegenerator/src/main/java/org/quickfixj/codegenerator/MessageCodeGenerator.java
@@ -207,7 +207,7 @@ public class MessageCodeGenerator {
             logInfo("Loading predefined xslt file:" + xsltFile);
             styleSource = new StreamSource(this.getClass().getResourceAsStream(xsltFile));
         }
-        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        TransformerFactory transformerFactory = new net.sf.saxon.TransformerFactoryImpl();
         return transformerFactory.newTransformer(styleSource);
     }
 

--- a/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/Fields.xsl
+++ b/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/Fields.xsl
@@ -18,7 +18,7 @@
 *****************************************************************************
 -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:qf="http://www.quickfixj.org" version="2.0">
  <xsl:output method="text" encoding="UTF-8"/>
  <xsl:param name="fieldName"/>
  <xsl:param name="fieldPackage"/>
@@ -151,26 +151,39 @@ public class <xsl:value-of select="@name"/> extends <xsl:call-template name="get
  </xsl:choose>
 </xsl:template>
 
+<xsl:function name="qf:sanitiseDescription">
+    <xsl:param name="text" />
+    <xsl:if test="contains('0123456789', substring($text, 1, 1))">
+        <xsl:text>N_</xsl:text>
+    </xsl:if>
+    <xsl:variable name="toReplace">.,+-=:()/&amp;&quot;&apos;&lt;&gt;</xsl:variable>
+    <xsl:for-each select="tokenize(translate($text,$toReplace,''),' ')">
+        <xsl:value-of select="upper-case(substring(.,1,1))" />
+        <xsl:value-of select="substring(.,2)" />
+    </xsl:for-each>
+</xsl:function>
+
 <xsl:template name="values">
 <xsl:for-each select="value">
+<xsl:variable name="description" select="string-join(qf:sanitiseDescription(@description),'')"/>
 <xsl:choose>
-	<xsl:when test="../@type='STRING'">public static final String <xsl:value-of select="@description"/> = "<xsl:value-of select="@enum"/>";
+	<xsl:when test="../@type='STRING'">public static final String <xsl:value-of select="$description"/> = "<xsl:value-of select="@enum"/>";
 	</xsl:when>
-	<xsl:when test="../@type='MULTIPLESTRINGVALUE'">public static final String <xsl:value-of select="@description"/> = "<xsl:value-of select="@enum"/>";
+	<xsl:when test="../@type='MULTIPLESTRINGVALUE'">public static final String <xsl:value-of select="$description"/> = "<xsl:value-of select="@enum"/>";
 	</xsl:when>
-	<xsl:when test="../@type='MULTIPLEVALUESTRING'">public static final String <xsl:value-of select="@description"/> = "<xsl:value-of select="@enum"/>";
+	<xsl:when test="../@type='MULTIPLEVALUESTRING'">public static final String <xsl:value-of select="$description"/> = "<xsl:value-of select="@enum"/>";
 	</xsl:when>
-        <xsl:when test="../@type='BOOLEAN'">public static final boolean <xsl:value-of select="@description"/> = <xsl:call-template name="y-or-n-to-bool" />;
+        <xsl:when test="../@type='BOOLEAN'">public static final boolean <xsl:value-of select="$description"/> = <xsl:call-template name="y-or-n-to-bool" />;
 	</xsl:when>
-	<xsl:when test="../@type='INT'">public static final int <xsl:value-of select="@description"/> = <xsl:value-of select="@enum"/>;
+	<xsl:when test="../@type='INT'">public static final int <xsl:value-of select="$description"/> = <xsl:value-of select="@enum"/>;
 	</xsl:when>
-	<xsl:when test="../@type='NUMINGROUP'">public static final int <xsl:value-of select="@description"/> = <xsl:value-of select="@enum"/>;
+	<xsl:when test="../@type='NUMINGROUP'">public static final int <xsl:value-of select="$description"/> = <xsl:value-of select="@enum"/>;
 	</xsl:when>
-	<xsl:when test="../@type='EXCHANGE'">public static final String <xsl:value-of select="@description"/> = "<xsl:value-of select="@enum"/>";
+	<xsl:when test="../@type='EXCHANGE'">public static final String <xsl:value-of select="$description"/> = "<xsl:value-of select="@enum"/>";
 	</xsl:when>
-	<xsl:when test="../@type='MONTHYEAR'">public static final String <xsl:value-of select="@description"/> = "<xsl:value-of select="@enum"/>";
+	<xsl:when test="../@type='MONTHYEAR'">public static final String <xsl:value-of select="$description"/> = "<xsl:value-of select="@enum"/>";
 	</xsl:when>
-	<xsl:otherwise>public static final char <xsl:value-of select="@description"/> = '<xsl:value-of select="@enum"/>';
+	<xsl:otherwise>public static final char <xsl:value-of select="$description"/> = '<xsl:value-of select="@enum"/>';
 	</xsl:otherwise>
 </xsl:choose>
 </xsl:for-each>

--- a/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/Message.xsl
+++ b/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/Message.xsl
@@ -18,7 +18,7 @@
 *****************************************************************************
 -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
  <xsl:output method="text" encoding="UTF-8"/>
  <xsl:param name="serialVersionUID"/>
  <xsl:param name="messagePackage"/>

--- a/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/MessageFactory.xsl
+++ b/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/MessageFactory.xsl
@@ -18,7 +18,7 @@
 *****************************************************************************
 -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
  <xsl:output method="text" encoding="UTF-8"/>
  <xsl:param name="fieldPackage"/>
  <xsl:param name="messagePackage"/>

--- a/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/MessageSubclass.xsl
+++ b/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/MessageSubclass.xsl
@@ -18,7 +18,7 @@
 *****************************************************************************
 -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
  <xsl:output method="text" encoding="UTF-8" />
  <xsl:param name="orderedFields"/>
  <xsl:param name="itemName"/>


### PR DESCRIPTION
**Changes**
- use Saxon instead of Xalan for XSLT
- update all .xsl files to XSLT 2.0
- implement a sanitise description function which allows use of code generation with verbose data dictionaries

**Rationale**
Bloomberg have produced a data dictionary which is incompatible with the current codegenerator.   They have for example replaced
```xml
    <field number="13" name="CommType" type="CHAR">
      <value enum="1" description="PER_UNIT"/>
      <value enum="2" description="PERCENTAGE"/>
      <value enum="3" description="ABSOLUTE"/>
      <value enum="4" description="PERCENTAGE_WAIVED_CASH_DISCOUNT"/>
      <value enum="5" description="PERCENTAGE_WAIVED_ENHANCED_UNITS"/>
      <value enum="6" description="POINTS_PER_BOND_OR_OR_CONTRACT"/>
    </field>
```
with
```xml
    <field number="13" name="CommType" type="CHAR">
     <value enum="1" description="Amount per unit"/>
      <value enum="2" description="Percent"/>
      <value enum="3" description="Absolute (total monetary amount)"/>
    </field>
```
They also make use of various special characters so I have removed the following `.,+-=:()/&amp;&quot;&apos;&lt;&gt;` and also added a `N_` prefix for any value which starts with a digit.  I am then able to run the codegenerator against their dictionary with a few trivial changes which I have requested they make.  Should they re-write the entire dictionary to be consistent with quickfix this PR will be unnecessary.

This results in generated code as follows:
```java
public class CommType extends CharField {

	static final long serialVersionUID = 20050617;

	public static final int FIELD = 13;
	public static final char AmountPerUnit = '1';
	public static final char Percent = '2';
	public static final char AbsoluteTotalMonetaryAmount = '3';
	
	public CommType() {
		super(13);
	}

	public CommType(char data) {
		super(13, data);
	}
	
}
```