### PR TITLE
Update getString signature in SessionSettings

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/SessionSettings.java
+++ b/quickfixj-core/src/main/java/quickfix/SessionSettings.java
@@ -128,7 +128,6 @@ public class SessionSettings {
      * @param key
      * @return the default string value
      * @throws ConfigError
-     * @throws FieldConvertError
      */
     public String getString(String key) throws ConfigError {
         return getString(DEFAULT_SESSION_ID, key);
@@ -141,7 +140,6 @@ public class SessionSettings {
      * @param key the settings key
      * @return the string value for the setting
      * @throws ConfigError configuration error, probably a missing setting.
-     * @throws FieldConvertError error during field type conversion.
      */
     public String getString(SessionID sessionID, String key) throws ConfigError {
         final String value = interpolate(getSessionProperties(sessionID).getProperty(key));

--- a/quickfixj-core/src/main/java/quickfix/SessionSettings.java
+++ b/quickfixj-core/src/main/java/quickfix/SessionSettings.java
@@ -130,7 +130,7 @@ public class SessionSettings {
      * @throws ConfigError
      * @throws FieldConvertError
      */
-    public String getString(String key) throws ConfigError, FieldConvertError {
+    public String getString(String key) throws ConfigError {
         return getString(DEFAULT_SESSION_ID, key);
     }
 
@@ -143,7 +143,7 @@ public class SessionSettings {
      * @throws ConfigError configuration error, probably a missing setting.
      * @throws FieldConvertError error during field type conversion.
      */
-    public String getString(SessionID sessionID, String key) throws ConfigError, FieldConvertError {
+    public String getString(SessionID sessionID, String key) throws ConfigError {
         final String value = interpolate(getSessionProperties(sessionID).getProperty(key));
         if (value == null) {
             throw new ConfigError(key + " not defined");

--- a/quickfixj-core/src/main/java/quickfix/mina/ssl/SSLSupport.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/ssl/SSLSupport.java
@@ -20,7 +20,6 @@
 package quickfix.mina.ssl;
 
 import quickfix.ConfigError;
-import quickfix.FieldConvertError;
 import quickfix.SessionID;
 import quickfix.SessionSettings;
 
@@ -89,7 +88,7 @@ public class SSLSupport {
     public static String[] getSupportedProtocols(SSLContext sslContext) {
         try {
             return ((SSLSocket) sslContext.getSocketFactory().createSocket()).getSupportedProtocols();
-        } catch (IOException e) {
+        } catch (IOException ignored) {
         }
 
         return null;
@@ -121,7 +120,7 @@ public class SSLSupport {
         if (sessionSettings.isSetting(sessionID, key)) {
             try {
                 propertyValue = sessionSettings.getString(sessionID, key);
-            } catch (ConfigError | FieldConvertError ignored) {
+            } catch (ConfigError ignored) {
             }
         }
         return propertyValue;


### PR DESCRIPTION
Hi,

`FieldConvertError` is not being thrown in `getString` method. 

Regards,
Martin