### PR TITLE
fix javadoc generation for release

### DIFF
--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -337,6 +337,26 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <maxmemory>3g</maxmemory>
+                            <includeDependencySources>false</includeDependencySources>
+                            <!-- we do not want to have javadoc for the field and message classes in the core module -->
+                            <sourcepath>src/main/java</sourcepath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>

--- a/quickfixj-messages/quickfixj-messages-fix40/pom.xml
+++ b/quickfixj-messages/quickfixj-messages-fix40/pom.xml
@@ -41,6 +41,26 @@
 					</execution>
 				</executions>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <maxmemory>3g</maxmemory>
+                            <detectOfflineLinks>false</detectOfflineLinks>
+                            <includeDependencySources>false</includeDependencySources>
+                            <sourcepath>${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/fix40;${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/field</sourcepath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>

--- a/quickfixj-messages/quickfixj-messages-fix41/pom.xml
+++ b/quickfixj-messages/quickfixj-messages-fix41/pom.xml
@@ -40,7 +40,26 @@
 					</execution>
 				</executions>
 			</plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <maxmemory>3g</maxmemory>
+                            <detectOfflineLinks>false</detectOfflineLinks>
+                            <includeDependencySources>false</includeDependencySources>
+                            <sourcepath>${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/fix41;${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/field</sourcepath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>

--- a/quickfixj-messages/quickfixj-messages-fix42/pom.xml
+++ b/quickfixj-messages/quickfixj-messages-fix42/pom.xml
@@ -40,7 +40,26 @@
 					</execution>
 				</executions>
 			</plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <maxmemory>3g</maxmemory>
+                            <detectOfflineLinks>false</detectOfflineLinks>
+                            <includeDependencySources>false</includeDependencySources>
+                            <sourcepath>${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/fix42;${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/field</sourcepath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>

--- a/quickfixj-messages/quickfixj-messages-fix43/pom.xml
+++ b/quickfixj-messages/quickfixj-messages-fix43/pom.xml
@@ -40,7 +40,26 @@
 					</execution>
 				</executions>
 			</plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <maxmemory>3g</maxmemory>
+                            <detectOfflineLinks>false</detectOfflineLinks>
+                            <includeDependencySources>false</includeDependencySources>
+                            <sourcepath>${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/fix43;${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/field</sourcepath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>

--- a/quickfixj-messages/quickfixj-messages-fix44/pom.xml
+++ b/quickfixj-messages/quickfixj-messages-fix44/pom.xml
@@ -40,7 +40,26 @@
 					</execution>
 				</executions>
 			</plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <maxmemory>3g</maxmemory>
+                            <detectOfflineLinks>false</detectOfflineLinks>
+                            <includeDependencySources>false</includeDependencySources>
+                            <sourcepath>${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/fix44;${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/field</sourcepath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>

--- a/quickfixj-messages/quickfixj-messages-fix50/pom.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50/pom.xml
@@ -40,7 +40,26 @@
 					</execution>
 				</executions>
 			</plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <maxmemory>3g</maxmemory>
+                            <detectOfflineLinks>false</detectOfflineLinks>
+                            <includeDependencySources>false</includeDependencySources>
+                            <sourcepath>${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/fix50;${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/field</sourcepath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>

--- a/quickfixj-messages/quickfixj-messages-fix50sp1/pom.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50sp1/pom.xml
@@ -40,7 +40,26 @@
 					</execution>
 				</executions>
 			</plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <maxmemory>3g</maxmemory>
+                            <detectOfflineLinks>false</detectOfflineLinks>
+                            <includeDependencySources>false</includeDependencySources>
+                            <sourcepath>${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/fix50sp1;${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/field</sourcepath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>

--- a/quickfixj-messages/quickfixj-messages-fix50sp2/pom.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50sp2/pom.xml
@@ -40,7 +40,26 @@
 					</execution>
 				</executions>
 			</plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <maxmemory>3g</maxmemory>
+                            <detectOfflineLinks>false</detectOfflineLinks>
+                            <includeDependencySources>false</includeDependencySources>
+                            <sourcepath>${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/fix50sp2;${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/field</sourcepath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>

--- a/quickfixj-messages/quickfixj-messages-fixt11/pom.xml
+++ b/quickfixj-messages/quickfixj-messages-fixt11/pom.xml
@@ -40,7 +40,26 @@
 					</execution>
 				</executions>
 			</plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <maxmemory>3g</maxmemory>
+                            <detectOfflineLinks>false</detectOfflineLinks>
+                            <includeDependencySources>false</includeDependencySources>
+                            <sourcepath>${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/fixt11;${project.basedir}/../../quickfixj-core/target/generated-sources/quickfix/field</sourcepath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>


### PR DESCRIPTION
  - only create and include javadoc for the specific FIX messages classes
  - formerly every message javadoc package had all the docs for all messages included
  - same for the core module javadoc package