### PR TITLE
QFJ-943: optional watermarks-based back pressure propagation from inbo…

### DIFF
--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -401,24 +401,6 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.9.1</version>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>${project.build.directory}/generated-sources</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -401,6 +401,24 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.9.1</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/quickfixj-core/src/main/java/quickfix/AbstractSessionConnectorBuilder.java
+++ b/quickfixj-core/src/main/java/quickfix/AbstractSessionConnectorBuilder.java
@@ -1,0 +1,74 @@
+package quickfix;
+
+public abstract class AbstractSessionConnectorBuilder<Derived, Product> {
+    private final Class<Derived> derived;
+    Application application;
+    MessageStoreFactory messageStoreFactory;
+    SessionSettings settings;
+    LogFactory logFactory;
+    MessageFactory messageFactory;
+
+    int queueCapacity = -1;
+    int queueLowerWatermark = -1;
+    int queueUpperWatermark = -1;
+
+    AbstractSessionConnectorBuilder(Class<Derived> derived) {
+        this.derived = derived;
+    }
+
+    public Derived withApplication(Application val) throws ConfigError {
+        application = val;
+        return derived.cast(this);
+    }
+
+    public Derived withMessageStoreFactory(MessageStoreFactory val) throws ConfigError {
+        messageStoreFactory = val;
+        return derived.cast(this);
+    }
+
+    public Derived withSettings(SessionSettings val) {
+        settings = val;
+        return derived.cast(this);
+    }
+
+    public Derived withLogFactory(LogFactory val) throws ConfigError {
+        logFactory = val;
+        return derived.cast(this);
+    }
+
+    public Derived withMessageFactory(MessageFactory val) throws ConfigError {
+        messageFactory = val;
+        return derived.cast(this);
+    }
+
+    public Derived withQueueCapacity(int val) throws  ConfigError {
+        if (queueLowerWatermark >= 0) {
+            throw new ConfigError("queue capacity and watermarks may not be configured together");
+        } else if (queueCapacity < 0) {
+            throw new ConfigError("negative queue capacity");
+        }
+        queueCapacity = val;
+        return derived.cast(this);
+    }
+
+    public Derived withQueueWatermarks(int lower, int upper) throws ConfigError {
+        if (queueCapacity >= 0) {
+            throw new ConfigError("queue capacity and watermarks may not be configured together");
+        } else if (queueLowerWatermark < 0 || queueUpperWatermark <= queueLowerWatermark) {
+            throw new ConfigError("invalid queue watermarks, required: 0 <= lower watermark < upper watermark");
+        }
+        queueLowerWatermark = lower;
+        queueUpperWatermark = upper;
+        return derived.cast(this);
+    }
+
+    public final Product build() throws ConfigError {
+        if (logFactory == null) {
+            logFactory = new ScreenLogFactory(settings);
+        }
+
+        return doBuild();
+    }
+
+    protected abstract Product doBuild() throws ConfigError;
+}

