### PR TITLE
QFJ-932 - data dictionary validation format independent

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/DataDictionary.java
+++ b/quickfixj-core/src/main/java/quickfix/DataDictionary.java
@@ -812,6 +812,18 @@ public class DataDictionary {
         }
     }
 
+    private int countElementNodes(NodeList nodes) {
+        int elementNodesCount = 0;
+
+        for (int i = 0; i < nodes.getLength(); i++) {
+            if (nodes.item(i).getNodeType() == Node.ELEMENT_NODE) {
+                elementNodesCount++;
+            }
+        }
+
+        return elementNodesCount;
+    }
+
     private void read(String location) throws ConfigError {
         final InputStream inputStream = FileUtil.open(getClass(), location, URL, FILESYSTEM,
                 CONTEXT_RESOURCE, CLASSLOADER_RESOURCE);
@@ -885,7 +897,7 @@ public class DataDictionary {
         }
 
         final NodeList fieldNodes = fieldsNode.item(0).getChildNodes();
-        if (fieldNodes.getLength() == 0) {
+        if (countElementNodes(fieldNodes) == 0) {
             throw new ConfigError("No fields defined");
         }
 
@@ -964,7 +976,7 @@ public class DataDictionary {
         }
 
         final NodeList messageNodes = messagesNode.item(0).getChildNodes();
-        if (messageNodes.getLength() == 0) {
+        if (countElementNodes(messageNodes) == 0) {
             throw new ConfigError("No messages defined");
         }
 
@@ -1000,7 +1012,7 @@ public class DataDictionary {
     private void load(Document document, String msgtype, Node node) throws ConfigError {
         String name;
         final NodeList fieldNodes = node.getChildNodes();
-        if (fieldNodes.getLength() == 0) {
+        if (countElementNodes(fieldNodes) == 0) {
             throw new ConfigError("No fields found: msgType=" + msgtype);
         }
 

--- a/quickfixj-core/src/test/java/quickfix/DataDictionaryTest.java
+++ b/quickfixj-core/src/test/java/quickfix/DataDictionaryTest.java
@@ -229,6 +229,500 @@ public class DataDictionaryTest {
     }
 
     @Test
+    public void testMessageWithNoChildren40() throws Exception {
+        String data = "";
+        data += "<fix major=\"4\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\"/>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No fields found: msgType=msg");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testMessageWithTextElement40() throws Exception {
+        String data = "";
+        data += "<fix major=\"4\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No fields found: msgType=msg");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testMessagesWithNoChildren40() throws Exception {
+        String data = "";
+        data += "<fix major=\"4\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages/>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No messages defined");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testMessagesWithTextElement40() throws Exception {
+        String data = "";
+        data += "<fix major=\"4\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No messages defined");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testHeaderWithNoChildren40() throws Exception {
+        String data = "";
+        data += "<fix major=\"4\" minor=\"0\">";
+        data += "  <header/>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "      <field name=\"Account\" required=\"N\"/>";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No fields found: msgType=HEADER");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testHeaderWithTextElement40() throws Exception {
+        String data = "";
+        data += "<fix major=\"4\" minor=\"0\">";
+        data += "  <header>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "      <field name=\"Account\" required=\"N\"/>";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No fields found: msgType=HEADER");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testTrailerWithNoChildren40() throws Exception {
+        String data = "";
+        data += "<fix major=\"4\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer/>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "      <field name=\"Account\" required=\"N\"/>";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No fields found: msgType=TRAILER");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testTrailerWithTextElement40() throws Exception {
+        String data = "";
+        data += "<fix major=\"4\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "      <field name=\"Account\" required=\"N\"/>";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No fields found: msgType=TRAILER");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testFieldsWithNoChildren40() throws Exception {
+        String data = "";
+        data += "<fix major=\"4\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields/>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "      <field name=\"Account\" required=\"N\"/>";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No fields defined");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testFieldsWithTextElement40() throws Exception {
+        String data = "";
+        data += "<fix major=\"4\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "      <field name=\"Account\" required=\"N\"/>";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No fields defined");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testMessageWithNoChildren50() throws Exception {
+        String data = "";
+        data += "<fix major=\"5\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\"/>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No fields found: msgType=msg");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testMessageWithTextElement50() throws Exception {
+        String data = "";
+        data += "<fix major=\"5\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No fields found: msgType=msg");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testMessagesWithNoChildren50() throws Exception {
+        String data = "";
+        data += "<fix major=\"5\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages/>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No messages defined");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testMessagesWithTextElement50() throws Exception {
+        String data = "";
+        data += "<fix major=\"5\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No messages defined");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testHeaderWithNoChildren50() throws Exception {
+        String data = "";
+        data += "<fix major=\"5\" minor=\"0\">";
+        data += "  <header/>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "      <field name=\"Account\" required=\"N\"/>";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testHeaderWithTextElement50() throws Exception {
+        String data = "";
+        data += "<fix major=\"5\" minor=\"0\">";
+        data += "  <header>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "      <field name=\"Account\" required=\"N\"/>";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testTrailerWithNoChildren50() throws Exception {
+        String data = "";
+        data += "<fix major=\"5\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer/>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "      <field name=\"Account\" required=\"N\"/>";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testTrailerWithTextElement50() throws Exception {
+        String data = "";
+        data += "<fix major=\"5\" minor=\"0\">";
+        data += "  <header>";
+        data += "    <field name=\"BeginString\" required=\"Y\"/>";
+        data += "  </header>";
+        data += "  <trailer>";
+        data += "  </trailer>";
+        data += "  <fields>";
+        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
+        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
+        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "      <field name=\"Account\" required=\"N\"/>";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testFieldsWithNoChildren50() throws Exception {
+        String data = "";
+        data += "<fix major=\"5\" minor=\"0\">";
+        data += "  <header/>";
+        data += "  <trailer/>";
+        data += "  <fields/>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "      <field name=\"Account\" required=\"N\"/>";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No fields defined");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
+    public void testFieldsWithTextElement50() throws Exception {
+        String data = "";
+        data += "<fix major=\"5\" minor=\"0\">";
+        data += "  <header/>";
+        data += "  <trailer/>";
+        data += "  <fields>";
+        data += "  </fields>";
+        data += "  <messages>";
+        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
+        data += "      <field name=\"Account\" required=\"N\"/>";
+        data += "    </message>";
+        data += "  </messages>";
+        data += "</fix>";
+
+        expectedException.expect(ConfigError.class);
+        expectedException.expectMessage("No fields defined");
+
+        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
+    }
+
+    @Test
     public void testHeaderGroupField() throws Exception {
         DataDictionary dd = getDictionary();
         assertTrue(dd.isHeaderGroup(NoHops.FIELD));


### PR DESCRIPTION
Data dictionary validation is format independent now. The following tags are not allowed to be empty (with exception to \<header/> and \<trailer/> for FIX version 5.0 and higher).

- \<header/>
- \<trailer/>
- \<fields/>
- \<message/>
- \<messages/>