### PR TITLE
Fix for dropped logout message issue

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/SessionConnector.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/SessionConnector.java
@@ -195,6 +195,25 @@ public abstract class SessionConnector implements Connector {
         return true;
     }
 
+    /**
+     * Check if we have at least one session and that at least one session is logged on.
+     *
+     * @return false if no sessions exist or all sessions are logged off, true otherwise
+     */
+    //visible for testing only
+    boolean anyLoggedOn() {
+        // if no session, not logged on
+        if (sessions.isEmpty())
+            return false;
+        for (Session session : sessions.values()) {
+            // at least one session logged on
+            if (session.isLoggedOn())
+                return true;
+        }
+        // no sessions are logged on
+        return false;
+    }
+
     private Set<quickfix.Session> getLoggedOnSessions() {
         Set<quickfix.Session> loggedOnSessions = new HashSet<>(sessions.size());
         for (Session session : sessions.values()) {
@@ -219,7 +238,7 @@ public abstract class SessionConnector implements Connector {
             }
         }
 
-        if (isLoggedOn()) {
+        if (anyLoggedOn()) {
             if (forceDisconnect) {
                 for (Session session : sessions.values()) {
                     try {

--- a/quickfixj-core/src/test/java/quickfix/mina/SessionConnectorTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/SessionConnectorTest.java
@@ -129,6 +129,7 @@ public class SessionConnectorTest extends TestCase {
         assertNotNull(session2);
         sessions.put(session2.getSessionID(), session2);
         assertFalse(connector.isLoggedOn());
+        assertTrue(connector.anyLoggedOn());
     }
 
     /**


### PR DESCRIPTION
Fix for issue described in forum post: [Acceptor dropping logout messages](http://quickfix-j.364392.n2.nabble.com/Acceptor-dropping-logout-messages-td7579837.html).

The issue exists in 1.6.x so would be good to merge there too.

### Issue

When a FIX acceptor is shutdown, a call is made to `SessionConnector.logoutAllSessions()`. This calls `Session.logout()` on all sessions in turn, regardless of prior status. The [logout()](https://github.com/quickfix-j/quickfixj/blob/06c312ef42bd53a99d997cee713dbdc9eab95fd5/quickfixj-core/src/main/java/quickfix/Session.java#L725) method is asynchronous and merely sets a private flag in `Session`. The actual logout message is sent later when the flag is picked up by a background thread (see [Session.next()](https://github.com/quickfix-j/quickfixj/blob/06c312ef42bd53a99d997cee713dbdc9eab95fd5/quickfixj-core/src/main/java/quickfix/Session.java#L1793)). 

After the `SessionConnector.logout()` call completes, the `SessionConnector` should wait for all sessions to be logged out. However, due to incorrect use of `SessionConnector.isLoggedOn()`, `waitForLogout()` is never called. 

`isLoggedOn()` performs an AND-style operation on the results of all `session.isLoggedOn()` methods. This means that if one or more sessions are not logged on, we do not wait for those that are. 

### Fix

The simple fix is to add a new method `anyLoggedOn()` to check if any of the FIX sessions are logged on. If so, then `waitForLogout()` is called and the required logout messages are sent before termination of the connection.
