### PR TITLE
After scheduled logout/disconnection FIX session starts connection attempts from the 1st host on the list

### DIFF
--- a/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
+++ b/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
@@ -498,11 +498,29 @@
     <TD>"TCP" </TD>
   </TR>
   <TR ALIGN="left" VALIGN="middle">
+    <TD> <I>SocketConnectPort&lt;n&gt;</I> </TD>
+    <TD> Alternate socket port(s) for connecting to a session for failover or load balancing,
+         where <B>n</B> is a positive integer, i.e. SocketConnectPort1, SocketConnectPort2, etc.
+         Must be consecutive and have a matching SocketConnectHost&lt;n&gt;
+    </TD>
+    <TD> positive integer </TD>
+    <TD>&nbsp; </TD>
+  </TR>
+  <TR ALIGN="left" VALIGN="middle">
 
     <TD> <I>SocketConnectHost&lt;n&gt;</I> </TD>
-    <TD> Alternate socket hosts for connecting to a session for failover, where <B>n</B> is a
-         positive integer. (i.e.) SocketConnectHost1, SocketConnectHost2... must be consecutive
-         and have a matching SocketConnectPort[n]</TD>
+    <TD> Alternate socket host(s) for connecting to a session for failover or load balancing,
+         where <B>n</B> is a positive integer, i.e. SocketConnectHost1, SocketConnectHost2, etc.
+         Must be consecutive and have a matching SocketConnectPort&lt;n&gt;
+         <p>
+      Connection list iteration rules:
+      <ul>
+        <li>Connections are tried one after another until one is successful: SocketConnectHost:SocketConnectPort,
+          SocketConnectHost1:SocketConnectPort1, etc.</li>
+        <li>Next connection attempt after a successful connection will start at first defined connection again:
+          SocketConnectHost:SocketConnectPort.</li>
+      </ul>
+    </TD>
     <TD> valid IP address in the format of x.x.x.x or a domain name </TD>
 
     <TD>&nbsp; </TD>

--- a/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
@@ -34,6 +34,7 @@ import quickfix.mina.CompositeIoFilterChainBuilder;
 import quickfix.mina.EventHandlingStrategy;
 import quickfix.mina.NetworkingOptions;
 import quickfix.mina.ProtocolFactory;
+import quickfix.mina.SessionConnector;
 import quickfix.mina.message.FIXProtocolCodecFactory;
 import quickfix.mina.ssl.SSLConfig;
 import quickfix.mina.ssl.SSLContextFactory;
@@ -49,7 +50,6 @@ import java.util.Arrays;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import quickfix.mina.SessionConnector;
 
 public class IoSessionInitiator {
     private final static long CONNECT_POLL_TIMEOUT = 2000L;
@@ -228,6 +228,7 @@ public class IoSessionInitiator {
                 if (connectFuture.getSession() != null) {
                     ioSession = connectFuture.getSession();
                     connectionFailureCount = 0;
+                    nextSocketAddressIndex = 0;
                     lastConnectTime = System.currentTimeMillis();
                     connectFuture = null;
                 } else {


### PR DESCRIPTION
**Example**
Session configuration snippet:
```
SocketConnectHost=host_0
SocketConnectPort=port_0
SocketConnectHost1=host_1
SocketConnectPort1=port_1
StartTime=07:30:00
EndTime=17:30:00
```
**Issue**
FIX session establishes connection to host_0 at 07:30:00
FIX session disconnects at 17:30:00
Next day FIX session established connection to host_1 at 07:30:00, but it is expected to be host_0

For my own reference: PROM-4719