### PR TITLE
Minor cleanup in AbstractIoHandler.sessionClosed()

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/AbstractIoHandler.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/AbstractIoHandler.java
@@ -114,8 +114,8 @@ public abstract class AbstractIoHandler extends IoHandlerAdapter {
         } catch (Exception e) {
             throw e;
         } finally {
-            ioSession.closeNow();
             ioSession.removeAttribute(SessionConnector.QF_SESSION);
+            ioSession.closeNow();
         }
     }
 

--- a/quickfixj-core/src/main/java/quickfix/mina/AbstractIoHandler.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/AbstractIoHandler.java
@@ -110,12 +110,12 @@ public abstract class AbstractIoHandler extends IoHandlerAdapter {
             Session quickFixSession = findQFSession(ioSession);
             if (quickFixSession != null) {
                 eventHandlingStrategy.onMessage(quickFixSession, EventHandlingStrategy.END_OF_STREAM);
-                ioSession.removeAttribute(SessionConnector.QF_SESSION);
             }
-            ioSession.closeNow();
         } catch (Exception e) {
-            ioSession.closeNow();
             throw e;
+        } finally {
+            ioSession.closeNow();
+            ioSession.removeAttribute(SessionConnector.QF_SESSION);
         }
     }
 


### PR DESCRIPTION
Make sure QF_SESSION attribute gets removed in any case. SingleThreadedEventHandlingStrategy.onMessage() might throw an Exception.