--- a/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
@@ -31,6 +31,34 @@ public class SocketAcceptor extends AbstractSocketAcceptor {
     private volatile Boolean isStarted = Boolean.FALSE;
     private final SingleThreadedEventHandlingStrategy eventHandlingStrategy;
 
+    private SocketAcceptor(Builder builder) throws ConfigError {
+        super(builder.application, builder.messageStoreFactory, builder.settings,
+                builder.logFactory, builder.messageFactory);
+
+        if (builder.queueCapacity >= 0) {
+            eventHandlingStrategy
+                    = new SingleThreadedEventHandlingStrategy(this, builder.queueCapacity);
+        } else {
+            eventHandlingStrategy
+                    = new SingleThreadedEventHandlingStrategy(this, builder.queueLowerWatermark, builder.queueUpperWatermark);
+        }
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static final class Builder extends AbstractSessionConnectorBuilder<Builder, SocketAcceptor> {
+        private Builder() {
+            super(Builder.class);
+        }
+
+        @Override
+        protected SocketAcceptor doBuild() throws ConfigError {
+            return new SocketAcceptor(this);
+        }
+    }
+
     public SocketAcceptor(Application application, MessageStoreFactory messageStoreFactory,
             SessionSettings settings, LogFactory logFactory, MessageFactory messageFactory,
             int queueCapacity)

--- a/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
@@ -31,6 +31,34 @@ public class SocketInitiator extends AbstractSocketInitiator {
     private volatile Boolean isStarted = Boolean.FALSE;
     private final SingleThreadedEventHandlingStrategy eventHandlingStrategy;
 
+    private SocketInitiator(Builder builder) throws ConfigError {
+        super(builder.application, builder.messageStoreFactory, builder.settings,
+                builder.logFactory, builder.messageFactory);
+
+        if (builder.queueCapacity >= 0) {
+            eventHandlingStrategy
+                    = new SingleThreadedEventHandlingStrategy(this, builder.queueCapacity);
+        } else {
+            eventHandlingStrategy
+                    = new SingleThreadedEventHandlingStrategy(this, builder.queueLowerWatermark, builder.queueUpperWatermark);
+        }
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static final class Builder extends AbstractSessionConnectorBuilder<Builder, SocketInitiator> {
+        private Builder() {
+            super(Builder.class);
+        }
+
+        @Override
+        protected SocketInitiator doBuild() throws ConfigError {
+            return new SocketInitiator(this);
+        }
+    }
+
     public SocketInitiator(Application application, MessageStoreFactory messageStoreFactory,
             SessionSettings settings, MessageFactory messageFactory, int queueCapacity) throws ConfigError {
         super(application, messageStoreFactory, settings, new ScreenLogFactory(settings),

--- a/quickfixj-core/src/main/java/quickfix/ThreadedSocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/ThreadedSocketAcceptor.java
@@ -29,6 +29,34 @@ import quickfix.mina.acceptor.AbstractSocketAcceptor;
 public class ThreadedSocketAcceptor extends AbstractSocketAcceptor {
     private final ThreadPerSessionEventHandlingStrategy eventHandlingStrategy;
 
+    private ThreadedSocketAcceptor(Builder builder) throws ConfigError {
+        super(builder.application, builder.messageStoreFactory, builder.settings,
+                builder.logFactory, builder.messageFactory);
+
+        if (builder.queueCapacity >= 0) {
+            eventHandlingStrategy
+                    = new ThreadPerSessionEventHandlingStrategy(this, builder.queueCapacity);
+        } else {
+            eventHandlingStrategy
+                    = new ThreadPerSessionEventHandlingStrategy(this, builder.queueLowerWatermark, builder.queueUpperWatermark);
+        }
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static final class Builder extends AbstractSessionConnectorBuilder<Builder, ThreadedSocketAcceptor> {
+        private Builder() {
+            super(Builder.class);
+        }
+
+        @Override
+        protected ThreadedSocketAcceptor doBuild() throws ConfigError {
+            return new ThreadedSocketAcceptor(this);
+        }
+    }
+
     public ThreadedSocketAcceptor(Application application, MessageStoreFactory messageStoreFactory,
                                   SessionSettings settings, LogFactory logFactory, MessageFactory messageFactory,
                                   int queueCapacity )

--- a/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
@@ -29,6 +29,34 @@ import quickfix.mina.initiator.AbstractSocketInitiator;
 public class ThreadedSocketInitiator extends AbstractSocketInitiator {
     private final ThreadPerSessionEventHandlingStrategy eventHandlingStrategy;
 
+    private ThreadedSocketInitiator(Builder builder) throws ConfigError {
+        super(builder.application, builder.messageStoreFactory, builder.settings,
+                builder.logFactory, builder.messageFactory);
+
+        if (builder.queueCapacity >= 0) {
+            eventHandlingStrategy
+                    = new ThreadPerSessionEventHandlingStrategy(this, builder.queueCapacity);
+        } else {
+            eventHandlingStrategy
+                    = new ThreadPerSessionEventHandlingStrategy(this, builder.queueLowerWatermark, builder.queueUpperWatermark);
+        }
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static final class Builder extends AbstractSessionConnectorBuilder<Builder, ThreadedSocketInitiator> {
+        private Builder() {
+            super(Builder.class);
+        }
+
+        @Override
+        protected ThreadedSocketInitiator doBuild() throws ConfigError {
+            return new ThreadedSocketInitiator(this);
+        }
+    }
+
     public ThreadedSocketInitiator(Application application,
             MessageStoreFactory messageStoreFactory, SessionSettings settings,
             LogFactory logFactory, MessageFactory messageFactory, int queueCapacity) throws ConfigError {

--- a/quickfixj-core/src/main/java/quickfix/mina/EventHandlingStrategy.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/EventHandlingStrategy.java
@@ -30,6 +30,8 @@ import quickfix.SessionID;
  * it only handles message reception events.
  */
 public interface EventHandlingStrategy {
+    final String LOWER_WATERMARK_FMT = "inbound queue size < lower watermark (%d), socket reads resumed";
+    final String UPPER_WATERMARK_FMT = "inbound queue size > upper watermark (%d), socket reads suspended";
 
     /**
      * Constant indicating how long we wait for an incoming message. After

--- a/quickfixj-core/src/main/java/quickfix/mina/EventHandlingStrategy.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/EventHandlingStrategy.java
@@ -19,9 +19,7 @@
 
 package quickfix.mina;
 
-import org.apache.mina.core.session.IoSession;
 import quickfix.Message;
-import quickfix.Responder;
 import quickfix.Session;
 import quickfix.SessionID;
 
@@ -30,9 +28,6 @@ import quickfix.SessionID;
  * it only handles message reception events.
  */
 public interface EventHandlingStrategy {
-    final String LOWER_WATERMARK_FMT = "inbound queue size < lower watermark (%d), socket reads resumed";
-    final String UPPER_WATERMARK_FMT = "inbound queue size > upper watermark (%d), socket reads suspended";
-
     /**
      * Constant indicating how long we wait for an incoming message. After
      * thread has been asked to stop, it can take up to this long to terminate.
@@ -52,15 +47,4 @@ public interface EventHandlingStrategy {
     int getQueueSize();
 
     int getQueueSize(SessionID sessionID);
-
-    static IoSession lookupIoSession(Session qfSession) {
-        final Responder responder = qfSession.getResponder();
-
-        if (responder instanceof IoSessionResponder) {
-            return ((IoSessionResponder)responder).getIoSession();
-        } else {
-            return null;
-        }
-    }
-
 }

--- a/quickfixj-core/src/main/java/quickfix/mina/EventHandlingStrategy.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/EventHandlingStrategy.java
@@ -19,7 +19,9 @@
 
 package quickfix.mina;
 
+import org.apache.mina.core.session.IoSession;
 import quickfix.Message;
+import quickfix.Responder;
 import quickfix.Session;
 import quickfix.SessionID;
 
@@ -48,4 +50,15 @@ public interface EventHandlingStrategy {
     int getQueueSize();
 
     int getQueueSize(SessionID sessionID);
+
+    static IoSession lookupIoSession(Session qfSession) {
+        final Responder responder = qfSession.getResponder();
+
+        if (responder instanceof IoSessionResponder) {
+            return ((IoSessionResponder)responder).getIoSession();
+        } else {
+            return null;
+        }
+    }
+
 }

--- a/quickfixj-core/src/main/java/quickfix/mina/IoSessionResponder.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/IoSessionResponder.java
@@ -95,4 +95,7 @@ public class IoSessionResponder implements Responder {
         return null;
     }
 
+    IoSession getIoSession() {
+        return ioSession;
+    }
 }

--- a/quickfixj-core/src/main/java/quickfix/mina/QueueTracker.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/QueueTracker.java
@@ -8,23 +8,4 @@ interface QueueTracker<E> {
     void put(E e) throws InterruptedException;
     E poll(long timeout, TimeUnit unit) throws InterruptedException;
     int drainTo(Collection<E> collection);
-
-    static <E> QueueTracker<E> wrap(BlockingQueue<E> queue) {
-        return new QueueTracker<E>() {
-            @Override
-            public void put(E e) throws InterruptedException {
-                queue.put(e);
-            }
-
-            @Override
-            public E poll(long timeout, TimeUnit unit) throws InterruptedException {
-                return queue.poll(timeout, unit);
-            }
-
-            @Override
-            public int drainTo(Collection<E> collection) {
-                return queue.drainTo(collection);
-            }
-        };
-    }
 }

--- a/quickfixj-core/src/main/java/quickfix/mina/QueueTracker.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/QueueTracker.java
@@ -1,0 +1,30 @@
+package quickfix.mina;
+
+import java.util.Collection;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+interface QueueTracker<E> {
+    void put(E e) throws InterruptedException;
+    E poll(long timeout, TimeUnit unit) throws InterruptedException;
+    int drainTo(Collection<E> collection);
+
+    static <E> QueueTracker<E> wrap(BlockingQueue<E> queue) {
+        return new QueueTracker<E>() {
+            @Override
+            public void put(E e) throws InterruptedException {
+                queue.put(e);
+            }
+
+            @Override
+            public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+                return queue.poll(timeout, unit);
+            }
+
+            @Override
+            public int drainTo(Collection<E> collection) {
+                return queue.drainTo(collection);
+            }
+        };
+    }
+}

--- a/quickfixj-core/src/main/java/quickfix/mina/QueueTrackers.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/QueueTrackers.java
@@ -1,0 +1,89 @@
+package quickfix.mina;
+
+import org.apache.mina.core.session.IoSession;
+import quickfix.Responder;
+import quickfix.Session;
+
+import java.util.Collection;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static java.lang.String.format;
+
+/**
+ * Queue trackers factory methods
+ */
+final class QueueTrackers {
+    private static final String LOWER_WATERMARK_FMT = "inbound queue size < lower watermark (%d), socket reads resumed";
+    private static final String UPPER_WATERMARK_FMT = "inbound queue size > upper watermark (%d), socket reads suspended";
+
+    /**
+     * Watermarks-based queue tracker
+     */
+    static <E> WatermarkTracker<E, Session> newMultiSessionWatermarkTracker(
+            BlockingQueue<E> queue,
+            long lowerWatermark, long upperWatermark,
+            Function<E, Session> classifier) {
+        return WatermarkTracker.newMulti(queue, lowerWatermark, upperWatermark, classifier,
+                qfSession -> resumeReads(qfSession, (int)lowerWatermark),
+                qfSession -> suspendReads(qfSession, (int)upperWatermark));
+    }
+
+    /**
+     * Default no-op queue tracker
+     */
+    static <E> QueueTracker<E> newDefaultQueueTracker(BlockingQueue<E> queue) {
+        return new QueueTracker<E>() {
+            @Override
+            public void put(E e) throws InterruptedException {
+                queue.put(e);
+            }
+
+            @Override
+            public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+                return queue.poll(timeout, unit);
+            }
+
+            @Override
+            public int drainTo(Collection<E> collection) {
+                return queue.drainTo(collection);
+            }
+        };
+    }
+
+    private static IoSession lookupIoSession(Session qfSession) {
+        final Responder responder = qfSession.getResponder();
+
+        if (responder instanceof IoSessionResponder) {
+            return ((IoSessionResponder)responder).getIoSession();
+        } else {
+            return null;
+        }
+    }
+
+    private static void resumeReads(Session qfSession, int queueLowerWatermark) {
+        final IoSession ioSession = lookupIoSession(qfSession);
+        if (ioSession != null && ioSession.isReadSuspended()) {
+            ioSession.resumeRead();
+            qfSession.getLog().onEvent(format(LOWER_WATERMARK_FMT, queueLowerWatermark));
+        }
+    }
+
+    private static void suspendReads(Session qfSession, int queueUpperWatermark) {
+        final IoSession ioSession = lookupIoSession(qfSession);
+        if (ioSession != null && !ioSession.isReadSuspended()) {
+            ioSession.suspendRead();
+            qfSession.getLog().onEvent(format(UPPER_WATERMARK_FMT, queueUpperWatermark));
+        }
+    }
+
+    static <E, Void> WatermarkTracker<E, Void> newSingleSessionWatermarkTracker(
+            BlockingQueue<E> queue,
+            long lowerWatermark, long upperWatermark,
+            Session qfSession) {
+        return WatermarkTracker.newMono(queue, lowerWatermark, upperWatermark,
+                () -> resumeReads(qfSession, (int)lowerWatermark),
+                () -> suspendReads(qfSession, (int)upperWatermark));
+    }
+}

--- a/quickfixj-core/src/main/java/quickfix/mina/SingleThreadedEventHandlingStrategy.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/SingleThreadedEventHandlingStrategy.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.String.format;
 import static quickfix.mina.EventHandlingStrategy.lookupIoSession;
 
 /**
@@ -65,16 +66,14 @@ public class SingleThreadedEventHandlingStrategy implements EventHandlingStrateg
                     final IoSession ioSession = lookupIoSession(qfSession);
                     if (ioSession != null && ioSession.isReadSuspended()) {
                         ioSession.resumeRead();
-                        LOG.info("{}: inbound queue size < lower watermark ({}), socket reads resumed",
-                                qfSession.getSessionID(), queueLowerWatermark);
+                        qfSession.getLog().onEvent(format(LOWER_WATERMARK_FMT, queueLowerWatermark));
                     }
                 },
                 qfSession -> { // upper watermark crossed up, while reads active
                     final IoSession ioSession = lookupIoSession(qfSession);
                     if (ioSession != null && !ioSession.isReadSuspended()) {
                         ioSession.suspendRead();
-                        LOG.info("{}: inbound queue size > upper watermark ({}), socket reads suspended",
-                                qfSession.getSessionID(), queueUpperWatermark);
+                        qfSession.getLog().onEvent(format(UPPER_WATERMARK_FMT, queueUpperWatermark));
                     }
                 });
     }

--- a/quickfixj-core/src/main/java/quickfix/mina/SingleThreadedEventHandlingStrategy.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/SingleThreadedEventHandlingStrategy.java
@@ -33,6 +33,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static quickfix.mina.EventHandlingStrategy.lookupIoSession;
+
 /**
  * Processes messages for all sessions in a single thread.
  */
@@ -75,15 +77,6 @@ public class SingleThreadedEventHandlingStrategy implements EventHandlingStrateg
                                 qfSession.getSessionID(), queueUpperWatermark);
                     }
                 });
-    }
-    private static IoSession lookupIoSession(Session qfSession) {
-        final Responder responder = qfSession.getResponder();
-
-        if (responder instanceof IoSessionResponder) {
-            return ((IoSessionResponder)responder).getIoSession();
-        } else {
-            return null;
-        }
     }
 
     public void setExecutor(Executor executor) {

--- a/quickfixj-core/src/main/java/quickfix/mina/ThreadPerSessionEventHandlingStrategy.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/ThreadPerSessionEventHandlingStrategy.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.String.format;
 import static quickfix.mina.EventHandlingStrategy.lookupIoSession;
 
 /**
@@ -192,16 +193,14 @@ public class ThreadPerSessionEventHandlingStrategy implements EventHandlingStrat
                             final IoSession ioSession = lookupIoSession(quickfixSession);
                             if (ioSession != null && ioSession.isReadSuspended()) {
                                 ioSession.resumeRead();
-                                LOG.info("{}: inbound queue size < lower watermark ({}), socket reads resumed",
-                                        quickfixSession.getSessionID(), queueLowerWatermark);
+                                quickfixSession.getLog().onEvent(format(LOWER_WATERMARK_FMT, queueLowerWatermark));
                             }
                         },
                         () -> { // upper watermark crossed up, while reads active
                             final IoSession ioSession = lookupIoSession(quickfixSession);
                             if (ioSession != null && !ioSession.isReadSuspended()) {
                                 ioSession.suspendRead();
-                                LOG.info("{}: inbound queue size > upper watermark ({}), socket reads suspended",
-                                        quickfixSession.getSessionID(), queueUpperWatermark);
+                                quickfixSession.getLog().onEvent(format(UPPER_WATERMARK_FMT, queueUpperWatermark));
                             }
                         });
             }

--- a/quickfixj-core/src/main/java/quickfix/mina/WatermarkTracker.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/WatermarkTracker.java
@@ -75,14 +75,14 @@ public class WatermarkTracker<E,S> implements QueueTracker<E> {
         }
     }
 
-    public static <E, Void> WatermarkTracker<E, Void> newMono(
+    static <E, Void> WatermarkTracker<E, Void> newMono(
             BlockingQueue<E> queue,
             long lowerWatermark, long upperWatermark,
             Runnable onLowerWatermarkCrossed, Runnable onUpperWatermarkCrossed) {
-        return new WatermarkTracker<E, Void>(queue, lowerWatermark, upperWatermark, onLowerWatermarkCrossed, onUpperWatermarkCrossed);
+        return new WatermarkTracker<>(queue, lowerWatermark, upperWatermark, onLowerWatermarkCrossed, onUpperWatermarkCrossed);
     }
 
-    public static <E, S> WatermarkTracker<E, S> newMulti(
+    static <E, S> WatermarkTracker<E, S> newMulti(
             BlockingQueue<E> queue,
             long lowerWatermark, long upperWatermark,
             Function<E, S> classifier,

--- a/quickfixj-core/src/main/java/quickfix/mina/WatermarkTracker.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/WatermarkTracker.java
@@ -17,11 +17,6 @@
  * are not clear to you.
  ******************************************************************************/
 
-/*
- * Copyright (c) 2018 Vladimir Lysyy (mrbald@github)
- * ALv2 (http://www.apache.org/licenses/LICENSE-2.0)
- */
-
 package quickfix.mina;
 
 import java.util.AbstractCollection;
@@ -100,8 +95,6 @@ public class WatermarkTracker<E,S> implements QueueTracker<E> {
             long lowerWatermark, long upperWatermark,
             Function<E, S> classifier,
             Consumer<S> onLowerWatermarkCrossed, Consumer<S> onUpperWatermarkCrossed) {
-        assert lowerWatermark >= 0 && lowerWatermark < upperWatermark;
-
         this.queue = queue;
         this.lowerWatermark = lowerWatermark;
         this.upperWatermark = upperWatermark;
@@ -118,8 +111,6 @@ public class WatermarkTracker<E,S> implements QueueTracker<E> {
             BlockingQueue<E> queue,
             long lowerWatermark, long upperWatermark,
             Runnable onLowerWatermarkCrossed, Runnable onUpperWatermarkCrossed) {
-        assert lowerWatermark >= 0 && lowerWatermark < upperWatermark;
-
         this.queue = queue;
         this.lowerWatermark = lowerWatermark;
         this.upperWatermark = upperWatermark;

--- a/quickfixj-core/src/main/java/quickfix/mina/WatermarkTracker.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/WatermarkTracker.java
@@ -1,0 +1,185 @@
+/*******************************************************************************
+ * Copyright (c) quickfixengine.org  All rights reserved.
+ *
+ * This file is part of the QuickFIX FIX Engine
+ *
+ * This file may be distributed under the terms of the quickfixengine.org
+ * license as defined by quickfixengine.org and appearing in the file
+ * LICENSE included in the packaging of this file.
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING
+ * THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * See http://www.quickfixengine.org/LICENSE for licensing information.
+ *
+ * Contact ask@quickfixengine.org if any conditions of this licensing
+ * are not clear to you.
+ ******************************************************************************/
+
+/*
+ * Copyright (c) 2018 Vladimir Lysyy (mrbald@github)
+ * ALv2 (http://www.apache.org/licenses/LICENSE-2.0)
+ */
+
+package quickfix.mina;
+
+import java.util.AbstractCollection;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * A blocking queue wrapper implementing watermarks-based back pressure propagation
+ * from the queue sink to one or more logical sources.
+ *
+ * @param <E> payload type
+ * @param <S> logical source key type
+ *
+ * @author Vladimir Lysyy (mrbald@github)
+ */
+public class WatermarkTracker<E,S> implements QueueTracker<E> {
+    private final BlockingQueue<E> queue;
+    private final long lowerWatermark;
+    private final long upperWatermark;
+    private final Consumer<S> onLowerWatermarkCrossed;
+    private final Consumer<S> onUpperWatermarkCrossed;
+    private final Function<E, S> classifier;
+    private final Function<S, StreamTracker> trackerSupplier;
+
+    class StreamTracker {
+        private final S key;
+        long counter = 0;
+        private boolean suspended = false;
+
+        StreamTracker(S key) {
+            this.key = key;
+        }
+
+        synchronized void incoming(int n) {
+            if ((counter += n) >= upperWatermark && !suspended) {
+                suspended = true;
+                onUpperWatermarkCrossed.accept(key);
+            }
+        }
+
+        synchronized void outgoing(int n) {
+            if ((counter -= n) == lowerWatermark && suspended) {
+                suspended = false;
+                onLowerWatermarkCrossed.accept(key);
+            }
+        }
+
+        synchronized boolean isSuspended() {
+            return suspended;
+        }
+    }
+
+    public static <E, Void> WatermarkTracker<E, Void> newMono(
+            BlockingQueue<E> queue,
+            long lowerWatermark, long upperWatermark,
+            Runnable onLowerWatermarkCrossed, Runnable onUpperWatermarkCrossed) {
+        return new WatermarkTracker<E, Void>(queue, lowerWatermark, upperWatermark, onLowerWatermarkCrossed, onUpperWatermarkCrossed);
+    }
+
+    public static <E, S> WatermarkTracker<E, S> newMulti(
+            BlockingQueue<E> queue,
+            long lowerWatermark, long upperWatermark,
+            Function<E, S> classifier,
+            Consumer<S> onLowerWatermarkCrossed, Consumer<S> onUpperWatermarkCrossed) {
+        return new WatermarkTracker<>(queue, lowerWatermark, upperWatermark, classifier, onLowerWatermarkCrossed, onUpperWatermarkCrossed);
+    }
+
+    private WatermarkTracker(
+            BlockingQueue<E> queue,
+            long lowerWatermark, long upperWatermark,
+            Function<E, S> classifier,
+            Consumer<S> onLowerWatermarkCrossed, Consumer<S> onUpperWatermarkCrossed) {
+        assert lowerWatermark >= 0 && lowerWatermark < upperWatermark;
+
+        this.queue = queue;
+        this.lowerWatermark = lowerWatermark;
+        this.upperWatermark = upperWatermark;
+        this.classifier = classifier;
+        this.onLowerWatermarkCrossed = onLowerWatermarkCrossed;
+        this.onUpperWatermarkCrossed = onUpperWatermarkCrossed;
+
+        final Map<S, StreamTracker> trackerMap = new ConcurrentHashMap<>();
+
+        this.trackerSupplier = key -> trackerMap.computeIfAbsent(key, StreamTracker::new);
+    }
+
+    private WatermarkTracker(
+            BlockingQueue<E> queue,
+            long lowerWatermark, long upperWatermark,
+            Runnable onLowerWatermarkCrossed, Runnable onUpperWatermarkCrossed) {
+        assert lowerWatermark >= 0 && lowerWatermark < upperWatermark;
+
+        this.queue = queue;
+        this.lowerWatermark = lowerWatermark;
+        this.upperWatermark = upperWatermark;
+        this.classifier = x -> null;
+        this.onLowerWatermarkCrossed = x -> onLowerWatermarkCrossed.run();
+        this.onUpperWatermarkCrossed = x -> onUpperWatermarkCrossed.run();
+
+        final StreamTracker streamTracker = new StreamTracker(null);
+
+        this.trackerSupplier = key -> streamTracker;
+    }
+
+    @Override
+    public void put(E e) throws InterruptedException {
+        queue.put(e);
+        trackerForPayload(e).incoming(1);
+    }
+
+    @Override
+    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+        final E e = queue.poll(timeout, unit);
+
+        if (e != null) {
+            trackerForPayload(e).outgoing(1);
+        }
+
+        return e;
+    }
+
+    @Override
+    public int drainTo(Collection<E> collection) {
+        return queue.drainTo(new AbstractCollection<E>() {
+            @Override public Iterator<E> iterator() { throw new UnsupportedOperationException(); }
+            @Override public int size() { throw new UnsupportedOperationException(); }
+
+            public boolean add(E e) {
+                final boolean added = collection.add(e);
+                if (added) {
+                    trackerForPayload(e).outgoing(1);
+                }
+                return added;
+            }
+
+        });
+    }
+
+    public boolean isSuspended(S key) {
+        return trackerForStream(key).isSuspended();
+    }
+
+    public boolean isSuspended() {
+        return isSuspended(null);
+    }
+
+    StreamTracker trackerForPayload(E e) {
+        return trackerForStream(classifier.apply(e));
+    }
+
+    StreamTracker trackerForStream(S s) {
+        return trackerSupplier.apply(s);
+    }
+
+}

--- a/quickfixj-core/src/test/java/quickfix/mina/ThreadPerSessionEventHandlingStrategyTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/ThreadPerSessionEventHandlingStrategyTest.java
@@ -47,7 +47,6 @@ import quickfix.field.converter.UtcTimestampConverter;
 import quickfix.fix40.Logon;
 
 import java.util.Date;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -74,7 +73,7 @@ public class ThreadPerSessionEventHandlingStrategyTest {
         }
 
         @Override
-        protected Message getNextMessage(BlockingQueue<Message> messages) throws InterruptedException {
+        protected Message getNextMessage(QueueTracker<Message> queueTracker) throws InterruptedException {
             if (getMessageCount-- == 0) {
                 throw new InterruptedException("END COUNT");
             }
@@ -84,7 +83,7 @@ public class ThreadPerSessionEventHandlingStrategyTest {
                 }
                 throw (RuntimeException) getNextMessageException;
             }
-            return super.getNextMessage(messages);
+            return super.getNextMessage(queueTracker);
         }
     }
 

--- a/quickfixj-core/src/test/java/quickfix/mina/WatermarkTrackerTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/WatermarkTrackerTest.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright (c) quickfixengine.org  All rights reserved.
+ *
+ * This file is part of the QuickFIX FIX Engine
+ *
+ * This file may be distributed under the terms of the quickfixengine.org
+ * license as defined by quickfixengine.org and appearing in the file
+ * LICENSE included in the packaging of this file.
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING
+ * THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * See http://www.quickfixengine.org/LICENSE for licensing information.
+ *
+ * Contact ask@quickfixengine.org if any conditions of this licensing
+ * are not clear to you.
+ ******************************************************************************/
+
+/*
+ * Copyright (c) 2018 Vladimir Lysyy (mrbald@github)
+ * ALv2 (http://www.apache.org/licenses/LICENSE-2.0)
+ */
+
+package quickfix.mina;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static quickfix.mina.WatermarkTracker.newMono;
+import static quickfix.mina.WatermarkTracker.newMulti;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WatermarkTrackerTest {
+    @Mock
+    private Runnable onLowerMono;
+
+    @Mock
+    private Runnable onUpperMono;
+
+    @Mock
+    private Consumer<Integer> onLowerMulti;
+
+    @Mock
+    private Consumer<Integer> onUpperMulti;
+
+    private BlockingQueue<Integer> queue;
+
+    private WatermarkTracker<Integer, Void> mono;
+
+    @Before
+    public void setUp() {
+        queue = new ArrayBlockingQueue<>(4);
+        mono = newMono(queue, 1, 3, onLowerMono, onUpperMono);
+    }
+
+    @Test
+    public void basics() throws InterruptedException {
+        mono.put(1);
+        assertEquals(1, queue.size());
+
+        final Integer x = mono.poll(1, TimeUnit.DAYS);
+        assertEquals(0, queue.size());
+        assertEquals(1, x.intValue());
+    }
+
+    /*
+     * Queue size over time in the below test, covers all scenarios
+     *
+     * (queue size)
+     *  3           *   *
+     *  2         *   *   *
+     *  1   *   *           *
+     *  0 *   *               *
+     *    1 2 3 4 5 6 7 8 9 0 1 (steps)
+     */
+    @Test
+    public void watermarks() throws InterruptedException {
+        // cross lower watermark up
+        mono.put(1);
+        verifyState(false, false, false);
+
+        // cross lower watermark down while not suspended
+        mono.poll(1, TimeUnit.DAYS);
+        verifyState(false, false, false);
+
+        // cross lower then upper watermarks up
+        mono.put(1);
+        verifyState(false, false, false);
+
+        mono.put(2);
+        verifyState(false, false, false);
+
+        mono.put(3);
+        verifyState(true, false, true);
+
+        // cross upper watermark down
+        mono.poll(1, TimeUnit.DAYS); // 3
+        verifyState(true, false, false);
+
+        // cross upper watermark back up (without reaching the lower)
+        mono.put(3);
+        verifyState(true, false, false);
+
+        // cross upper then lower watermarks down
+        mono.poll(1, TimeUnit.DAYS); // 2
+        verifyState(true, false, false);
+
+        mono.poll(1, TimeUnit.DAYS); // 2
+        verifyState(false, true, false);
+
+        mono.poll(1, TimeUnit.DAYS); // 1
+        verifyState(false, false, false);
+    }
+
+    @Test
+    public void multiShouldWork() throws InterruptedException {
+        final Function<Integer, Integer> classifier = x -> x % 2;
+        final WatermarkTracker<Integer, Integer> multi
+                = newMulti(queue, 1, 3, classifier, onLowerMulti, onUpperMulti);
+
+        assertEquals(multi.trackerForStream(0), multi.trackerForStream(0));
+        assertEquals(multi.trackerForStream(1), multi.trackerForStream(1));
+        assertNotEquals(multi.trackerForStream(0), multi.trackerForStream(1));
+
+        assertEquals(multi.trackerForPayload(0), multi.trackerForPayload(2));
+        assertEquals(multi.trackerForPayload(1), multi.trackerForPayload(3));
+        assertNotEquals(multi.trackerForPayload(0), multi.trackerForPayload(1));
+
+        multi.put(1);
+        assertEquals(1, multi.trackerForPayload(1).counter);
+        multi.put(3);
+        assertEquals(2, multi.trackerForPayload(3).counter);
+    }
+
+    // === helpers ===
+
+    private void verifyState(boolean suspended, boolean onLower, boolean onUpper) {
+        assertEquals(suspended, mono.isSuspended());
+        verify(onLowerMono, times(onLower ? 1 : 0)).run();
+        verify(onUpperMono, times(onUpper ? 1 : 0)).run();
+        reset(onLowerMono, onUpperMono);
+    }
+}

--- a/quickfixj-core/src/test/java/quickfix/mina/WatermarkTrackerTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/WatermarkTrackerTest.java
@@ -17,11 +17,6 @@
  * are not clear to you.
  ******************************************************************************/
 
-/*
- * Copyright (c) 2018 Vladimir Lysyy (mrbald@github)
- * ALv2 (http://www.apache.org/licenses/LICENSE-2.0)
- */
-
 package quickfix.mina;
 
 import org.junit.Before;


### PR DESCRIPTION
The background for this change is described in the QFJ-943

To make sure writes to the inbound FIX Message queue don't block the MINA IO loop a blocking queue can be replaced with watermarks-based (configured with lower and upper watermark values instead of fixed queue capacity.

When using watermarks the queue is no longer limited in size.
Instead, when queue grows above the upper watermark, the socket reads of the respective session are suspended by unsubscribing from reads with MINA selector (IoSession.suspendRead()), nicely propagating back pressure onto the remote end of the TCP session by the TCP flow control.

When the queue drains below the lower watermark the socket is resubscribed for reads (IoSession.resumeRead()and the back pressure is relieved.

The functionality is implemented with a standalone class WatermarkTracker.

Watermarks - enabled queue in SPSC scenario shows somewhat near 300ns enqueue/dequeue times, which should not be a problem considering general latencies of QuickFIXj, so I left it with JDK collections.

The implementation is sandboxed / benchmarked in https://github.com/mrbald/ufwj. Additionally, the threaded initiator tested under load in a prod-like environment

NB: watermarks do not save the day if one side of the fix session outperforms the other side on the average. If socket reads get disabled for long enough the receiver starts missing heartbeats and eventually drops the link.