### PR TITLE
[Tom/Andrey] remove duplicate field definitions in fix44 xml spec

### DIFF
--- a/quickfixj-messages/quickfixj-messages-fix44/src/main/resources/FIX44.modified.xml
+++ b/quickfixj-messages/quickfixj-messages-fix44/src/main/resources/FIX44.modified.xml
@@ -2393,7 +2393,6 @@
       <field name="AllocSettlCurrency" required="N"/>
       <field name="SettlCurrFxRate" required="N"/>
       <field name="SettlCurrFxRateCalc" required="N"/>
-      <field name="AccruedInterestAmt" required="N"/>
       <field name="AllocAccruedInterestAmt" required="N"/>
       <field name="AllocInterestAtMaturity" required="N"/>
       <field name="SettlInstMode" required="N"/>
@@ -2726,7 +2725,6 @@
     <field name="Text" required="N"/>
     <field name="EncodedTextLen" required="N"/>
     <field name="EncodedText" required="N"/>
-    <field name="SettlInstSource" required="N"/>
     <field name="ClOrdID" required="N"/>
     <field name="TransactTime" required="Y"/>
     <group name="NoSettlInst" required="N">

--- a/quickfixj-messages/quickfixj-messages-fix44/src/main/resources/FIX44.xml
+++ b/quickfixj-messages/quickfixj-messages-fix44/src/main/resources/FIX44.xml
@@ -2393,7 +2393,6 @@
       <field name="AllocSettlCurrency" required="N"/>
       <field name="SettlCurrFxRate" required="N"/>
       <field name="SettlCurrFxRateCalc" required="N"/>
-      <field name="AccruedInterestAmt" required="N"/>
       <field name="AllocAccruedInterestAmt" required="N"/>
       <field name="AllocInterestAtMaturity" required="N"/>
       <field name="SettlInstMode" required="N"/>
@@ -2726,7 +2725,6 @@
     <field name="Text" required="N"/>
     <field name="EncodedTextLen" required="N"/>
     <field name="EncodedText" required="N"/>
-    <field name="SettlInstSource" required="N"/>
     <field name="ClOrdID" required="N"/>
     <field name="TransactTime" required="Y"/>
     <group name="NoSettlInst" required="N">


### PR DESCRIPTION
 AllocationInstruction and SettlementInstructions had duplicate fields
 declared in their FIX schemas (AccruedInterestAmt and SettlInstSource)
 respectively. We have removed those declarations that
 were incorrect according to the FIX protocol