### PR TITLE
Better error messages in dictionary generator

### DIFF
--- a/quickfixj-dictgenerator/src/main/java/org/quickfixj/dictgenerator/Generator.java
+++ b/quickfixj-dictgenerator/src/main/java/org/quickfixj/dictgenerator/Generator.java
@@ -218,13 +218,11 @@ public class Generator {
     }
 
     private MsgType getNextMsgType(Map<String, MsgType> msgTypes) {
-        try
-        {
-            return msgTypes.values().iterator().next();
-        }
-        catch(NoSuchElementException ex)
-        {
-            throw new RuntimeException("Message type not found. Check the MsgType.xml file.", ex);
+        Iterator<MsgType> it = msgTypes.values().iterator();
+        if(it.hasNext()) {
+            return it.next();
+        } else {
+            throw new RuntimeException("Message type not found. Check the MsgType.xml file.");
         }
     }
 

--- a/quickfixj-dictgenerator/src/main/java/org/quickfixj/dictgenerator/Generator.java
+++ b/quickfixj-dictgenerator/src/main/java/org/quickfixj/dictgenerator/Generator.java
@@ -22,12 +22,7 @@ package org.quickfixj.dictgenerator;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.Writer;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 /**
  * QFJ-483: QFJ Dictionary Generator
@@ -90,11 +85,11 @@ public class Generator {
         if (!merged) {
             if (admin) {
                 builder.append("  <header>\n");
-                Component standardHeader = repository.getStandardHeader(msgTypes.values().iterator().next());
+                Component standardHeader = repository.getStandardHeader(getNextMsgType(msgTypes));
                 addMsgContents(builder, standardHeader.getMsgContent(), "    ");
                 builder.append("  </header>\n");
                 builder.append("  <trailer>\n");
-                Component standardTrailer = repository.getStandardTrailer(msgTypes.values().iterator().next());
+                Component standardTrailer = repository.getStandardTrailer(getNextMsgType(msgTypes));
                 addMsgContents(builder, standardTrailer.getMsgContent(), "    ");
                 builder.append("  </trailer>\n");
             } else {
@@ -103,11 +98,11 @@ public class Generator {
             }
         } else {
             builder.append("  <header>\n");
-            Component standardHeader = repository.getStandardHeader(msgTypes.values().iterator().next());
+            Component standardHeader = repository.getStandardHeader(getNextMsgType(msgTypes));
             addMsgContents(builder, standardHeader.getMsgContent(), "    ");
             builder.append("  </header>\n");
             builder.append("  <trailer>\n");
-            Component standardTrailer = repository.getStandardTrailer(msgTypes.values().iterator().next());
+            Component standardTrailer = repository.getStandardTrailer(getNextMsgType(msgTypes));
             addMsgContents(builder, standardTrailer.getMsgContent(), "    ");
             builder.append("  </trailer>\n");
         }
@@ -219,6 +214,17 @@ public class Generator {
             writer.close();
         } catch (Exception e) {
             e.printStackTrace();
+        }
+    }
+
+    private MsgType getNextMsgType(Map<String, MsgType> msgTypes) {
+        try
+        {
+            return msgTypes.values().iterator().next();
+        }
+        catch(NoSuchElementException ex)
+        {
+            throw new RuntimeException("Message type not found. Check the MsgType.xml file.", ex);
         }
     }
 

--- a/quickfixj-dictgenerator/src/main/java/org/quickfixj/dictgenerator/Repository.java
+++ b/quickfixj-dictgenerator/src/main/java/org/quickfixj/dictgenerator/Repository.java
@@ -108,11 +108,11 @@ public class Repository {
         List<?> msgTypeNodes = msgType.selectNodes("//dataroot/MsgType[NotReqXML=" + notReqXML + "]");
         for (Object o : msgTypeNodes) {
             Node node = (Node) o;
-            String msgID = node.selectSingleNode("MsgID").getText();
-            String messageName = node.selectSingleNode("MessageName").getText();
-            String componentType = node.selectSingleNode("ComponentType").getText();
-            String category = node.selectSingleNode("Category").getText();
-            String msgType = node.selectSingleNode("MsgType").getText();
+            String msgID = getSingleNodeTextSafe(node, "MsgID");
+            String messageName = getSingleNodeTextSafe(node, "MessageName");
+            String componentType = getSingleNodeTextSafe(node, "ComponentType");
+            String category = getSingleNodeTextSafe(node, "Category");
+            String msgType = getSingleNodeTextSafe(node, "MsgType");
             msgTypeMap.put(msgType, new MsgType(msgID, messageName, componentType, category, notReqXML, msgType));
         }
 
@@ -124,8 +124,8 @@ public class Repository {
             System.out.println("\t " + msgType.getName());
             for (Object o : msgContentsNodes) {
                 Node node = (Node) o;
-                String tagText = node.selectSingleNode("TagText").getText();
-                String reqd = node.selectSingleNode("Reqd").getText();
+                String tagText = getSingleNodeTextSafe(node, "TagText");
+                String reqd = getSingleNodeTextSafe(node, "Reqd");
                 //if (allFields.containsKey(tagText) && notReqXML.equals(allFields.get(tagText).getNotReqXML())) {
                 if (allFields.containsKey(tagText)) {
                     MsgTypeField msgTypeField = new MsgTypeField(allFields.get(tagText), reqd);
@@ -148,12 +148,12 @@ public class Repository {
         List<?> fieldNodes = fields.selectNodes("//dataroot/Fields");
         for (Object o : fieldNodes) {
             Node node = (Node) o;
-            String tag = node.selectSingleNode("Tag").getText();
-            String fieldName = node.selectSingleNode("FieldName").getText();
+            String tag = getSingleNodeTextSafe(node, "Tag");
+            String fieldName = getSingleNodeTextSafe(node, "FieldName");
             System.out.println("\t " + fieldName + "(" + tag + ")");
-            String type = node.selectSingleNode("Type").getText();
-            String desc = node.selectSingleNode("Desc").getText();
-            String notReqXML = node.selectSingleNode("NotReqXML").getText();
+            String type = getSingleNodeTextSafe(node, "Type");
+            String desc = getSingleNodeTextSafe(node, "Desc");
+            String notReqXML = getSingleNodeTextSafe(node, "NotReqXML");
             Field field = new Field(tag, fieldName, type, desc, notReqXML);
             allFields.put(field.getTag(), field);
             // Find enums
@@ -162,9 +162,9 @@ public class Repository {
             if (!enumNodes.isEmpty()) {
                 for (Object enumO : enumNodes) {
                     Node enumNode = (Node) enumO;
-                    String enumName = enumNode.selectSingleNode("Enum").getText();
+                    String enumName = getSingleNodeTextSafe(enumNode, "Enum");
                     System.out.println("\t\t " + enumName);
-                    String enumDesc = enumNode.selectSingleNode("Description").getText();
+                    String enumDesc = getSingleNodeTextSafe(enumNode, "Description");
                     field.addEnum(new Enum(enumName, enumDesc));
                 }
             }
@@ -172,16 +172,24 @@ public class Repository {
         System.out.println(getClass().getSimpleName() + ": " + allFields.size() + " Fields found");
     }
 
+    private String getSingleNodeTextSafe(Node node, String tag) {
+        Node nodeWithTag = node.selectSingleNode(tag);
+        if(nodeWithTag != null)
+            return nodeWithTag.getText();
+        else
+            throw new RuntimeException("Node with tag "+tag+" not found in "+node.getPath());
+    }
+
     private void initComponents() {
         System.out.println(getClass().getSimpleName() + ": Init Components...");
         List<?> componentNodes = components.selectNodes("//dataroot/Components");
         for (Object o : componentNodes) {
             Node node = (Node) o;
-            String msgID = node.selectSingleNode("MsgID").getText();
-            String componentName = node.selectSingleNode("ComponentName").getText();
-            String componentType = node.selectSingleNode("ComponentType").getText();
-            String category = node.selectSingleNode("Category").getText();
-            String notReqXML = node.selectSingleNode("NotReqXML").getText();
+            String msgID = getSingleNodeTextSafe(node, "MsgID");
+            String componentName = getSingleNodeTextSafe(node, "ComponentName");
+            String componentType = getSingleNodeTextSafe(node, "ComponentType");
+            String category = getSingleNodeTextSafe(node, "Category");
+            String notReqXML = getSingleNodeTextSafe(node, "NotReqXML");
             allComponents.put(componentName, new Component(msgID, componentName, componentType, category, notReqXML));
         }
 
@@ -202,8 +210,8 @@ public class Repository {
         }
         for (Object o : msgContentsNodes) {
             Node node = (Node) o;
-            String tagText = node.selectSingleNode("TagText").getText();
-            String reqd = node.selectSingleNode("Reqd").getText();
+            String tagText = getSingleNodeTextSafe(node, "TagText");
+            String reqd = getSingleNodeTextSafe(node, "Reqd");
             if (allFields.containsKey(tagText)) {
                 ComponentField componentField = new ComponentField(allFields.get(tagText), reqd);
                 component.addMsgContent(componentField);
@@ -229,8 +237,8 @@ public class Repository {
     class MsgContentNodeComparator implements Comparator<Object> {
         public int compare(Object o1, Object o2) {
             try {
-                Double pos1 = Double.parseDouble(((Node) o1).selectSingleNode("Position").getText());
-                Double pos2 = Double.parseDouble(((Node) o2).selectSingleNode("Position").getText());
+                Double pos1 = Double.parseDouble(getSingleNodeTextSafe((Node) o1, "Position"));
+                Double pos2 = Double.parseDouble(getSingleNodeTextSafe((Node) o2, "Position"));
                 return pos1.compareTo(pos2);
             } catch (Exception e) {
                 return 0;
@@ -241,8 +249,8 @@ public class Repository {
     class EnumNodeComparator implements Comparator<Object> {
         public int compare(Object o1, Object o2) {
             try {
-                Double pos1 = Double.parseDouble(((Node) o1).selectSingleNode("Sort").getText());
-                Double pos2 = Double.parseDouble(((Node) o2).selectSingleNode("Sort").getText());
+                Double pos1 = Double.parseDouble(getSingleNodeTextSafe((Node) o1, "Sort"));
+                Double pos2 = Double.parseDouble(getSingleNodeTextSafe((Node) o2, "Sort"));
                 return pos1.compareTo(pos2);
             } catch (Exception e) {
                 return 0;


### PR DESCRIPTION
I was creating a dictionary from a repository and got:

- NullpointerExceptions because NotReqXML was written with wrong letter case
- NoSuchElementException because it was not finding the session messages.

This change gives better errors in both cases, so that it is easier to find the reason of the problem.