### PR TITLE
QFJ-940 - Event log omits parts of received message in case of validation errors

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -129,6 +129,10 @@ public class Message extends FieldMap {
      * Do not call this method concurrently while modifying the contents of the message.
      * This is likely to produce unexpected results or will fail with a ConcurrentModificationException
      * since FieldMap.calculateString() is iterating over the TreeMap of fields.
+     * 
+     * Use toRawString() to get the raw message data.
+     * 
+     * @return Message as String with calculated body length and checksum.
      */
     @Override
     public String toString() {
@@ -142,6 +146,21 @@ public class Message extends FieldMap {
         trailer.calculateString(sb, null, null);
 
         return sb.toString();
+    }
+
+    /**
+     * Return the raw message data as it was passed to the Message class.
+     * 
+     * This is only available after Message has been parsed via constructor or Message.fromString().
+     * Otherwise this method will return NULL.
+     * 
+     * This method neither does change fields nor calculate body length or checksum.
+     * Use toString() for that purpose.
+     * 
+     * @return Message as String without recalculating body length and checksum.
+     */
+    public String toRawString() {
+        return messageData;
     }
 
     public int bodyLength() {

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -1508,7 +1508,7 @@ public class Session implements Closeable {
 
         reject.setString(Text.FIELD, str);
         sendRaw(reject, 0);
-        getLog().onErrorEvent("Reject sent for Message " + msgSeqNum + ": " + str);
+        getLog().onErrorEvent("Reject sent for message " + msgSeqNum + ": " + str);
     }
 
     private boolean isPossibleDuplicate(Message message) throws FieldNotFound {
@@ -1531,7 +1531,7 @@ public class Session implements Closeable {
         }
         if (!state.isLogonReceived()) {
             final String errorMessage = "Tried to send a reject while not logged on: " + reason
-                    + " (field " + field + ")";
+                    + (reason.endsWith("" + field) ? "" : " (field " + field + ")");
             throw new SessionException(errorMessage);
         }
 
@@ -1588,16 +1588,15 @@ public class Session implements Closeable {
         } finally {
             state.unlockTargetMsgSeqNum();
         }
-
+        final String logMessage = "Reject sent for message " + msgSeqNum;
         if (reason != null && (field > 0 || err == SessionRejectReason.INVALID_TAG_NUMBER)) {
             setRejectReason(reject, field, reason, true);
-            getLog().onErrorEvent(
-                    "Reject sent for Message " + msgSeqNum + ": " + reason + ":" + field);
+            getLog().onErrorEvent(logMessage + ": " + reason + (reason.endsWith("" + field) ? "" : ":" + field));
         } else if (reason != null) {
             setRejectReason(reject, reason);
-            getLog().onErrorEvent("Reject sent for Message " + msgSeqNum + ": " + reason);
+            getLog().onErrorEvent(logMessage + ": " + reason);
         } else {
-            getLog().onErrorEvent("Reject sent for Message " + msgSeqNum);
+            getLog().onErrorEvent(logMessage);
         }
 
         if (enableLastMsgSeqNumProcessed) {
@@ -1651,7 +1650,7 @@ public class Session implements Closeable {
         final String reason = BusinessRejectReasonText.getMessage(err);
         setRejectReason(reject, field, reason, field != 0);
         getLog().onErrorEvent(
-                "Reject sent for Message " + msgSeqNum + (reason != null ? (": " + reason) : "")
+                "Reject sent for message " + msgSeqNum + (reason != null ? (": " + reason) : "")
                         + (field != 0 ? (": tag=" + field) : ""));
 
         sendRaw(reject, 0);
@@ -2283,7 +2282,7 @@ public class Session implements Closeable {
                     if (begin != 0) {
                         generateSequenceReset(receivedMessage, begin, msgSeqNum);
                     }
-                    getLog().onEvent("Resending Message: " + msgSeqNum);
+                    getLog().onEvent("Resending message: " + msgSeqNum);
                     send(msg.toString());
                     begin = 0;
                     appMessageJustSent = true;
@@ -2577,7 +2576,7 @@ public class Session implements Closeable {
 
             return result;
         } catch (final IOException e) {
-            logThrowable(getLog(), "Error Reading/Writing in MessageStore", e);
+            logThrowable(getLog(), "Error reading/writing in MessageStore", e);
             return false;
         } catch (final FieldNotFound e) {
             logThrowable(state.getLog(), "Error accessing message fields", e);

--- a/quickfixj-core/src/test/java/quickfix/MessageTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageTest.java
@@ -1755,6 +1755,22 @@ public class MessageTest {
         assertEquals("780508", underlyingSymbol);
     }
 
+    @Test
+    // QFJ-940
+    public void testRawString() throws Exception {
+
+        String test = "8=FIX.4.4|9=431|35=d|49=1|34=2|52=20140117-18:20:26.629|56=3|57=21|322=388721|"
+                + "323=4|320=1|393=42|82=1|67=1|711=1|311=780508|309=text|305=8|463=FXXXXX|307=text|542=20140716|"
+                + "436=10.0|9013=1.0|9014=1.0|9017=10|9022=1|9024=1.0|9025=Y|916=20140701|917=20150731|9201=23974|"
+                + "9200=17|9202=text|9300=727|9301=text|9302=text|9303=text|998=text|9100=text|9101=text|9085=text|"
+                + "9083=0|9084=0|9061=579|9062=text|9063=text|9032=10.0|9002=F|9004=780415|9005=780503|10=223|";
+        
+        DataDictionary dictionary = new DataDictionary(DataDictionaryTest.getDictionary());
+        Message message = new Message();
+        message.fromString(test.replaceAll("\\|", "\001"), dictionary, true);
+        assertEquals(test, message.toRawString().replaceAll("\001", "\\|"));
+    }
+
     private void assertHeaderField(Message message, String expectedValue, int field)
             throws FieldNotFound {
         assertEquals(expectedValue, message.getHeader().getString(field));


### PR DESCRIPTION
- added method Message.toRawString() which returns the message string as it was passed to the Message class
- in case of errors: log raw message data instead of incompletely parsed message
- added unit test
- improved some log messages in Session class