### PR TITLE
QFJ-888: DefaultMessageFactory does not support FIX5.0 SP1/2

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/DefaultMessageFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/DefaultMessageFactory.java
@@ -19,9 +19,11 @@
 
 package quickfix;
 
+import quickfix.field.ApplVerID;
 import quickfix.field.MsgType;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static quickfix.FixVersions.BEGINSTRING_FIX40;
@@ -40,6 +42,8 @@ import static quickfix.FixVersions.FIX50SP2;
 public class DefaultMessageFactory implements MessageFactory {
     private final Map<String, MessageFactory> messageFactories = new ConcurrentHashMap<>();
 
+    private final ApplVerID defaultApplVerID;
+
     /**
      * Constructs a DefaultMessageFactory, which dynamically loads and delegates to
      * the default version-specific message factories, if they are available at runtime.
@@ -47,8 +51,28 @@ public class DefaultMessageFactory implements MessageFactory {
      * Callers can set the {@link Thread#setContextClassLoader context classloader},
      * which will be used to load the classes if {@link Class#forName Class.forName}
      * fails to do so (e.g. in an OSGi environment).
+     * <p>
+     * Equivalent to {@link #DefaultMessageFactory(String) DefaultMessageFactory}({@link ApplVerID#FIX50 ApplVerID.FIX50}).
      */
     public DefaultMessageFactory() {
+        this(FIX50);
+    }
+
+    /**
+     * Constructs a DefaultMessageFactory, which dynamically loads and delegates to
+     * the default version-specific message factories, if they are available at runtime.
+     * <p>
+     * Callers can set the {@link Thread#setContextClassLoader context classloader},
+     * which will be used to load the classes if {@link Class#forName Class.forName}
+     * fails to do so (e.g. in an OSGi environment).
+     *
+     * @param defaultApplVerID ApplVerID value used by default for {@link #create(String, ApplVerID, String)}
+     */
+    public DefaultMessageFactory(String defaultApplVerID) {
+        Objects.requireNonNull(defaultApplVerID, "defaultApplVerID");
+
+        this.defaultApplVerID = new ApplVerID(defaultApplVerID);
+
         // To loosen the coupling between this factory and generated code, the
         // message factories are discovered at run time using reflection
         addFactory(BEGINSTRING_FIX40);
@@ -118,27 +142,23 @@ public class DefaultMessageFactory implements MessageFactory {
         }
     }
 
+    @Override
     public Message create(String beginString, String msgType) {
+        return create(beginString, defaultApplVerID, msgType);
+    }
+
+    @Override
+    public Message create(String beginString, ApplVerID applVerID, String msgType) {
         MessageFactory messageFactory = messageFactories.get(beginString);
-        if (beginString.equals(BEGINSTRING_FIXT11)) {
-            // The default message factory assumes that only FIX 5.0 will be
-            // used with FIXT 1.1 sessions. A more flexible approach will require
-            // an extension to the QF JNI API. Until then, you will need a custom
-            // message factory if you want to use application messages prior to
-            // FIX 5.0 with a FIXT 1.1 session.
-            //
-            // TODO: how do we support 50/50SP1/50SP2 concurrently?
-            //
-            // If you need to determine admin message category based on a data
-            // dictionary, then use a custom message factory and don't use the
-            // static method used below.
-            if (!MessageUtils.isAdminMessage(msgType)) {
-                messageFactory = messageFactories.get(FIX50);
+        if (beginString.equals(BEGINSTRING_FIXT11) && !MessageUtils.isAdminMessage(msgType)) {
+            if (applVerID == null) {
+                applVerID = new ApplVerID(defaultApplVerID.getValue());
             }
+            messageFactory = messageFactories.get(MessageUtils.toBeginString(applVerID));
         }
 
         if (messageFactory != null) {
-            return messageFactory.create(beginString, msgType);
+            return messageFactory.create(beginString, applVerID, msgType);
         }
 
         Message message = new Message();

--- a/quickfixj-core/src/main/java/quickfix/DefaultMessageFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/DefaultMessageFactory.java
@@ -55,7 +55,7 @@ public class DefaultMessageFactory implements MessageFactory {
      * Equivalent to {@link #DefaultMessageFactory(String) DefaultMessageFactory}({@link ApplVerID#FIX50 ApplVerID.FIX50}).
      */
     public DefaultMessageFactory() {
-        this(FIX50);
+        this(ApplVerID.FIX50);
     }
 
     /**

--- a/quickfixj-core/src/main/java/quickfix/MessageFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/MessageFactory.java
@@ -19,6 +19,8 @@
 
 package quickfix;
 
+import quickfix.field.ApplVerID;
+
 /**
  * Used by a Session to create a Message.
  *
@@ -34,6 +36,18 @@ public interface MessageFactory {
      * @return a message instance
      */
     Message create(String beginString, String msgType);
+
+    /**
+     * Creates a message for a specified type, FIX version, and ApplVerID.
+     *
+     * @param beginString the FIX version (for example, "FIX.4.2")
+     * @param applVerID the ApplVerID (for example "6" for FIX44)
+     * @param msgType the FIX message type (for example, "D" for an order)
+     * @return a message instance
+     */
+    default Message create(String beginString, ApplVerID applVerID, String msgType) {
+        return create(beginString, msgType);
+    }
 
     /**
      * Creates a group for the specified parent message type and

--- a/quickfixj-core/src/main/java/quickfix/MessageUtils.java
+++ b/quickfixj-core/src/main/java/quickfix/MessageUtils.java
@@ -142,7 +142,7 @@ public class MessageUtils {
         final DataDictionary applicationDataDictionary = ddProvider == null ? null : ddProvider
                 .getApplicationDataDictionary(applVerID);
 
-        final quickfix.Message message = messageFactory.create(beginString, msgType);
+        final quickfix.Message message = messageFactory.create(beginString, applVerID, msgType);
         final DataDictionary payloadDictionary = MessageUtils.isAdminMessage(msgType)
                 ? sessionDataDictionary
                 : applicationDataDictionary;

--- a/quickfixj-core/src/test/java/quickfix/DefaultMessageFactoryTest.java
+++ b/quickfixj-core/src/test/java/quickfix/DefaultMessageFactoryTest.java
@@ -2,13 +2,13 @@ package quickfix;
 
 import static org.junit.Assert.*;
 import static quickfix.FixVersions.*;
+import static quickfix.field.ApplVerID.*;
 
 import org.junit.Test;
 
-import quickfix.field.LinesOfText;
-import quickfix.field.MsgType;
-import quickfix.field.NoLinesOfText;
-import quickfix.field.NoMDEntries;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import quickfix.field.*;
 import quickfix.test.util.ExpectedTestFailure;
 
 /**
@@ -17,8 +17,19 @@ import quickfix.test.util.ExpectedTestFailure;
  * @author toli
  * @version $Id$
  */
+@RunWith(Parameterized.class)
 public class DefaultMessageFactoryTest {
-    private final DefaultMessageFactory factory = new DefaultMessageFactory();
+    private final DefaultMessageFactory factory;
+    private final Class<? extends Message> fixtCreateExpectedClass;
+
+    public DefaultMessageFactoryTest(String defaultApplVerID, Class<? extends Message> fixtCreateExpectedClass) {
+        if (defaultApplVerID != null) {
+            this.factory = new DefaultMessageFactory(defaultApplVerID);
+        } else {
+            this.factory = new DefaultMessageFactory();
+        }
+        this.fixtCreateExpectedClass = fixtCreateExpectedClass;
+    }
 
     @Test
     public void testMessageCreate() throws Exception {
@@ -27,18 +38,28 @@ public class DefaultMessageFactoryTest {
         assertMessage(quickfix.fix42.Advertisement.class, MsgType.ADVERTISEMENT, factory.create(BEGINSTRING_FIX42, MsgType.ADVERTISEMENT));
         assertMessage(quickfix.fix43.Advertisement.class, MsgType.ADVERTISEMENT, factory.create(BEGINSTRING_FIX43, MsgType.ADVERTISEMENT));
         assertMessage(quickfix.fix44.Advertisement.class, MsgType.ADVERTISEMENT, factory.create(BEGINSTRING_FIX44, MsgType.ADVERTISEMENT));
-        assertMessage(quickfix.fix50.Advertisement.class, MsgType.ADVERTISEMENT, factory.create(FIX50, MsgType.ADVERTISEMENT));
+        assertMessage(quickfix.fix50.Advertisement.class, MsgType.ADVERTISEMENT, factory.create(FixVersions.FIX50, MsgType.ADVERTISEMENT));
+        assertMessage(quickfix.fix50sp1.Advertisement.class, MsgType.ADVERTISEMENT, factory.create(FixVersions.FIX50SP1, MsgType.ADVERTISEMENT));
+        assertMessage(quickfix.fix50sp2.Advertisement.class, MsgType.ADVERTISEMENT, factory.create(FixVersions.FIX50SP2, MsgType.ADVERTISEMENT));
         assertMessage(quickfix.Message.class, MsgType.ADVERTISEMENT, factory.create("unknown", MsgType.ADVERTISEMENT));
     }
 
     @Test
     public void testFixtCreate() throws Exception {
         assertMessage(quickfix.fixt11.Logon.class, MsgType.LOGON, factory.create(BEGINSTRING_FIXT11, MsgType.LOGON));
+        assertMessage(fixtCreateExpectedClass, MsgType.EMAIL, factory.create(BEGINSTRING_FIXT11, MsgType.EMAIL));
+        assertMessage(quickfix.fix40.Email.class, MsgType.EMAIL, factory.create(BEGINSTRING_FIXT11, new ApplVerID(FIX40), MsgType.EMAIL));
+        assertMessage(quickfix.fix41.Email.class, MsgType.EMAIL, factory.create(BEGINSTRING_FIXT11, new ApplVerID(FIX41), MsgType.EMAIL));
+        assertMessage(quickfix.fix42.Email.class, MsgType.EMAIL, factory.create(BEGINSTRING_FIXT11, new ApplVerID(FIX42), MsgType.EMAIL));
+        assertMessage(quickfix.fix43.Email.class, MsgType.EMAIL, factory.create(BEGINSTRING_FIXT11, new ApplVerID(FIX43), MsgType.EMAIL));
+        assertMessage(quickfix.fix44.Email.class, MsgType.EMAIL, factory.create(BEGINSTRING_FIXT11, new ApplVerID(FIX44), MsgType.EMAIL));
+        assertMessage(quickfix.fix50.Email.class, MsgType.EMAIL, factory.create(BEGINSTRING_FIXT11, new ApplVerID(ApplVerID.FIX50), MsgType.EMAIL));
+        assertMessage(quickfix.fix50sp1.Email.class, MsgType.EMAIL, factory.create(BEGINSTRING_FIXT11, new ApplVerID(ApplVerID.FIX50SP1), MsgType.EMAIL));
+        assertMessage(quickfix.fix50sp2.Email.class, MsgType.EMAIL, factory.create(BEGINSTRING_FIXT11, new ApplVerID(ApplVerID.FIX50SP2), MsgType.EMAIL));
     }
 
     @Test
     public void testGroupCreate() throws Exception {
-
         new ExpectedTestFailure(IllegalArgumentException.class, "unknown") {
             protected void execute() throws Throwable {
                 factory.create("unknown", MsgType.NEWS, LinesOfText.FIELD);
@@ -50,7 +71,9 @@ public class DefaultMessageFactoryTest {
         assertEquals(quickfix.fix42.News.LinesOfText.class, factory.create(BEGINSTRING_FIX42, MsgType.NEWS, LinesOfText.FIELD).getClass());
         assertEquals(quickfix.fix43.News.LinesOfText.class, factory.create(BEGINSTRING_FIX43, MsgType.NEWS, LinesOfText.FIELD).getClass());
         assertEquals(quickfix.fix44.News.LinesOfText.class, factory.create(BEGINSTRING_FIX44, MsgType.NEWS, LinesOfText.FIELD).getClass());
-        assertEquals(quickfix.fix50.News.NoLinesOfText.class, factory.create(FIX50, MsgType.NEWS, NoLinesOfText.FIELD).getClass());
+        assertEquals(quickfix.fix50.News.NoLinesOfText.class, factory.create(FixVersions.FIX50, MsgType.NEWS, NoLinesOfText.FIELD).getClass());
+        assertEquals(quickfix.fix50sp1.News.NoLinesOfText.class, factory.create(FixVersions.FIX50SP1, MsgType.NEWS, NoLinesOfText.FIELD).getClass());
+        assertEquals(quickfix.fix50sp2.News.NoLinesOfText.class, factory.create(FixVersions.FIX50SP2, MsgType.NEWS, NoLinesOfText.FIELD).getClass());
         assertNull("if group can't be created return null",
                 factory.create(BEGINSTRING_FIX40, MsgType.MARKET_DATA_SNAPSHOT_FULL_REFRESH, NoMDEntries.FIELD));
     }
@@ -58,5 +81,19 @@ public class DefaultMessageFactoryTest {
     private static void assertMessage(Class<?> expectedMessageClass, String expectedMessageType, Message message) throws Exception {
         assertEquals(expectedMessageClass, message.getClass());
         assertEquals(expectedMessageType, message.getHeader().getString(MsgType.FIELD));
+    }
+
+    @Parameterized.Parameters(name = "defaultApplVerID = {0}")
+    public static Object[][] getParameters() {
+        return new Object[][] {
+                {ApplVerID.FIX40, quickfix.fix40.Email.class},
+                {ApplVerID.FIX41, quickfix.fix41.Email.class},
+                {ApplVerID.FIX42, quickfix.fix42.Email.class},
+                {ApplVerID.FIX43, quickfix.fix43.Email.class},
+                {ApplVerID.FIX44, quickfix.fix44.Email.class},
+                {ApplVerID.FIX50, quickfix.fix50.Email.class},
+                {ApplVerID.FIX50SP1, quickfix.fix50sp1.Email.class},
+                {ApplVerID.FIX50SP2, quickfix.fix50sp2.Email.class}
+        };
     }
 }

--- a/quickfixj-core/src/test/java/quickfix/test/acceptance/ATMessageCracker.java
+++ b/quickfixj-core/src/test/java/quickfix/test/acceptance/ATMessageCracker.java
@@ -65,6 +65,16 @@ class ATMessageCracker extends quickfix.MessageCracker {
         process(message, sessionID);
     }
 
+    public void onMessage(quickfix.fix50sp1.NewOrderSingle message, SessionID sessionID)
+            throws FieldNotFound, UnsupportedMessageType, IncorrectTagValue {
+        process(message, sessionID);
+    }
+
+    public void onMessage(quickfix.fix50sp2.NewOrderSingle message, SessionID sessionID)
+            throws FieldNotFound, UnsupportedMessageType, IncorrectTagValue {
+        process(message, sessionID);
+    }
+
     public void onMessage(quickfix.fix50.SecurityDefinition message, SessionID sessionID)
             throws FieldNotFound, UnsupportedMessageType, IncorrectTagValue {
         try {


### PR DESCRIPTION
The background for this change is described in [QFJ-888](https://www.quickfixj.org/jira/browse/QFJ-888).

Changes are as follows:
1. Added a new create method to `MessageFactory` which accepts an `ApplVerID`. The default behavior of the new method is to call `MessageFactory.create(beginString, msgType)` in order to maintain backwards compatibility.
2. Modified `MessageUtils.parse` to call the new create method, passing in the `ApplVerID` acquired from the incoming message or the session. Other calls to `MessageFactory.create` have remained as-is.
3. Added a new constructor to `DefaultMessageFactory` which accepts an `ApplVerID` value to be used as the default when `create(beginString, msgType)` or `create(beginString, null, msgType)` is called. The existing constructor calls the new one, passing in `ApplVerID.FIX50` in order to maintain backwards compatibility.
4. Implementation of message creation in `DefaultMessageFactory` has been moved to the new create method. The old create method calls `create(beginString, null, msgType)`. In the case where `applVerID` is null, the `defaultApplVerID` is used instead.

Ultimately, these changes provide the following:
1. Developers who use `DefaultMessageFactory` can now specify a default `ApplVerID` to be used for FIXT message construction.
2. FIXT message construction is now done dynamically according to the `ApplVerID` in the incoming message/session.