### PR TITLE
QFJ-942: Observing hangs in dispose() on stop()

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/QueueTracker.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/QueueTracker.java
@@ -1,7 +1,6 @@
 package quickfix.mina;
 
 import java.util.Collection;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 interface QueueTracker<E> {

--- a/quickfixj-core/src/main/java/quickfix/mina/acceptor/AbstractSocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/acceptor/AbstractSocketAcceptor.java
@@ -248,7 +248,7 @@ public abstract class AbstractSocketAcceptor extends SessionConnector implements
             IoAcceptor ioAcceptor = ioIt.next();
             SocketAddress localAddress = ioAcceptor.getLocalAddress();
             ioAcceptor.unbind();
-            ioAcceptor.dispose(true);
+            closeManagedSessionsAndDispose(ioAcceptor, true, log);
             log.info("No longer accepting connections on {}", localAddress);
             ioIt.remove();
         }

--- a/quickfixj-core/src/test/java/quickfix/SocketInitiatorTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SocketInitiatorTest.java
@@ -376,10 +376,11 @@ public class SocketInitiatorTest {
                 Session clientSession = Session.lookupSession(clientSessionID);
                 assertLoggedOn(clientApplication, clientSession);
 
+                clientApplication.setUpLogoutExpectation();
                 initiator.stop();
-                assertFalse(clientSession.isLoggedOn());
+                assertLoggedOut(clientApplication, clientSession);
                 assertFalse(initiator.getSessions().contains(clientSessionID));
-                assertTrue(initiator.getSessions().size() == 0);
+                assertTrue(initiator.getSessions().isEmpty());
                 if (messageLog != null) {
                     messageLogLength = messageLog.length();
                     assertTrue(messageLog.length() > 0);
@@ -482,9 +483,6 @@ public class SocketInitiatorTest {
         }
 
         final boolean await = clientApplication.logonLatch.await(20, TimeUnit.SECONDS); 
-        if (!await) {
-            ReflectionUtil.dumpStackTraces();
-        }
         assertTrue("Expected logon did not occur", await); 
         assertTrue("client session not logged in", clientSession.isLoggedOn());
     }


### PR DESCRIPTION
 - introduced SessionConnector.closeManagedSessionsAndDispose which makes an effort to close all managed sessions and disposes the IoService
 - used new method in Acceptor, Initiator and TestConnection (used for acceptance tests)

NOTE: this also needs MINA 2.0.17 (#177 ), otherwise there still might be hangs when trying to dispose the IoService.
See https://issues.apache.org/jira/browse/DIRMINA-1076