### PR TITLE
Cleanup Sessions on stop

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketAcceptor.java
@@ -107,7 +107,8 @@ public class SocketAcceptor extends AbstractSocketAcceptor {
                 stopSessionTimer();
             } finally {
                 eventHandlingStrategy.stopHandlingMessages();
-                Session.unregisterSessions(getSessions());
+                Session.unregisterSessions(getSessions(), true);
+                clearConnectorSessions();
                 isStarted = Boolean.FALSE;
             }
         }

--- a/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
@@ -96,7 +96,8 @@ public class SocketInitiator extends AbstractSocketInitiator {
                 stopInitiators();
             } finally {
                 eventHandlingStrategy.stopHandlingMessages();
-                Session.unregisterSessions(getSessions());
+                Session.unregisterSessions(getSessions(), true);
+                clearConnectorSessions();
                 isStarted = Boolean.FALSE;
             }
         }

--- a/quickfixj-core/src/main/java/quickfix/ThreadedSocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/ThreadedSocketAcceptor.java
@@ -87,7 +87,8 @@ public class ThreadedSocketAcceptor extends AbstractSocketAcceptor {
         }
         stopSessionTimer();
         eventHandlingStrategy.stopDispatcherThreads();
-        Session.unregisterSessions(getSessions());
+        Session.unregisterSessions(getSessions(), true);
+        clearConnectorSessions();
     }
 
     public void block() throws ConfigError, RuntimeError {

--- a/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
@@ -85,7 +85,8 @@ public class ThreadedSocketInitiator extends AbstractSocketInitiator {
         logoutAllSessions(forceDisconnect);
         stopInitiators();
         eventHandlingStrategy.stopDispatcherThreads();
-        Session.unregisterSessions(getSessions());
+        Session.unregisterSessions(getSessions(), true);
+        clearConnectorSessions();
     }
 
     public void block() throws ConfigError, RuntimeError {

--- a/quickfixj-core/src/main/java/quickfix/mina/SessionConnector.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/SessionConnector.java
@@ -120,6 +120,15 @@ public abstract class SessionConnector implements Connector {
     }
 
     /**
+     * Will remove all Sessions from the SessionConnector's Session map.
+     * Please make sure that these Sessions were unregistered before via
+     * Session.unregisterSessions().
+     */
+    protected void clearConnectorSessions() {
+        this.sessions.clear();
+    }
+
+    /**
      * Get the list of session managed by this connector.
      *
      * @return list of quickfix.Session objects

--- a/quickfixj-core/src/main/java/quickfix/mina/initiator/AbstractSocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/initiator/AbstractSocketInitiator.java
@@ -77,9 +77,6 @@ public abstract class AbstractSocketInitiator extends SessionConnector implement
     protected void createSessionInitiators()
             throws ConfigError {
         try {
-            // QFJ698: clear() is needed on restart, otherwise the set gets filled up with
-            // more and more initiators which are not equal because the local port differs
-            initiators.clear();
             createSessions();
             SessionSettings settings = getSettings();
             for (final Session session : getSessionMap().values()) {
@@ -278,8 +275,9 @@ public abstract class AbstractSocketInitiator extends SessionConnector implement
     }
 
     protected void stopInitiators() {
-        for (final IoSessionInitiator initiator : initiators) {
-            initiator.stop();
+        for (Iterator<IoSessionInitiator> iterator = initiators.iterator(); iterator.hasNext();) {
+            iterator.next().stop();
+            iterator.remove();
         }
         super.stopSessionTimer();
     }

--- a/quickfixj-core/src/test/java/org/quickfixj/jmx/mbean/session/SessionAdminTest.java
+++ b/quickfixj-core/src/test/java/org/quickfixj/jmx/mbean/session/SessionAdminTest.java
@@ -20,11 +20,12 @@ import java.util.ArrayList;
 public class SessionAdminTest extends TestCase {
 
     public void testResetSequence() throws Exception {
-        Session session = SessionFactoryTestSupport.createSession();
-        MockSessionAdmin admin = new MockSessionAdmin(session, null, null);
-        admin.resetSequence(25);
-        assertEquals(1, admin.sentMessages.size());
-        assertEquals(25, admin.sentMessages.get(0).getInt(NewSeqNo.FIELD));
+        try (Session session = SessionFactoryTestSupport.createSession()) {
+            MockSessionAdmin admin = new MockSessionAdmin(session, null, null);
+            admin.resetSequence(25);
+            assertEquals(1, admin.sentMessages.size());
+            assertEquals(25, admin.sentMessages.get(0).getInt(NewSeqNo.FIELD));
+        }
     }
 
     private class MockSessionAdmin extends SessionAdmin {

--- a/quickfixj-core/src/test/java/quickfix/FileLogTest.java
+++ b/quickfixj-core/src/test/java/quickfix/FileLogTest.java
@@ -202,14 +202,15 @@ public class FileLogTest {
         settings.setBool(sessionID, FileLogFactory.SETTING_INCLUDE_MILLIS_IN_TIMESTAMP, false);
         FileLogFactory factory = new FileLogFactory(settings);
 
-        Session session = new Session(new UnitTestApplication(), new MemoryStoreFactory(),
+        try (Session session = new Session(new UnitTestApplication(), new MemoryStoreFactory(),
                 sessionID, new DefaultDataDictionaryProvider(), null, factory,
-                new DefaultMessageFactory(), 0);
-        Session.registerSession(session);
-
-        FileLog log = (FileLog) session.getLog();
-        log.close();
-        log.logIncoming("test");
-        // no stack overflow exception thrown
+                new DefaultMessageFactory(), 0)) {
+            Session.registerSession(session);
+            
+            FileLog log = (FileLog) session.getLog();
+            log.close();
+            log.logIncoming("test");
+            // no stack overflow exception thrown
+        }
     }
 }

--- a/quickfixj-core/src/test/java/quickfix/JdbcLogTest.java
+++ b/quickfixj-core/src/test/java/quickfix/JdbcLogTest.java
@@ -26,14 +26,25 @@ import java.sql.Statement;
 
 import javax.sql.DataSource;
 
-import junit.framework.TestCase;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+import org.junit.After;
+import org.junit.Test;
 
-public class JdbcLogTest extends TestCase {
+public class JdbcLogTest {
     private JdbcLog log;
     private JdbcLogFactory logFactory;
     private Connection connection;
     private SessionID sessionID;
 
+    @After
+    public void tearDown() {
+        Session.unregisterSession(sessionID, true);
+    }
+
+    @Test
     public void testLog() throws Exception {
         doLogTest(null);
     }
@@ -60,6 +71,7 @@ public class JdbcLogTest extends TestCase {
         assertEquals(0, getRowCount(connection, "event_log"));
     }
 
+    @Test
     public void testLogWithHeartbeatFiltering() throws Exception {
         setUpJdbcLog(false, null);
 
@@ -83,6 +95,7 @@ public class JdbcLogTest extends TestCase {
      * (such as we can't connect ot the DB, or the tables are missing) and doesn't try
      * to print failing exceptions recursively until the stack overflows
      */
+    @Test
     public void testHandlesRecursivelyFailingException() throws Exception {
         setUpJdbcLog(false, null);
 

--- a/quickfixj-core/src/test/java/quickfix/SessionDisconnectConcurrentlyTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionDisconnectConcurrentlyTest.java
@@ -258,51 +258,52 @@ public class SessionDisconnectConcurrentlyTest extends TestCase {
         };
 
         final SessionID sessionID = new SessionID(FixVersions.BEGINSTRING_FIX44, "SENDER", "TARGET");
-        final Session session = new SessionFactoryTestSupport.Builder()
+        try (Session session = new SessionFactoryTestSupport.Builder()
                 .setSessionId(sessionID)
                 .setApplication(application)
                 .setLogFactory(null)
                 .setResetOnLogon(false)
                 .setIsInitiator(true)
-                .build();
-        final UnitTestResponder responder = new UnitTestResponder();
-        session.setResponder(responder);
-        session.addStateListener(responder);
-        session.logon();
-        session.next();
-
-        final Message logonRequest = new Message(responder.sentMessageData);
-
-        final Message logonResponse = new DefaultMessageFactory().create(sessionID.getBeginString(), MsgType.LOGON);
-        logonResponse.setInt(EncryptMethod.FIELD, EncryptMethod.NONE_OTHER);
-        logonResponse.setInt(HeartBtInt.FIELD, logonRequest.getInt(HeartBtInt.FIELD));
-
-        final Message.Header header = logonResponse.getHeader();
-        header.setString(BeginString.FIELD, sessionID.getBeginString());
-        header.setString(SenderCompID.FIELD, sessionID.getSenderCompID());
-        header.setString(TargetCompID.FIELD, sessionID.getTargetCompID());
-        header.setInt(MsgSeqNum.FIELD, 1);
-        header.setUtcTimeStamp(SendingTime.FIELD, SystemTime.getLocalDateTime(), true);
-
-        final PausableThreadPoolExecutor ptpe = new PausableThreadPoolExecutor();
-        ptpe.pause();
-
-        for (int j=0; j<1000; j++) {
-            final Thread thread = new Thread(() -> {
-                try {
-                    session.disconnect("No reason", false);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }, "disconnectThread"+j);
-            thread.setDaemon(true);
-            ptpe.submit(thread);
+                .build()) {
+            final UnitTestResponder responder = new UnitTestResponder();
+            session.setResponder(responder);
+            session.addStateListener(responder);
+            session.logon();
+            session.next();
+            
+            final Message logonRequest = new Message(responder.sentMessageData);
+            
+            final Message logonResponse = new DefaultMessageFactory().create(sessionID.getBeginString(), MsgType.LOGON);
+            logonResponse.setInt(EncryptMethod.FIELD, EncryptMethod.NONE_OTHER);
+            logonResponse.setInt(HeartBtInt.FIELD, logonRequest.getInt(HeartBtInt.FIELD));
+            
+            final Message.Header header = logonResponse.getHeader();
+            header.setString(BeginString.FIELD, sessionID.getBeginString());
+            header.setString(SenderCompID.FIELD, sessionID.getSenderCompID());
+            header.setString(TargetCompID.FIELD, sessionID.getTargetCompID());
+            header.setInt(MsgSeqNum.FIELD, 1);
+            header.setUtcTimeStamp(SendingTime.FIELD, SystemTime.getLocalDateTime(), true);
+            
+            final PausableThreadPoolExecutor ptpe = new PausableThreadPoolExecutor();
+            ptpe.pause();
+            
+            for (int j=0; j<1000; j++) {
+                final Thread thread = new Thread(() -> {
+                    try {
+                        session.disconnect("No reason", false);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }, "disconnectThread"+j);
+                thread.setDaemon(true);
+                ptpe.submit(thread);
+            }
+            
+            ptpe.resume();
+            ptpe.awaitTermination(2, TimeUnit.SECONDS);
+            ptpe.shutdownNow();
+            assertEquals(1, onLogoutCount.intValue());
         }
-
-        ptpe.resume();
-        ptpe.awaitTermination(2, TimeUnit.SECONDS);
-        ptpe.shutdownNow();
-        assertEquals(1, onLogoutCount.intValue());
     }
 
     private class UnitTestResponder implements Responder, SessionStateListener {

--- a/quickfixj-core/src/test/java/quickfix/SessionResetTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionResetTest.java
@@ -32,59 +32,60 @@ public class SessionResetTest {
 
         final UnitTestApplication application = new UnitTestApplication();
         final SessionID sessionID = new SessionID(FixVersions.BEGINSTRING_FIX44, "SENDER", "TARGET");
-        final Session session = SessionFactoryTestSupport.createSession(sessionID,
-                application, true, false);
-        final UnitTestResponder responder = new UnitTestResponder();
-        session.setResponder(responder);
-        session.addStateListener(responder);
-        session.logon();
-        session.next();
-
-        assertFalse(responder.onResetCalled);
-
-        final Message logonRequest = new Message(responder.sentMessageData);
-        final Message logonResponse = new DefaultMessageFactory().create(
-                sessionID.getBeginString(), MsgType.LOGON);
-        logonResponse.setInt(EncryptMethod.FIELD, EncryptMethod.NONE_OTHER);
-        logonResponse.setInt(HeartBtInt.FIELD, logonRequest.getInt(HeartBtInt.FIELD));
-
-        final Message.Header header = logonResponse.getHeader();
-        header.setString(BeginString.FIELD, sessionID.getBeginString());
-        header.setString(SenderCompID.FIELD, sessionID.getSenderCompID());
-        header.setString(TargetCompID.FIELD, sessionID.getTargetCompID());
-        header.setInt(MsgSeqNum.FIELD, 1);
-        header.setUtcTimeStamp(SendingTime.FIELD, SystemTime.getLocalDateTime(), true);
-
-        Thread resetThread = new Thread(() -> {
-            try {
-                session.reset();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }, "SessionReset");
-        resetThread.setDaemon(true);
-
-        Thread messageSender = new Thread(() -> {
-            for (int i = 2; i <= NUMBER_OF_ADMIN_MESSAGES; i++) {
-                session.send(createAdminMessage(i));
-            }
-        }, "SessionSend");
-        messageSender.setDaemon(true);
-
-        // submit threads to pausable executor and try to let them start at the same time
-        PausableThreadPoolExecutor ptpe = new PausableThreadPoolExecutor();
-        ptpe.pause();
-        ptpe.submit(messageSender);
-        ptpe.submit(resetThread);
-        ptpe.resume();
-        ptpe.awaitTermination(2, TimeUnit.SECONDS);
-
-        ThreadMXBean bean = ManagementFactory.getThreadMXBean();
-        long[] threadIds = bean.findDeadlockedThreads();
-        assertNull("no threads should be deadlocked", threadIds);
-        assertTrue("session should have been reset", responder.onResetCalled);
-        
-        ptpe.shutdownNow();
+        try (Session session = SessionFactoryTestSupport.createSession(sessionID,
+                application, true, false)) {
+            final UnitTestResponder responder = new UnitTestResponder();
+            session.setResponder(responder);
+            session.addStateListener(responder);
+            session.logon();
+            session.next();
+            
+            assertFalse(responder.onResetCalled);
+            
+            final Message logonRequest = new Message(responder.sentMessageData);
+            final Message logonResponse = new DefaultMessageFactory().create(
+                    sessionID.getBeginString(), MsgType.LOGON);
+            logonResponse.setInt(EncryptMethod.FIELD, EncryptMethod.NONE_OTHER);
+            logonResponse.setInt(HeartBtInt.FIELD, logonRequest.getInt(HeartBtInt.FIELD));
+            
+            final Message.Header header = logonResponse.getHeader();
+            header.setString(BeginString.FIELD, sessionID.getBeginString());
+            header.setString(SenderCompID.FIELD, sessionID.getSenderCompID());
+            header.setString(TargetCompID.FIELD, sessionID.getTargetCompID());
+            header.setInt(MsgSeqNum.FIELD, 1);
+            header.setUtcTimeStamp(SendingTime.FIELD, SystemTime.getLocalDateTime(), true);
+            
+            Thread resetThread = new Thread(() -> {
+                try {
+                    session.reset();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }, "SessionReset");
+            resetThread.setDaemon(true);
+            
+            Thread messageSender = new Thread(() -> {
+                for (int i = 2; i <= NUMBER_OF_ADMIN_MESSAGES; i++) {
+                    session.send(createAdminMessage(i));
+                }
+            }, "SessionSend");
+            messageSender.setDaemon(true);
+            
+            // submit threads to pausable executor and try to let them start at the same time
+            PausableThreadPoolExecutor ptpe = new PausableThreadPoolExecutor();
+            ptpe.pause();
+            ptpe.submit(messageSender);
+            ptpe.submit(resetThread);
+            ptpe.resume();
+            ptpe.awaitTermination(2, TimeUnit.SECONDS);
+            
+            ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+            long[] threadIds = bean.findDeadlockedThreads();
+            assertNull("no threads should be deadlocked", threadIds);
+            assertTrue("session should have been reset", responder.onResetCalled);
+            
+            ptpe.shutdownNow();
+        }
     }
 
     private Message createAdminMessage(int sequence) {

--- a/quickfixj-core/src/test/java/quickfix/SocketInitiatorTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SocketInitiatorTest.java
@@ -58,6 +58,8 @@ import quickfix.test.util.ReflectionUtil;
 
 public class SocketInitiatorTest {
     private final Logger log = LoggerFactory.getLogger(getClass());
+    // store static Session count before the test to check cleanup
+    private static final int SESSION_COUNT = Session.numSessions();
 
     @Before
     public void setUp() throws Exception {
@@ -376,8 +378,8 @@ public class SocketInitiatorTest {
 
                 initiator.stop();
                 assertFalse(clientSession.isLoggedOn());
-                assertTrue(initiator.getSessions().contains(clientSessionID));
-                assertTrue(initiator.getSessions().size() == 1);
+                assertFalse(initiator.getSessions().contains(clientSessionID));
+                assertTrue(initiator.getSessions().size() == 0);
                 if (messageLog != null) {
                     messageLogLength = messageLog.length();
                     assertTrue(messageLog.length() > 0);
@@ -404,6 +406,8 @@ public class SocketInitiatorTest {
             serverThread.join();
         }
         assertEquals("Client application should receive logout", 2, clientApplication.logoutCounter);
+        assertTrue("After stop() the Session count should not be higher than before the test", Session.numSessions() <= SESSION_COUNT );
+        assertEquals("After stop() the Session count should be zero in Connector", 0, initiator.getSessions().size() );
     }
 
     private void doTestOfStop(SessionID clientSessionID, ClientApplication clientApplication,

--- a/quickfixj-core/src/test/java/quickfix/mina/ThreadPerSessionEventHandlingStrategyTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/ThreadPerSessionEventHandlingStrategyTest.java
@@ -123,54 +123,55 @@ public class ThreadPerSessionEventHandlingStrategyTest {
             }
         };
 
-        final Session session = setUpSession(sessionID, application);
+        try (Session session = setUpSession(sessionID, application)) {
 
-        final Message message = new Logon();
-        message.getHeader().setString(SenderCompID.FIELD, "ISLD");
-        message.getHeader().setString(TargetCompID.FIELD, "TW");
-        message.getHeader().setString(SendingTime.FIELD,
-                UtcTimestampConverter.convert(new Date(), false));
-        message.getHeader().setInt(MsgSeqNum.FIELD, 1);
-        message.setInt(HeartBtInt.FIELD, 30);
-
-        strategy.onMessage(session, message);
-
-        // Wait for a received message
-        if (!latch.await(5, TimeUnit.SECONDS)) {
-            fail("Timeout");
-        }
-
-        assertEquals(1, application.fromAdminMessages.size());
-
-        final Thread[] threads = new Thread[1024];
-        Thread.enumerate(threads);
-
-        Thread dispatcherThread = null;
-        for (final Thread thread : threads) {
-            if (thread.getName().startsWith("QF/J Session dispatcher")) {
-                dispatcherThread = thread;
-                // Dispatcher threads are not daemon threads
-                assertThat(dispatcherThread.isDaemon(), is(false));
-                break;
+            final Message message = new Logon();
+            message.getHeader().setString(SenderCompID.FIELD, "ISLD");
+            message.getHeader().setString(TargetCompID.FIELD, "TW");
+            message.getHeader().setString(SendingTime.FIELD,
+                    UtcTimestampConverter.convert(new Date(), false));
+            message.getHeader().setInt(MsgSeqNum.FIELD, 1);
+            message.setInt(HeartBtInt.FIELD, 30);
+            
+            strategy.onMessage(session, message);
+            
+            // Wait for a received message
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                fail("Timeout");
             }
-        }
-
-        // We should have found the dispatcher thread
-        assertThat(dispatcherThread, notNullValue());
-
-        // Stop the threads and then check the thread state
-        strategy.stopDispatcherThreads();
-
-        for (int i = 0; i < 10; i++) {
-            Thread.sleep(100);
-            if (!dispatcherThread.isAlive()) {
-                break;
+            
+            assertEquals(1, application.fromAdminMessages.size());
+            
+            final Thread[] threads = new Thread[1024];
+            Thread.enumerate(threads);
+            
+            Thread dispatcherThread = null;
+            for (final Thread thread : threads) {
+                if (thread.getName().startsWith("QF/J Session dispatcher")) {
+                    dispatcherThread = thread;
+                    // Dispatcher threads are not daemon threads
+                    assertThat(dispatcherThread.isDaemon(), is(false));
+                    break;
+                }
             }
+            
+            // We should have found the dispatcher thread
+            assertThat(dispatcherThread, notNullValue());
+            
+            // Stop the threads and then check the thread state
+            strategy.stopDispatcherThreads();
+            
+            for (int i = 0; i < 10; i++) {
+                Thread.sleep(100);
+                if (!dispatcherThread.isAlive()) {
+                    break;
+                }
+            }
+            
+            // Dispatcher thread should be dead
+            assertThat(dispatcherThread.isAlive(), is(false));
+            assertNull(strategy.getDispatcher(sessionID));
         }
-
-        // Dispatcher thread should be dead
-        assertThat(dispatcherThread.isAlive(), is(false));
-        assertNull(strategy.getDispatcher(sessionID));
     }
 
     /**
@@ -191,94 +192,97 @@ public class ThreadPerSessionEventHandlingStrategyTest {
             }
         };
 
-        final Session session = setUpSession(sessionID, application);
+        try (Session session = setUpSession(sessionID, application)) {
 
-        final Message message = new Logon();
-        message.getHeader().setString(SenderCompID.FIELD, "ISLD");
-        message.getHeader().setString(TargetCompID.FIELD, "TW");
-        message.getHeader().setString(SendingTime.FIELD,
-                UtcTimestampConverter.convert(new Date(), false));
-        message.getHeader().setInt(MsgSeqNum.FIELD, 1);
-        message.setInt(HeartBtInt.FIELD, 30);
-
-        strategy.onMessage(session, message);
-
-        // Wait for a received message
-        if (!latch.await(5, TimeUnit.SECONDS)) {
-            fail("Timeout");
-        }
-
-        assertEquals(1, application.fromAdminMessages.size());
-
-        Thread[] threads = new Thread[1024];
-        Thread.enumerate(threads);
-
-        Thread dispatcherThread = null;
-        for (final Thread thread : threads) {
-            if (thread != null && thread.getName().startsWith("QF/J Session dispatcher")) {
-                dispatcherThread = thread;
-                // Dispatcher threads are not daemon threads
-                assertThat(dispatcherThread.isDaemon(), is(false));
-                break;
+            final Message message = new Logon();
+            message.getHeader().setString(SenderCompID.FIELD, "ISLD");
+            message.getHeader().setString(TargetCompID.FIELD, "TW");
+            message.getHeader().setString(SendingTime.FIELD,
+                    UtcTimestampConverter.convert(new Date(), false));
+            message.getHeader().setInt(MsgSeqNum.FIELD, 1);
+            message.setInt(HeartBtInt.FIELD, 30);
+            
+            strategy.onMessage(session, message);
+            
+            // Wait for a received message
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                fail("Timeout");
             }
-        }
-
-        assertTrue(session.hasResponder());
-        // QFJ-790: we do not check the state of the responder anymore
-        // but wait for the END_OF_STREAM message to stop the threads.
-        strategy.onMessage(session, EventHandlingStrategy.END_OF_STREAM);
-
-        // sleep some time to let the thread stop
-        for (int i = 0; i < 20; i++) {
-            Thread.sleep(100);
-            if (!dispatcherThread.isAlive()) {
-                break;
+            
+            assertEquals(1, application.fromAdminMessages.size());
+            
+            Thread[] threads = new Thread[1024];
+            Thread.enumerate(threads);
+            
+            Thread dispatcherThread = null;
+            for (final Thread thread : threads) {
+                if (thread != null && thread.getName().startsWith("QF/J Session dispatcher")) {
+                    dispatcherThread = thread;
+                    // Dispatcher threads are not daemon threads
+                    assertThat(dispatcherThread.isDaemon(), is(false));
+                    break;
+                }
             }
-        }
-        assertNull(strategy.getDispatcher(sessionID));
-
-        threads = new Thread[1024];
-        Thread.enumerate(threads);
-
-        dispatcherThread = null;
-        for (final Thread thread : threads) {
-            if (thread != null && thread.getName().startsWith("QF/J Session dispatcher")) {
-                dispatcherThread = thread;
-                // Dispatcher threads are not daemon threads
-                assertThat(dispatcherThread.isDaemon(), is(false));
-                break;
+            
+            assertTrue(session.hasResponder());
+            // QFJ-790: we do not check the state of the responder anymore
+            // but wait for the END_OF_STREAM message to stop the threads.
+            strategy.onMessage(session, EventHandlingStrategy.END_OF_STREAM);
+            
+            // sleep some time to let the thread stop
+            for (int i = 0; i < 20; i++) {
+                Thread.sleep(100);
+                if (!dispatcherThread.isAlive()) {
+                    break;
+                }
             }
+            assertNull(strategy.getDispatcher(sessionID));
+            
+            threads = new Thread[1024];
+            Thread.enumerate(threads);
+            
+            dispatcherThread = null;
+            for (final Thread thread : threads) {
+                if (thread != null && thread.getName().startsWith("QF/J Session dispatcher")) {
+                    dispatcherThread = thread;
+                    // Dispatcher threads are not daemon threads
+                    assertThat(dispatcherThread.isDaemon(), is(false));
+                    break;
+                }
+            }
+            
+            // the session dispatcher should be dead and hence not listed in the threads array
+            assertNull(dispatcherThread);
+            assertFalse(session.hasResponder());
         }
-
-        // the session dispatcher should be dead and hence not listed in the threads array
-        assertNull(dispatcherThread);
-        assertFalse(session.hasResponder());
     }
 
     @Test
     public void testEventHandlingInterruptInRun() throws Exception {
         final SessionID sessionID = new SessionID(FixVersions.BEGINSTRING_FIX40, "TW", "ISLD");
-        final Session session = setUpSession(sessionID);
-        final Message message = new Logon();
-        message.setInt(HeartBtInt.FIELD, 30);
-        final ThreadPerSessionEventHandlingStrategyUnderTest strategy = new ThreadPerSessionEventHandlingStrategyUnderTest();
-
-        strategy.onMessage(session, message);
-        strategy.getNextMessageException = new InterruptedException("TEST");
-        strategy.getDispatcher(sessionID).run();
+        try (Session session = setUpSession(sessionID)) {
+            final Message message = new Logon();
+            message.setInt(HeartBtInt.FIELD, 30);
+            final ThreadPerSessionEventHandlingStrategyUnderTest strategy = new ThreadPerSessionEventHandlingStrategyUnderTest();
+            
+            strategy.onMessage(session, message);
+            strategy.getNextMessageException = new InterruptedException("TEST");
+            strategy.getDispatcher(sessionID).run();
+        }
     }
 
     @Test
     public void testEventHandlingRuntimeException() throws Exception {
         final SessionID sessionID = new SessionID(FixVersions.BEGINSTRING_FIX40, "TW", "ISLD");
-        final Session session = setUpSession(sessionID);
-        final Message message = new Logon();
-        message.setInt(HeartBtInt.FIELD, 30);
-        final ThreadPerSessionEventHandlingStrategyUnderTest strategy = new ThreadPerSessionEventHandlingStrategyUnderTest();
-
-        strategy.onMessage(session, message);
-        strategy.getNextMessageException = new NullPointerException("TEST");
-        strategy.getDispatcher(sessionID).run();
+        try (Session session = setUpSession(sessionID)) {
+            final Message message = new Logon();
+            message.setInt(HeartBtInt.FIELD, 30);
+            final ThreadPerSessionEventHandlingStrategyUnderTest strategy = new ThreadPerSessionEventHandlingStrategyUnderTest();
+            
+            strategy.onMessage(session, message);
+            strategy.getNextMessageException = new NullPointerException("TEST");
+            strategy.getDispatcher(sessionID).run();
+        }
     }
 
     // verify the assumption that this always returns null

--- a/quickfixj-core/src/test/java/quickfix/mina/acceptor/DynamicAcceptorSessionProviderTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/acceptor/DynamicAcceptorSessionProviderTest.java
@@ -81,37 +81,40 @@ public class DynamicAcceptorSessionProviderTest extends TestCase {
 
     public void testSessionCreation() throws Exception {
 
-        Session session1 = provider.getSession(new SessionID("FIX.4.2", "SENDER", "SENDERSUB",
-                "SENDERLOC", "TARGET", "TARGETSUB", "TARGETLOC", null), null);
-        SessionID sessionID1 = session1.getSessionID();
-        assertEquals("wrong FIX version", "FIX.4.2", sessionID1.getBeginString());
-        assertEquals("wrong sender", "SENDER", sessionID1.getSenderCompID());
-        assertEquals("wrong senderSub", "SENDERSUB", sessionID1.getSenderSubID());
-        assertEquals("wrong senderLoc", "SENDERLOC", sessionID1.getSenderLocationID());
-        assertEquals("wrong target", "TARGET", sessionID1.getTargetCompID());
-        assertEquals("wrong targetSub", "TARGETSUB", sessionID1.getTargetSubID());
-        assertEquals("wrong targetLoc", "TARGETLOC", sessionID1.getTargetLocationID());
-        assertEquals("wrong setting", false, session1.getResetOnLogout());
-        assertEquals("wrong setting", false, session1.getRefreshOnLogon());
-        assertEquals("wrong setting", false, session1.getCheckCompID());
+        try (Session session1 = provider.getSession(new SessionID("FIX.4.2", "SENDER", "SENDERSUB",
+                "SENDERLOC", "TARGET", "TARGETSUB", "TARGETLOC", null), null)) {
+            SessionID sessionID1 = session1.getSessionID();
+            assertEquals("wrong FIX version", "FIX.4.2", sessionID1.getBeginString());
+            assertEquals("wrong sender", "SENDER", sessionID1.getSenderCompID());
+            assertEquals("wrong senderSub", "SENDERSUB", sessionID1.getSenderSubID());
+            assertEquals("wrong senderLoc", "SENDERLOC", sessionID1.getSenderLocationID());
+            assertEquals("wrong target", "TARGET", sessionID1.getTargetCompID());
+            assertEquals("wrong targetSub", "TARGETSUB", sessionID1.getTargetSubID());
+            assertEquals("wrong targetLoc", "TARGETLOC", sessionID1.getTargetLocationID());
+            assertEquals("wrong setting", false, session1.getResetOnLogout());
+            assertEquals("wrong setting", false, session1.getRefreshOnLogon());
+            assertEquals("wrong setting", false, session1.getCheckCompID());
+        }
 
-        Session session2 = provider.getSession(new SessionID("FIX.4.4", "S1", "T"), null);
-        SessionID sessionID2 = session2.getSessionID();
-        assertEquals("wrong FIX version", "FIX.4.4", sessionID2.getBeginString());
-        assertEquals("wrong sender", "S1", sessionID2.getSenderCompID());
-        assertEquals("wrong target", "T", sessionID2.getTargetCompID());
-        assertEquals("wrong setting", true, session2.getResetOnLogout());
-        assertEquals("wrong setting", false, session2.getRefreshOnLogon());
-        assertEquals("wrong setting", true, session2.getCheckCompID());
+        try (Session session2 = provider.getSession(new SessionID("FIX.4.4", "S1", "T"), null)) {
+            SessionID sessionID2 = session2.getSessionID();
+            assertEquals("wrong FIX version", "FIX.4.4", sessionID2.getBeginString());
+            assertEquals("wrong sender", "S1", sessionID2.getSenderCompID());
+            assertEquals("wrong target", "T", sessionID2.getTargetCompID());
+            assertEquals("wrong setting", true, session2.getResetOnLogout());
+            assertEquals("wrong setting", false, session2.getRefreshOnLogon());
+            assertEquals("wrong setting", true, session2.getCheckCompID());
+        }
 
-        Session session3 = provider.getSession(new SessionID("FIX.4.4", "X", "Y"), null);
-        SessionID sessionID3 = session3.getSessionID();
-        assertEquals("wrong FIX version", "FIX.4.4", sessionID3.getBeginString());
-        assertEquals("wrong sender", "X", sessionID3.getSenderCompID());
-        assertEquals("wrong target", "Y", sessionID3.getTargetCompID());
-        assertEquals("wrong setting", false, session3.getResetOnLogout());
-        assertEquals("wrong setting", true, session3.getRefreshOnLogon());
-        assertEquals("wrong setting", true, session3.getCheckCompID());
+        try (Session session3 = provider.getSession(new SessionID("FIX.4.4", "X", "Y"), null)) {
+            SessionID sessionID3 = session3.getSessionID();
+            assertEquals("wrong FIX version", "FIX.4.4", sessionID3.getBeginString());
+            assertEquals("wrong sender", "X", sessionID3.getSenderCompID());
+            assertEquals("wrong target", "Y", sessionID3.getTargetCompID());
+            assertEquals("wrong setting", false, session3.getResetOnLogout());
+            assertEquals("wrong setting", true, session3.getRefreshOnLogon());
+            assertEquals("wrong setting", true, session3.getCheckCompID());
+        }
     }
 
     private void setUpSettings(SessionID templateID, String key, String value) {
@@ -137,9 +140,11 @@ public class DynamicAcceptorSessionProviderTest extends TestCase {
     public void testSimpleConstructor() throws Exception {
         provider = new DynamicAcceptorSessionProvider(settings, new SessionID("FIX.4.2", "ANY",
                 "ANY"), application, messageStoreFactory, logFactory, messageFactory);
-
         // Should actually throw an exception if it fails (see previous test)
-        assertNotNull(provider.getSession(new SessionID("FIX.4.2", "S", "T"), null));
+        try (Session session = provider.getSession(new SessionID("FIX.4.2", "S", "T"), null)) {
+            // Should actually throw an exception if it fails (see previous test)
+            assertNotNull(session);
+        }
     }
 
     /**
@@ -150,16 +155,18 @@ public class DynamicAcceptorSessionProviderTest extends TestCase {
 
         SessionID id1 = new SessionID("FIX.4.2", "me", "SENDERSUB",
                 "SENDERLOC", "you", "TARGETSUB", "TARGETLOC", null);
-        provider.getSession(id1, connector);
+        Session session = provider.getSession(id1, connector);
         assertEquals(1, connector.sessions.size());
         // try again with same sesionID - should still be 1
-        provider.getSession(id1, connector);
+        session = provider.getSession(id1, connector);
         assertEquals(1, connector.sessions.size());
+        session.close();
 
         SessionID id2 = new SessionID("FIX.4.2", "SENDER2", "SENDERSUB",
                 "SENDERLOC", "TARGET2", "TARGETSUB", "TARGETLOC", null);
-        provider.getSession(id2, connector);
+        Session session2 = provider.getSession(id2, connector);
         assertEquals(2, connector.sessions.size());
+        session2.close();
     }
 
     private static class MySessionConnector extends SessionConnector {

--- a/quickfixj-core/src/test/java/quickfix/mina/acceptor/DynamicAcceptorSessionProviderTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/acceptor/DynamicAcceptorSessionProviderTest.java
@@ -142,7 +142,6 @@ public class DynamicAcceptorSessionProviderTest extends TestCase {
                 "ANY"), application, messageStoreFactory, logFactory, messageFactory);
         // Should actually throw an exception if it fails (see previous test)
         try (Session session = provider.getSession(new SessionID("FIX.4.2", "S", "T"), null)) {
-            // Should actually throw an exception if it fails (see previous test)
             assertNotNull(session);
         }
     }


### PR DESCRIPTION
 - added logic to unregister Session to Session.close() method
 - changed some tests to use try-with-resources on Session and to close used Sessions in general
 - changed Connector implementations to clean up used Sessions on stop
 - changed AbstractSocketInitiator to clean up internal map of initiators on stop
 - added Initiator/Acceptor tests to ensure Sessions are unregistered on stop