### PR TITLE
Add getOptionalString + unit test to FieldMap

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/FieldMap.java
+++ b/quickfixj-core/src/main/java/quickfix/FieldMap.java
@@ -37,13 +37,8 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.TreeMap;
 
 /**
  * Field container used by messages, groups, and composites.
@@ -230,6 +225,15 @@ public abstract class FieldMap implements Serializable {
 
     public String getString(int field) throws FieldNotFound {
         return getField(field).getObject();
+    }
+
+    public Optional<String> getOptionalString(int field) {
+        final StringField f = (StringField) fields.get(field);
+        if (f == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(f.getValue());
+        }
     }
 
     public boolean getBoolean(int field) throws FieldNotFound {

--- a/quickfixj-core/src/test/java/quickfix/FieldMapTest.java
+++ b/quickfixj-core/src/test/java/quickfix/FieldMapTest.java
@@ -11,6 +11,7 @@ import quickfix.field.MDEntryTime;
 import quickfix.field.converter.UtcTimeOnlyConverter;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 /**
  * Tests the {@link FieldMap} class.
@@ -90,6 +91,16 @@ public class FieldMapTest extends TestCase {
         testOrdering(new int[] { 1, 2, 3 }, new int[] { 3, 1 }, new int[] { 3, 1, 2 });
         testOrdering(new int[] { 3, 2, 1 }, new int[] { 3, 1 }, new int[] { 3, 1, 2 });
     }
+
+    public void testOptionalString() {
+        FieldMap map = new Message();
+        map.setField(new StringField(128, "bigbank"));
+        Optional<String> optValue = map.getOptionalString(128);
+        assertTrue(optValue.isPresent());
+        assertEquals("bigbank", optValue.get());
+        assertFalse(map.getOptionalString(129).isPresent());
+    }
+
 
     private long epochMilliOfLocalDate(LocalDateTime localDateTime) {
         return localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli();


### PR DESCRIPTION
Adds single method to FieldMap to retrieve an Optional<String> value for a tag number. Added test to FieldMapTest also.

I am having a problem with builds in Travis with tests. Based on a comment on the email list I am assuming that is related to other work.