### PR TITLE
Add profile skipBundlePlugin to speed up build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,25 @@
 
 	<profiles>
 		<profile>
+			<id>skipBundlePlugin</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+			        <plugin>
+				        <groupId>org.apache.felix</groupId>
+				        <artifactId>maven-bundle-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase/>
+                            </execution>
+                        </executions>
+			        </plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>release</id>
 			<activation>
 				<activeByDefault>false</activeByDefault>


### PR DESCRIPTION
`mvn package -PskipBundlePlugin` can be used to speed up the build when no bundle MANIFEST is needed, i.e. when you do not want to use the resulting JARs in an OSGi environment.