### PR TITLE
Changes to stop() method of SocketAcceptor and SocketInitiator

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
@@ -106,8 +106,8 @@ public class SocketAcceptor extends AbstractSocketAcceptor {
                 }
                 stopSessionTimer();
             } finally {
-                Session.unregisterSessions(getSessions());
                 eventHandlingStrategy.stopHandlingMessages();
+                Session.unregisterSessions(getSessions());
                 isStarted = Boolean.FALSE;
             }
         }

--- a/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
@@ -95,8 +95,8 @@ public class SocketInitiator extends AbstractSocketInitiator {
                 logoutAllSessions(forceDisconnect);
                 stopInitiators();
             } finally {
-                Session.unregisterSessions(getSessions());
                 eventHandlingStrategy.stopHandlingMessages();
+                Session.unregisterSessions(getSessions());
                 isStarted = Boolean.FALSE;
             }
         }


### PR DESCRIPTION
- try to stop processing messages before removing Sessions
- this has now the same order as on the ThreadedSocketInitiator/Acceptor