### PR TITLE
QFJ-902: Fixing a bug with attempt to close stream multiple times

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/FileStore.java
+++ b/quickfixj-core/src/main/java/quickfix/FileStore.java
@@ -97,10 +97,10 @@ public class FileStore implements MessageStore, Closeable {
     }
 
     void initialize(boolean deleteFiles) throws IOException {
-        close();
-
         if (deleteFiles) {
-            deleteFiles();
+            closeAndDeleteFiles();
+        } else {
+            close();
         }
 
         String mode = READ_OPTION + WRITE_OPTION + (syncWrites ? SYNC_OPTION : NOSYNC_OPTION);
@@ -219,7 +219,7 @@ public class FileStore implements MessageStore, Closeable {
         }
     }
 
-    public void deleteFiles() throws IOException {
+    public void closeAndDeleteFiles() throws IOException {
         close();
         deleteFile(headerFileName);
         deleteFile(msgFileName);


### PR DESCRIPTION
* When a session window is not 'open', the quickfix timer thread will try to reset the filestore, which also initialises the creation time on the filestore.
* When there is another thread that tries to login (outside the session 'open' window), that thread will try to write something to the filestore, namely the header info, such as sequence number
* If the operation is interleaved in the following manner:
  1. Quickfix timer thread closes the underlying filestore
  2. Thread that accepts the login attempt to update the sequence number (which happens to be using buffered output stream, by the way)
  3. Quickfix timer thread tries to close the underlying filestore again
  Then the 3rd step above will fail. As part of the close, standard Java buffered output stream will see if there is anything on the buffer to be flushed out. In this scenario, there is something (an update to the sequence number). Therefore it will try to write to the output stream. However, the underlying stream is already closed (in step 1). Hence stream closed event error.
  Unfortunately, this last step (step 3) is also where quickfix tries to initialise the filestore creation time. Hence, the creation time is never updated (due to the exception). So any further attempt to login from client will get rejected with 'login attempt outside session window' error.