### PR TITLE
QFJ-914: Generate and package javadoc for release build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,9 +158,6 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>${maven-javadoc-plugin-version}</version>
-					<configuration>
-						<excludePackageNames>quickfix.fix*</excludePackageNames>
-					</configuration>
 					<executions>
 						<execution>
 							<id>attach-javadocs</id>

--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -396,10 +396,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin-version}</version>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jxr-plugin</artifactId>
                 <version>2.5</version>
             </plugin>

--- a/quickfixj-distribution/pom.xml
+++ b/quickfixj-distribution/pom.xml
@@ -151,7 +151,7 @@
 							<!-- don't use custom stylesheet since it just breaks all style -->
 							<!--<stylesheetfile>${project.parent.basedir}/quickfixj-core/src/main/doc/javadoc.css</stylesheetfile>-->
 							<show>protected</show>
-							<maxmemory>1536m</maxmemory>
+							<maxmemory>2g</maxmemory>
 							<breakiterator>true</breakiterator>
 						</configuration>
 					</execution>


### PR DESCRIPTION
 - re-enabled generation of javadoc for FIX field and message classes
 - if you do not want this, then -Dmaven.javadoc.skip=true is your friend :)