### PR TITLE
QFJ-533: Throw InvalidMessage when count field for repeating groups w…

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -578,7 +578,13 @@ public class Message extends FieldMap {
         final int[] fieldOrder = groupDataDictionary.getOrderedFields();
         int previousOffset = -1;
         final int groupCountTag = field.getField();
-        final int declaredGroupCount = Integer.parseInt(field.getValue());
+		// QFJ-533
+        int declaredGroupCount = 0;
+        try {
+          declaredGroupCount = Integer.parseInt(field.getValue());
+        } catch (final NumberFormatException e) {
+            throw new InvalidMessage("NumberFormatException: Repeating group count requires an Integer but found:" +field.getValue());
+        }
         parent.setField(groupCountTag, field);
         final int firstField = rg.getDelimiterField();
         boolean firstFieldFound = false;

--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -578,14 +578,14 @@ public class Message extends FieldMap {
         final int[] fieldOrder = groupDataDictionary.getOrderedFields();
         int previousOffset = -1;
         final int groupCountTag = field.getField();
-		// QFJ-533
+        // QFJ-533
         int declaredGroupCount = 0;
         try {
-             declaredGroupCount = Integer.parseInt(field.getValue());
+            declaredGroupCount = Integer.parseInt(field.getValue());
         } catch (final NumberFormatException e) {
-			 InvalidMessage invalidMessage = new InvalidMessage("Repeating group count requires an Integer but found:" +field.getValue());
-			 invalidMessage.initCause(e);
-		     throw invalidMessage;
+            InvalidMessage invalidMessage = new InvalidMessage("Repeating group count requires an Integer but found:" +field.getValue());
+            invalidMessage.initCause(e);
+            throw invalidMessage;
         }
         parent.setField(groupCountTag, field);
         final int firstField = rg.getDelimiterField();

--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -581,9 +581,11 @@ public class Message extends FieldMap {
 		// QFJ-533
         int declaredGroupCount = 0;
         try {
-          declaredGroupCount = Integer.parseInt(field.getValue());
+             declaredGroupCount = Integer.parseInt(field.getValue());
         } catch (final NumberFormatException e) {
-            throw new InvalidMessage("NumberFormatException: Repeating group count requires an Integer but found:" +field.getValue());
+			 InvalidMessage invalidMessage = new InvalidMessage("Repeating group count requires an Integer but found:" +field.getValue());
+			 invalidMessage.initCause(e);
+		     throw invalidMessage;
         }
         parent.setField(groupCountTag, field);
         final int firstField = rg.getDelimiterField();

--- a/quickfixj-core/src/test/java/quickfix/MessageTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageTest.java
@@ -1713,6 +1713,24 @@ public class MessageTest {
         // but we still should have the repeating group set and not ignore it
         assertEquals(1, parsed.getGroupCount(555));
     }
+    
+    // QFJ-533
+    @Test
+    public void testRepeatingGroupCountWithNonIntegerValues() throws Exception {
+        DataDictionary dictionary = new DataDictionary(DataDictionaryTest.getDictionary());
+        Message ioi = new quickfix.fix50.IOI();
+        ioi.setString(quickfix.field.NoPartyIDs.FIELD, "abc");
+        final String invalidCountMessage = ioi.toString();
+        try {
+            Message message =  new Message(invalidCountMessage, dictionary);
+        } catch (final InvalidMessage im) {
+            assertNotNull("InvalidMessage correctly thrown", im);
+        } catch (final Throwable e) {
+            e.printStackTrace();
+            fail("InvalidMessage expected, got " + e.getClass().getName());
+        }
+    }
+    
 
     // QFJ-770/QFJ-792
     @Test


### PR DESCRIPTION
…ould throw a NumberFormatException

See: https://www.quickfixj.org/jira/browse/QFJ-533