### PR TITLE
deprecated block() methods in SocketAcceptor and SocketInitiator...

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Connector.java
+++ b/quickfixj-core/src/main/java/quickfix/Connector.java
@@ -55,10 +55,11 @@ public interface Connector {
      * Start accepting connections. This method blocks until stop is called from
      * another thread.
      * This method must not be called by several threads concurrently.
-     *
+     * @deprecated Use start() instead.
      * @throws ConfigError Problem with acceptor configuration.
      * @throws RuntimeError Other unspecified error
      */
+    @Deprecated
     void block() throws ConfigError, RuntimeError;
 
     /**

--- a/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
@@ -70,6 +70,10 @@ public class SocketAcceptor extends AbstractSocketAcceptor {
     }
 
     @Override
+    @Deprecated
+    /**
+     * Use SocketAcceptor.start().
+     */
     public void block() throws ConfigError, RuntimeError {
         initialize(false);
     }

--- a/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
@@ -79,6 +79,10 @@ public class SocketInitiator extends AbstractSocketInitiator {
     }
 
     @Override
+    @Deprecated
+    /**
+     * Use SocketInitiator.start().
+     */
     public void block() throws ConfigError, RuntimeError {
         initialize(false);
     }


### PR DESCRIPTION
…since they are likely to cause deadlocks

 - the start() methods should be used instead