### PR TITLE
QFJ-942: Observing hangs in dispose() on stop()

### DIFF
--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -383,7 +383,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xmx512m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true</argLine>
+                    <argLine>-Xmx512m -Djava.net.preferIPv4Stack=true</argLine>
                     <includes>
                         <include>**/*Test.java</include>
                         <include>${acceptance.tests}</include>

--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
-            <version>2.0.16</version>
+            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
-            <version>2.0.17</version>
+            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Wait for MINA 2.0.17 (#177 )
Prepared for next MINA release. See https://issues.apache.org/jira/browse/DIRMINA-1076

But there are also changes to do in QFJs Acceptor/Initiator implementations with regard to clean up of managed sessions of a connector.