### PR TITLE
Correct handling of SystemTimeSource in tests

### DIFF
--- a/quickfixj-core/src/test/java/quickfix/FileLogTest.java
+++ b/quickfixj-core/src/test/java/quickfix/FileLogTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Date;
+import org.junit.After;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +38,11 @@ public class FileLogTest {
     @Before
     public void setUp() throws Exception {
         SystemTime.setTimeSource(new MockSystemTimeSource(System.currentTimeMillis()));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        SystemTime.setTimeSource(null);
     }
 
     @Test

--- a/quickfixj-core/src/test/java/quickfix/LogUtilTest.java
+++ b/quickfixj-core/src/test/java/quickfix/LogUtilTest.java
@@ -19,20 +19,28 @@
 
 package quickfix;
 
-import junit.framework.TestCase;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Date;
+import org.junit.After;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
 
-public class LogUtilTest extends TestCase {
+public class LogUtilTest {
 
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         SystemTime.setTimeSource(new MockSystemTimeSource(System.currentTimeMillis()));
     }
 
+    @After
+    public void tearDown() throws Exception {
+        SystemTime.setTimeSource(null);
+    }
+    
+    @Test
     public void testLogThrowable() throws ConfigError, FieldConvertError {
         ByteArrayOutputStream data = new ByteArrayOutputStream();
         LogFactory mockLogFactory = createLogFactory(data);

--- a/quickfixj-core/src/test/java/quickfix/test/acceptance/AcceptanceTestSuite.java
+++ b/quickfixj-core/src/test/java/quickfix/test/acceptance/AcceptanceTestSuite.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import quickfix.SystemTime;
 
 public class AcceptanceTestSuite extends TestSuite {
     private static final String ATEST_TIMEOUT_KEY = "atest.timeout";
@@ -153,6 +154,8 @@ public class AcceptanceTestSuite extends TestSuite {
     public AcceptanceTestSuite(String testDirectory, boolean multithreaded, Map<Object, Object> overridenProperties) {
         this.multithreaded = multithreaded;
         this.overridenProperties = overridenProperties;
+        SystemTime.setTimeSource(null);
+
         String name = testDirectory.substring(testDirectory.lastIndexOf(File.separatorChar) + 1);
         this.setName(name + (multithreaded ? "-threaded" : ""));
         Long timeout = Long.getLong(ATEST_TIMEOUT_KEY);


### PR DESCRIPTION
 - some unit tests did not reset it which lead to errors depending on test order
 - e.g. ResynchTest and AcceptanceTests were failing constantly on my machine because LogUtilTest did not reset
   the SystemTimeSource and as a result the Session did not send out any heartbeats