### PR TITLE
Re-enabled acceptor sessions in finally block

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -1986,11 +1986,12 @@ public class Session implements Closeable {
 
                 stateListener.onLogout();
             }
+        } finally {
             // QFJ-457 now enabled again if acceptor
             if (!state.isInitiator()) {
                 setEnabled(true);
             }
-        } finally {
+            
             state.setLogonReceived(false);
             state.setLogonSent(false);
             state.setLogoutSent(false);

--- a/quickfixj-core/src/test/java/quickfix/mina/SessionConnectorTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/SessionConnectorTest.java
@@ -79,7 +79,8 @@ public class SessionConnectorTest extends TestCase {
 
         assertTrue(session.isEnabled());
         connector.logoutAllSessions(true);
-        assertFalse(session.isEnabled());
+        // Acceptors should get re-enabled after Logout
+        assertTrue(session.isEnabled());
 
         assertEquals(9999, connector.getIntSetting(Acceptor.SETTING_SOCKET_ACCEPT_PORT));
 


### PR DESCRIPTION
The Acceptor sessions should get re-enabled if socket was disconnected during logout.

When the following disconnect code runs it skips re-enable the acceptor session.
                if (!hasResponder()) {
                    if (!ENCOUNTERED_END_OF_STREAM.equals(reason)) {
                        getLog().onEvent("Already disconnected: " + reason);
                    }
                    return;
                }