### PR TITLE
improving flaky SSLCertificateTest

### DIFF
--- a/quickfixj-core/src/test/java/quickfix/mina/ssl/SSLCertificateTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/ssl/SSLCertificateTest.java
@@ -545,11 +545,11 @@ public class SSLCertificateTest {
 
         private SessionConnector prepareConnector(SessionSettings sessionSettings) throws ConfigError {
             SessionConnector sessionConnector = createConnector(sessionSettings);
-            sessionConnector.setIoFilterChainBuilder(chain -> chain.addLast("SSL exception handler", new IoFilterAdapter() {
+            sessionConnector.setIoFilterChainBuilder(chain -> chain.addFirst("Exception handler", new IoFilterAdapter() {
                 @Override
                 public void exceptionCaught(NextFilter nextFilter, IoSession session, Throwable cause)
                         throws Exception {
-                    LOGGER.info("SSL exception", cause);
+                    LOGGER.info("exceptionCaught", cause);
                     exceptionThrownLatch.countDown();
                     nextFilter.exceptionCaught(session, cause);
                 }


### PR DESCRIPTION
**SSLCertificateTest** fails quite often on Travis.

I was able to recreate **SSLCertificateTest** false positive failing tests locally using the same Travis CI Docker image snapshot as https://travis-ci.org/quickfix-j/quickfixj worker - **travisci/ci-garnet:packer-1512502276-986baf0**.

It seems that sometimes MINA produces exceptions other than SSLHandshakeException, where **org.apache.mina.filter.ssl.SslFilter#exceptionCaught(NextFilter nextFilter, IoSession session, Throwable cause)** can stop executing the filter chain (it actually has a special handling routine for **WriteToClosedSessionException**) , hence the exception is never captured by **SSLCertificateTest**.

_22:17:21.792 [NioProcessor-8] INFO  q.m.s.SSLCertificateTest$TestInitiator -
org.apache.mina.core.write.WriteToClosedSessionException: null
        at org.apache.mina.core.polling.AbstractPollingIoProcessor.clearWriteRequestQueue(AbstractPollingIoProcessor.java:633)
        at org.apache.mina.core.polling.AbstractPollingIoProcessor.removeNow(AbstractPollingIoProcessor.java:576)
        at org.apache.mina.core.polling.AbstractPollingIoProcessor.writeBuffer(AbstractPollingIoProcessor.java:923)
        at org.apache.mina.core.polling.AbstractPollingIoProcessor.flushNow(AbstractPollingIoProcessor.java:840)
        at org.apache.mina.core.polling.AbstractPollingIoProcessor.flush(AbstractPollingIoProcessor.java:767)
        at org.apache.mina.core.polling.AbstractPollingIoProcessor.access$700(AbstractPollingIoProcessor.java:68)
        at org.apache.mina.core.polling.AbstractPollingIoProcessor$Processor.run(AbstractPollingIoProcessor.java:1125)
        at org.apache.mina.util.NamePreservingRunnable.run(NamePreservingRunnable.java:64)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)_

The fix is to register test exception handler before MINA **org.apache.mina.filter.ssl.SslFilter**. I run the test over 20 times on mentioned  Docker image and I could not see the issue anymore (on average it took less than 3 consecutive runs to see false positive failure).