### PR TITLE
QFJ-950 reject garbled messages

### DIFF
--- a/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
+++ b/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
@@ -422,7 +422,7 @@
   </TR>
   <TR ALIGN="left" VALIGN="middle">
     <TD> <I>RejectGarbledMessage</I> </TD>
-    <TD> If RejectGarbledMessage is set to Y, garbled messages will be rejected instead of ignored.<br>
+    <TD> If RejectGarbledMessage is set to Y, garbled messages will be rejected (with a generic error message in 58/Text field) instead of ignored.<br>
         This is only working for messages that pass the FIX decoder and reach the engine.<br>
         Messages that cannot be considered a real FIX message (i.e. not starting with 8=FIX or not ending with 10=xxx) will be ignored in any case.</TD>
     <TD> Y<br>N</TD>

--- a/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
+++ b/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
@@ -76,6 +76,7 @@
     <LI><A HREF="#Storage">Storage</A></LI>
     <LI><A HREF="#Logging">Logging</A></LI>
     <LI><A HREF="#Miscellaneous">Miscellaneous</A></LI>
+    <LI><A HREF="#Invalid vs Garbled Messages">Invalid vs Garbled Messages</A></LI>
     <LI><A HREF="#Sample Settings File">Sample Settings File</A></LI>
   </UL>
   <TABLE class="settings" cellspacing="0">
@@ -424,13 +425,17 @@
     <TD> <I>RejectGarbledMessage</I> </TD>
     <TD> If RejectGarbledMessage is set to Y, garbled messages will be rejected (with a generic error message in 58/Text field) instead of ignored.<br>
         This is only working for messages that pass the FIX decoder and reach the engine.<br>
-        Messages that cannot be considered a real FIX message (i.e. not starting with 8=FIX or not ending with 10=xxx) will be ignored in any case.</TD>
+        Messages that cannot be considered a real FIX message (i.e. not starting with 8=FIX or not ending with 10=xxx) will be ignored in any case.<br>
+        See <A HREF="#Invalid vs Garbled Messages">Invalid vs Garbled Messages</A> for further explanation.
+    </TD>
     <TD> Y<br>N</TD>
     <TD> N </TD>
   </TR>
   <TR ALIGN="left" VALIGN="middle">
     <TD> <I>RejectInvalidMessage</I> </TD>
-    <TD> If RejectInvalidMessage is set to N, only a warning will be logged on reception of message that fails data dictionary validation.</TD>
+    <TD> If RejectInvalidMessage is set to N, only a warning will be logged on reception of message that fails data dictionary validation.<br>
+         See <A HREF="#Invalid vs Garbled Messages">Invalid vs Garbled Messages</A> for further explanation.
+    </TD>
     <TD> Y<br>N</TD>
     <TD> Y </TD>
   </TR>
@@ -1258,6 +1263,82 @@
   </TR>
   </tbody>
   </TABLE>
+
+  <H3><A NAME="Invalid vs Garbled Messages">Rejecting Invalid vs Garbled Messages</A></H3>
+  
+  <p>
+      There are mainly two settings that influence QFJ's rejection behaviour:
+  </p>
+  <ul>
+      <li>RejectInvalidMessage</li>
+      <li>RejectGarbledMessage</li>
+  </ul>
+
+  <p>
+      While the first applies to messages that fail data dictionary validation,
+      the latter applies to messages that fail basic validity checks on the FIX protocol level.
+  </p>
+  
+  <H4>Setting RejectInvalidMessage</H4>
+  
+  <p>
+      If RejectInvalidMessage is set to
+  </p>
+  <ul>
+      <li>Y, the problematic message will be rejected (this is the default setting).</li>
+      <li>N, only a warning will be logged on reception of a message that fails data dictionary validation.
+          The message will then be handed over to the application level code.</li>
+  </ul>
+
+  <H4>Setting RejectGarbledMessage</H4>
+
+  <p>
+      If RejectGarbledMessage is set to
+  </p>
+  <ul>
+      <li>Y, garbled messages will be rejected (with a generic error message in 58/Text field) instead of ignored.</li>
+      <li>N, garbled messages will be ignored and the sequence number not be incremented (this is the default setting).</li>
+  </ul>
+
+  <H5>Information on garbled messages</H5>
+  <p>
+      In FIX it is legal to ignore a message under certain circumstances. Since FIX is an optimistic protocol
+      it expects that some errors are transient and will correct themselves with the next message transmission.
+      Therefore the sequence number is not incremented and a resend request is issued on the next received
+      message that has a higher sequence number than expected.
+  </p>
+
+  <p>
+      In the case that the error is not transient, the default behaviour is not optimal because not consuming a
+      message sequence number can lead to follow-up problems since QFJ will wait for the message to be resent
+      and queue all subsequent messages until the resend request has been satisfied (i.e. infinite resend loop).
+  </p>
+
+  What constitutes a garbled message (taken from the FIX protocol specification):
+  <blockquote>
+      <li>BeginString (tag #8) is not the first tag in a message or is not of the format 8=FIXT.n.m.</li>
+      <li>BodyLength (tag #9) is not the second tag in a message or does not contain the correct byte count.</li>
+      <li>MsgType (tag #35) is not the third tag in a message.</li>
+      <li>Checksum (tag #10) is not the last tag or contains an incorrect value.</li>
+
+      If the MsgSeqNum(tag #34) is missing a logout message should be sent terminating the FIX Connection, as this
+      indicates a serious application error that is likely only circumvented by software modification.
+  </blockquote>
+
+  <p>
+      You have the possibility to adapt QFJ's behaviour for some of the cases mentioned above.<br>
+  </p>
+  <li>If an incoming message does neither start with the BeginString tag nor does it end with the Checksum tag, the message
+      cannot be passed to the session and will be discarded by the FIX decoder right away.</li>
+  <li>Examples where the message will be rejected instead of ignored when RejectGarbledMessage=Y:
+      <ul>
+          <li>incorrect checksum</li>
+          <li>repeating group count field contains no valid integer</li>
+          <li>no SOH delimiter found in field</li>
+          <li>missing MsgType</li>
+          <li>invalid tags, e.g. 49foo=bar</li>
+      </ul>
+  </li>
 
   <H3><A NAME="Sample Settings File">Sample Settings File</A></H3>
 

--- a/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
+++ b/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
@@ -421,6 +421,14 @@
 
   </TR>
   <TR ALIGN="left" VALIGN="middle">
+    <TD> <I>RejectGarbledMessage</I> </TD>
+    <TD> If RejectGarbledMessage is set to Y, garbled messages will be rejected instead of ignored.<br>
+        This is only working for messages that pass the FIX decoder and reach the engine.<br>
+        Messages that cannot be considered a real FIX message (i.e. not starting with 8=FIX or not ending with 10=xxx) will be ignored in any case.</TD>
+    <TD> Y<br>N</TD>
+    <TD> N </TD>
+  </TR>
+  <TR ALIGN="left" VALIGN="middle">
     <TD> <I>RejectInvalidMessage</I> </TD>
     <TD> If RejectInvalidMessage is set to N, only a warning will be logged on reception of message that fails data dictionary validation.</TD>
     <TD> Y<br>N</TD>

--- a/quickfixj-core/src/main/java/quickfix/DefaultSessionFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/DefaultSessionFactory.java
@@ -81,6 +81,9 @@ public class DefaultSessionFactory implements SessionFactory {
         try {
             String connectionType = null;
 
+            final boolean rejectGarbledMessage = getSetting(settings, sessionID,
+                    Session.SETTING_REJECT_GARBLED_MESSAGE, false);
+
             final boolean rejectInvalidMessage = getSetting(settings, sessionID,
                     Session.SETTING_REJECT_INVALID_MESSAGE, true);
 
@@ -209,7 +212,7 @@ public class DefaultSessionFactory implements SessionFactory {
                     resetOnLogon, resetOnLogout, resetOnDisconnect, refreshAtLogon, checkCompID,
                     redundantResentRequestAllowed, persistMessages, useClosedIntervalForResend,
                     testRequestDelayMultiplier, senderDefaultApplVerID, validateSequenceNumbers,
-                    logonIntervals, resetOnError, disconnectOnError, disableHeartBeatCheck,
+                    logonIntervals, resetOnError, disconnectOnError, disableHeartBeatCheck, rejectGarbledMessage,
                     rejectInvalidMessage, rejectMessageOnUnhandledException, requiresOrigSendingTime,
                     forceResendWhenCorruptedStore, allowedRemoteAddresses, validateIncomingMessage,
                     resendRequestChunkSize, enableNextExpectedMsgSeqNum, enableLastMsgSeqNumProcessed);

--- a/quickfixj-core/src/main/java/quickfix/InvalidMessage.java
+++ b/quickfixj-core/src/main/java/quickfix/InvalidMessage.java
@@ -25,16 +25,42 @@ package quickfix;
  */
 public class InvalidMessage extends Exception {
 
+    Message fixMessage;
+
     public InvalidMessage() {
         super();
+    }
+
+    public InvalidMessage(Message fixMessage) {
+        super();
+        setGarbledFixMessage(fixMessage);
     }
 
     public InvalidMessage(String message) {
         super(message);
     }
+
+    public InvalidMessage(String message, Message fixMessage) {
+        super(message);
+        setGarbledFixMessage(fixMessage);
+    }
     
     public InvalidMessage(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    public InvalidMessage(String message, Throwable cause, Message fixMessage) {
+        super(message, cause);
+        setGarbledFixMessage(fixMessage);
+    }
+    
+    public Message getFixMessage() {
+        return fixMessage;
+    }
+    
+    private void setGarbledFixMessage(Message fixMessage) {
+        this.fixMessage = fixMessage;
+        this.fixMessage.setGarbled(true);
     }
 
 }

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -958,7 +958,7 @@ public class Session implements Closeable {
                         + "' does not match the session version '" + sessionBeginString + "'");
             }
 
-            if (msgType.equals(MsgType.LOGON)) {
+            if (MsgType.LOGON.equals(msgType)) {
                 if (sessionID.isFIXT()) {
                     targetDefaultApplVerID.set(new ApplVerID(message
                             .getString(DefaultApplVerID.FIELD)));
@@ -1064,7 +1064,7 @@ public class Session implements Closeable {
                 generateBusinessReject(message,
                         BusinessRejectReason.CONDITIONALLY_REQUIRED_FIELD_MISSING, e.field);
             } else {
-                if (msgType.equals(MsgType.LOGON)) {
+                if (MsgType.LOGON.equals(msgType)) {
                     getLog().onErrorEvent("Required field missing from logon");
                     disconnect("Required field missing from logon", true);
                 } else {
@@ -1108,7 +1108,7 @@ public class Session implements Closeable {
             if (logErrorAndDisconnectIfRequired(e, message)) {
                 return;
             }
-            if (msgType.equals(MsgType.LOGOUT)) {
+            if (MsgType.LOGOUT.equals(msgType)) {
                 nextLogout(message);
             } else {
                 generateLogout("Incorrect BeginString: " + e.getMessage());
@@ -1136,7 +1136,7 @@ public class Session implements Closeable {
                     generateBusinessReject(message, BusinessRejectReason.APPLICATION_NOT_AVAILABLE,
                             0);
                 } else {
-                    if (msgType.equals(MsgType.LOGON)) {
+                    if (MsgType.LOGON.equals(msgType)) {
                         disconnect("Problem processing Logon message", true);
                     } else {
                         generateReject(message, SessionRejectReason.OTHER, 0);
@@ -1225,7 +1225,7 @@ public class Session implements Closeable {
     }
 
     private boolean isStateRefreshNeeded(String msgType) {
-        return refreshMessageStoreAtLogon && !state.isInitiator() && msgType.equals(MsgType.LOGON);
+        return refreshMessageStoreAtLogon && !state.isInitiator() && MsgType.LOGON.equals(msgType));
     }
 
     private void nextReject(Message reject) throws FieldNotFound, RejectLogon, IncorrectDataFormat,
@@ -1517,7 +1517,7 @@ public class Session implements Closeable {
         reject.setString(RefSeqNum.FIELD, msgSeqNum);
 
         // QFJ-557: Only advance the sequence number if we are at the expected number.
-        if (!msgType.equals(MsgType.LOGON) && !msgType.equals(MsgType.SEQUENCE_RESET)
+        if (!MsgType.LOGON.equals(msgType) && !MsgType.SEQUENCE_RESET.equals(msgType))
                 && Integer.parseInt(msgSeqNum) == getExpectedTargetNum()) {
             state.incrNextTargetMsgSeqNum();
         }
@@ -1570,7 +1570,7 @@ public class Session implements Closeable {
         }
 
         if (beginString.compareTo(FixVersions.BEGINSTRING_FIX42) >= 0) {
-            if (!msgType.equals("")) {
+            if (!"".equals(msgType)) {
                 reject.setString(RefMsgType.FIELD, msgType);
             }
             if (beginString.compareTo(FixVersions.BEGINSTRING_FIX44) > 0) {
@@ -1597,7 +1597,7 @@ public class Session implements Closeable {
         state.lockTargetMsgSeqNum();
         try {
             // QFJ-557: Only advance the sequence number if we are at the expected number.
-            if (!msgType.equals(MsgType.LOGON) && !msgType.equals(MsgType.SEQUENCE_RESET)
+            if (!MsgType.LOGON.equals(msgType) && !MsgType.SEQUENCE_RESET.equals(msgType))
                     && msgSeqNum == getExpectedTargetNum()) {
                 state.incrNextTargetMsgSeqNum();
             }
@@ -1838,12 +1838,12 @@ public class Session implements Closeable {
     }
 
     private synchronized boolean validLogonState(String msgType) {
-        return msgType.equals(MsgType.LOGON) && state.isResetSent() || state.isResetReceived() ||
-                msgType.equals(MsgType.LOGON) && !state.isLogonReceived() ||
-                !msgType.equals(MsgType.LOGON) && state.isLogonReceived() ||
-                msgType.equals(MsgType.LOGOUT) && state.isLogonSent() ||
-                !msgType.equals(MsgType.LOGOUT) && state.isLogoutSent() ||
-                msgType.equals(MsgType.SEQUENCE_RESET) || msgType.equals(MsgType.REJECT);
+        return MsgType.LOGON.equals(msgType) && state.isResetSent() || state.isResetReceived() ||
+                MsgType.LOGON.equals(msgType) && !state.isLogonReceived() ||
+                !MsgType.LOGON.equals(msgType) && state.isLogonReceived() ||
+                MsgType.LOGOUT.equals(msgType) && state.isLogonSent() ||
+                !MsgType.LOGOUT.equals(msgType) && state.isLogoutSent() ||
+                MsgType.SEQUENCE_RESET.equals(msgType) || MsgType.REJECT.equals(msgType);
     }
 
     private boolean verify(Message message) throws RejectLogon, FieldNotFound, IncorrectDataFormat,
@@ -2358,7 +2358,7 @@ public class Session implements Closeable {
             getLog().onEvent("Processing queued message: " + num);
 
             final String msgType = msg.getHeader().getString(MsgType.FIELD);
-            if (msgType.equals(MsgType.LOGON) || msgType.equals(MsgType.RESEND_REQUEST)) {
+            if (MsgType.LOGON.equals(msgType) || MsgType.RESEND_REQUEST.equals(msgType)) {
                 // Logon and ResendRequest processing has already been done, so we just need to increment the target seqnum.
                 state.incrNextTargetMsgSeqNum();
             } else {
@@ -2448,7 +2448,7 @@ public class Session implements Closeable {
         final Message.Header header = msg.getHeader();
         final String msgType = header.getString(MsgType.FIELD);
 
-        if (!msgType.equals(MsgType.SEQUENCE_RESET)) {
+        if (!MsgType.SEQUENCE_RESET.equals(msgType)) {
             if (header.isSetField(OrigSendingTime.FIELD)) {
                 final LocalDateTime origSendingTime = header.getUtcTimeStamp(OrigSendingTime.FIELD);
                 final LocalDateTime sendingTime = header.getUtcTimeStamp(SendingTime.FIELD);
@@ -2546,7 +2546,7 @@ public class Session implements Closeable {
                     logApplicationException("toAdmin()", t);
                 }
 
-                if (msgType.equals(MsgType.LOGON)) {
+                if (MsgType.LOGON.equals(msgType)) {
                     if (!state.isResetReceived()) {
                         boolean resetSeqNumFlag = false;
                         if (message.isSetField(ResetSeqNumFlag.FIELD)) {
@@ -2561,9 +2561,9 @@ public class Session implements Closeable {
                 }
 
                 messageString = message.toString();
-                if (msgType.equals(MsgType.LOGON) || msgType.equals(MsgType.LOGOUT)
-                        || msgType.equals(MsgType.RESEND_REQUEST)
-                        || msgType.equals(MsgType.SEQUENCE_RESET) || isLoggedOn()) {
+                if (MsgType.LOGON.equals(msgType) || MsgType.LOGOUT.equals(msgType)
+                        || MsgType.RESEND_REQUEST.equals(msgType)
+                        || MsgType.SEQUENCE_RESET.equals(msgType) || isLoggedOn()) {
                     result = send(messageString);
                 }
             } else {

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -333,6 +333,15 @@ public class Session implements Closeable {
      */
     public static final String SETTING_ENABLE_NEXT_EXPECTED_MSG_SEQ_NUM = "EnableNextExpectedMsgSeqNum";
 
+    /**
+     * Reject garbled messages instead of ignoring them.
+     * This is only working for messages that pass the FIX decoder and reach the engine.
+     * Messages that cannot be considered a real FIX message (i.e. not starting with
+     * 8=FIX or not ending with 10=xxx) will be ignored in any case.
+     * Default is "N".
+     */
+    public static final String SETTING_REJECT_GARBLED_MESSAGE = "RejectGarbledMessage";
+
     public static final String SETTING_REJECT_INVALID_MESSAGE = "RejectInvalidMessage";
 
     public static final String SETTING_REJECT_MESSAGE_ON_UNHANDLED_EXCEPTION = "RejectMessageOnUnhandledException";
@@ -389,6 +398,7 @@ public class Session implements Closeable {
     private final boolean checkCompID;
     private final boolean useClosedRangeForResend;
     private boolean disableHeartBeatCheck = false;
+    private boolean rejectGarbledMessage = false;
     private boolean rejectInvalidMessage = false;
     private boolean rejectMessageOnUnhandledException = false;
     private boolean requiresOrigSendingTime = false;
@@ -434,7 +444,7 @@ public class Session implements Closeable {
                 logFactory, messageFactory, heartbeatInterval, true, DEFAULT_MAX_LATENCY, UtcTimestampPrecision.MILLIS,
                 false, false, false, false, true, false, true, false,
                 DEFAULT_TEST_REQUEST_DELAY_MULTIPLIER, null, true, new int[] { 5 }, false, false,
-                false, true, false, true, false, null, true, DEFAULT_RESEND_RANGE_CHUNK_SIZE, false, false);
+                false, false, true, false, true, false, null, true, DEFAULT_RESEND_RANGE_CHUNK_SIZE, false, false);
     }
 
     Session(Application application, MessageStoreFactory messageStoreFactory, SessionID sessionID,
@@ -447,7 +457,7 @@ public class Session implements Closeable {
             boolean useClosedRangeForResend, double testRequestDelayMultiplier,
             DefaultApplVerID senderDefaultApplVerID, boolean validateSequenceNumbers,
             int[] logonIntervals, boolean resetOnError, boolean disconnectOnError,
-            boolean disableHeartBeatCheck, boolean rejectInvalidMessage,
+            boolean disableHeartBeatCheck, boolean rejectGarbledMessage, boolean rejectInvalidMessage,
             boolean rejectMessageOnUnhandledException, boolean requiresOrigSendingTime,
             boolean forceResendWhenCorruptedStore, Set<InetAddress> allowedRemoteAddresses,
             boolean validateIncomingMessage, int resendRequestChunkSize,
@@ -473,6 +483,7 @@ public class Session implements Closeable {
         this.resetOnError = resetOnError;
         this.disconnectOnError = disconnectOnError;
         this.disableHeartBeatCheck = disableHeartBeatCheck;
+        this.rejectGarbledMessage = rejectGarbledMessage;
         this.rejectInvalidMessage = rejectInvalidMessage;
         this.rejectMessageOnUnhandledException = rejectMessageOnUnhandledException;
         this.requiresOrigSendingTime = requiresOrigSendingTime;
@@ -2783,6 +2794,10 @@ public class Session implements Closeable {
         return state.isLogoutTimedOut();
     }
 
+    public boolean isRejectGarbledMessage() {
+        return rejectGarbledMessage;
+    }
+
     public boolean isUsingDataDictionary() {
         return dataDictionaryProvider != null;
     }
@@ -2890,6 +2905,10 @@ public class Session implements Closeable {
 
     public void setIgnoreHeartBeatFailure(boolean ignoreHeartBeatFailure) {
         disableHeartBeatCheck = ignoreHeartBeatFailure;
+    }
+
+    public void setRejectGarbledMessage(boolean rejectGarbledMessage) {
+        this.rejectGarbledMessage = rejectGarbledMessage;
     }
 
     public void setRejectInvalidMessage(boolean rejectInvalidMessage) {

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -1076,6 +1076,8 @@ public class Session implements Closeable {
                ignore the message and let the problem correct itself (optimistic approach).
                Target sequence number is not incremented, so it will trigger a ResendRequest
                on the next message that is received. */
+            
+            // TODO configure
             getLog().onErrorEvent("Skipping invalid message: " + e + ": " + getMessageToLog(message));
             if (resetOrDisconnectIfRequired(message)) {
                 return;
@@ -1225,7 +1227,7 @@ public class Session implements Closeable {
     }
 
     private boolean isStateRefreshNeeded(String msgType) {
-        return refreshMessageStoreAtLogon && !state.isInitiator() && MsgType.LOGON.equals(msgType));
+        return refreshMessageStoreAtLogon && !state.isInitiator() && MsgType.LOGON.equals(msgType);
     }
 
     private void nextReject(Message reject) throws FieldNotFound, RejectLogon, IncorrectDataFormat,
@@ -1517,7 +1519,7 @@ public class Session implements Closeable {
         reject.setString(RefSeqNum.FIELD, msgSeqNum);
 
         // QFJ-557: Only advance the sequence number if we are at the expected number.
-        if (!MsgType.LOGON.equals(msgType) && !MsgType.SEQUENCE_RESET.equals(msgType))
+        if (!MsgType.LOGON.equals(msgType) && !MsgType.SEQUENCE_RESET.equals(msgType)
                 && Integer.parseInt(msgSeqNum) == getExpectedTargetNum()) {
             state.incrNextTargetMsgSeqNum();
         }
@@ -1597,7 +1599,7 @@ public class Session implements Closeable {
         state.lockTargetMsgSeqNum();
         try {
             // QFJ-557: Only advance the sequence number if we are at the expected number.
-            if (!MsgType.LOGON.equals(msgType) && !MsgType.SEQUENCE_RESET.equals(msgType))
+            if (!MsgType.LOGON.equals(msgType) && !MsgType.SEQUENCE_RESET.equals(msgType)
                     && msgSeqNum == getExpectedTargetNum()) {
                 state.incrNextTargetMsgSeqNum();
             }

--- a/quickfixj-core/src/test/java/quickfix/SessionFactoryTestSupport.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionFactoryTestSupport.java
@@ -115,7 +115,7 @@ public class SessionFactoryTestSupport implements SessionFactory {
                     timestampPrecision, resetOnLogon, resetOnLogout, resetOnDisconnect, refreshMessageStoreAtLogon,
                     checkCompID, redundantResentRequestsAllowed, persistMessages, useClosedRangeForResend,
                     testRequestDelayMultiplier, senderDefaultApplVerID, validateSequenceNumbers, logonIntervals,
-                    resetOnError, disconnectOnError, disableHeartBeatCheck, rejectInvalidMessage,
+                    resetOnError, disconnectOnError, disableHeartBeatCheck, false, rejectInvalidMessage,
                     rejectMessageOnUnhandledException, requiresOrigSendingTime, forceResendWhenCorruptedStore,
                     allowedRemoteAddresses, validateIncomingMessage, resendRequestChunkSize, enableNextExpectedMsgSeqNum,
                     enableLastMsgSeqNumProcessed);

--- a/quickfixj-core/src/test/java/quickfix/SessionTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionTest.java
@@ -85,7 +85,7 @@ public class SessionTest {
                 mockMessageStoreFactory, sessionID, null, null, mockLogFactory,
                 new DefaultMessageFactory(), 30, false, 30, UtcTimestampPrecision.MILLIS, true, false,
                 false, false, false, false, true, false, 1.5, null, true,
-                new int[] { 5 }, false, false, false, true, false, true, false,
+                new int[] { 5 }, false, false, false, false, true, false, true, false,
                 null, true, 0, false, false)) {
             // Simulate socket disconnect
             session.setResponder(null);
@@ -126,7 +126,7 @@ public class SessionTest {
                 mockMessageStoreFactory, sessionID, null, null, mockLogFactory,
                 new DefaultMessageFactory(), 30, false, 30, UtcTimestampPrecision.MILLIS, true, false,
                 false, false, false, false, true, false, 1.5, null, true,
-                new int[] { 5 }, false, false, false, true, false, true, false,
+                new int[] { 5 }, false, false, false, false, true, false, true, false,
                 null, true, 0, false, false)) {
             // Simulate socket disconnect
             session.setResponder(null);
@@ -1980,7 +1980,7 @@ public class SessionTest {
                 new DefaultMessageFactory(), isInitiator ? 30 : 0, false, 30,
                 UtcTimestampPrecision.MILLIS, resetOnLogon, false, false, false, false, false, true,
                 false, 1.5, null, validateSequenceNumbers, new int[] { 5 },
-                false, false, false, true, false, true, false, null, true,
+                false, false, false, false, true, false, true, false, null, true,
                 chunkSize, false, false)) {
 
             UnitTestResponder responder = new UnitTestResponder();
@@ -2042,7 +2042,7 @@ public class SessionTest {
 				sessionID, null, null, null,
 				new DefaultMessageFactory(), 30, false, 30, UtcTimestampPrecision.MILLIS, resetOnLogon,
 				false, false, false, false, false, true, false, 1.5, null, validateSequenceNumbers,
-				new int[]{5}, false, false, false, true, false, true, false, null, true, 0,
+				new int[]{5}, false, false, false, false, true, false, true, false, null, true, 0,
 				false, false);
 
 		Responder mockResponder = mock(Responder.class);
@@ -2090,7 +2090,7 @@ public class SessionTest {
 				sessionID, null, null, null,
 				new DefaultMessageFactory(), 30, false, 30, UtcTimestampPrecision.MILLIS, resetOnLogon,
 				false, false, false, false, false, true, false, 1.5, null, validateSequenceNumbers,
-				new int[]{5}, false, false, false, true, false, true, false, null, true, 0,
+				new int[]{5}, false, false, false, false, true, false, true, false, null, true, 0,
 				enableNextExpectedMsgSeqNum, false);
 
 		Responder mockResponder = mock(Responder.class);
@@ -2139,7 +2139,7 @@ public class SessionTest {
                 new DefaultMessageFactory(), isInitiator ? 30 : 0, false, 30,
                 UtcTimestampPrecision.MILLIS, resetOnLogon, false, false, false, false, false, true,
                 false, 1.5, null, validateSequenceNumbers, new int[] { 5 },
-                false, disconnectOnError, false, true, false, true, false,
+                false, disconnectOnError, false, false, true, false, true, false,
                 null, true, 0, false, false)) {
 
             UnitTestResponder responder = new UnitTestResponder();
@@ -2175,7 +2175,7 @@ public class SessionTest {
                 new DefaultMessageFactory(), isInitiator ? 30 : 0, false, 30,
                 UtcTimestampPrecision.NANOS, resetOnLogon, false, false, false, false, false, true,
                 false, 1.5, null, validateSequenceNumbers, new int[] { 5 },
-                false, disconnectOnError, false, true, false, true, false,
+                false, disconnectOnError, false, false, true, false, true, false,
                 null, true, 0, false, false)) {
 
             UnitTestResponder responder = new UnitTestResponder();
@@ -2227,7 +2227,7 @@ public class SessionTest {
                 sessionID, null, null, null,
                 new DefaultMessageFactory(), isInitiator ? 30 : 0, false, 30, UtcTimestampPrecision.MILLIS, resetOnLogon,
                 false, false, false, false, false, true, false, 1.5, null, validateSequenceNumbers,
-                new int[]{5}, false, false, false, true, false, true, false, null, true, 0,
+                new int[]{5}, false, false, false, false, true, false, true, false, null, true, 0,
                 false, false);
 
         UnitTestResponder responder = new UnitTestResponder();
@@ -2343,7 +2343,7 @@ public class SessionTest {
                 sessionID, null, null, null,
                 new DefaultMessageFactory(), isInitiator ? 30 : 0, false, 30, UtcTimestampPrecision.MILLIS, resetOnLogon,
                 false, false, false, false, false, true, false, 1.5, null, validateSequenceNumbers,
-                new int[]{5}, false, false, false, true, false, true, false, null, true, 0,
+                new int[]{5}, false, false, false, false, true, false, true, false, null, true, 0,
                 enableNextExpectedMsgSeqNum, false);
         UnitTestResponder responder = new UnitTestResponder();
         session.setResponder(responder);

--- a/quickfixj-core/src/test/java/quickfix/test/acceptance/AcceptanceTestSuite.java
+++ b/quickfixj-core/src/test/java/quickfix/test/acceptance/AcceptanceTestSuite.java
@@ -273,6 +273,11 @@ public class AcceptanceTestSuite extends TestSuite {
         acceptanceTests.addTest(new AcceptanceTestServerSetUp(new AcceptanceTestSuite("timestamps", true, timestampProperties)));
         acceptanceTests.addTest(new AcceptanceTestServerSetUp(new AcceptanceTestSuite("timestamps", false, timestampProperties)));
 
+        Map<Object, Object> rejectGarbledMessagesProperties = new HashMap<>();
+        rejectGarbledMessagesProperties.put(Session.SETTING_REJECT_GARBLED_MESSAGE, "Y");
+        acceptanceTests.addTest(new AcceptanceTestServerSetUp(new AcceptanceTestSuite("rejectGarbledMessages", true, rejectGarbledMessagesProperties)));
+        acceptanceTests.addTest(new AcceptanceTestServerSetUp(new AcceptanceTestSuite("rejectGarbledMessages", false, rejectGarbledMessagesProperties)));
+
         return acceptanceTests;
     }
 

--- a/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/rejectGarbledMessages/fix50/QFJ950-RejectGarbledMessages.def
+++ b/quickfixj-core/src/test/resources/quickfix/test/acceptance/definitions/rejectGarbledMessages/fix50/QFJ950-RejectGarbledMessages.def
@@ -1,0 +1,49 @@
+# If message is garbled and setting RejectGarbledMessage=Y, then msg should be rejected
+
+iCONNECT
+I8=FIXT.1.135=A34=149=TW52=<TIME>56=ISLD98=0108=301137=7
+E8=FIXT.1.19=6835=A34=149=ISLD52=00000000-00:00:00.00056=TW98=0108=301137=710=7
+
+# Incorrect checksum
+I8=FIXT.1.135=034=249=TW52=<TIME>56=ISLD10=256
+# expect Reject msg
+E8=FIXT.1.19=5935=334=249=ISLD52=00000000-00:00:00.00056=TW45=258=Message failed basic validity check372=010=0
+# Correct checksum
+I8=FIXT.1.135=034=349=TW52=<TIME>56=ISLD
+# Incorrect checksum
+I8=FIXT.1.135=D34=449=TW52=<TIME>56=ISLD11=ID21=340=154=155=INTC10=256
+# expect Reject msg
+E8=FIXT.1.19=5935=334=349=ISLD52=00000000-00:00:00.00056=TW45=458=Message failed basic validity check372=D10=0
+# correct checksum
+I8=FIXT.1.135=034=549=TW52=<TIME>56=ISLD
+
+# 35 is first field - note: FixMessageDecoder only considers messages starting with 8=FIX so 35 will be missing in the parsed msg
+I35=08=FIXT.1.19=2934=649=TW52=<TIME>56=ISLD10=121
+# expect Reject msg
+E8=FIXT.1.19=5935=334=449=ISLD52=00000000-00:00:00.00056=TW45=658=Message failed basic validity check10=0
+# check seqnums are in sync
+I8=FIXT.1.135=134=749=TW52=<TIME>56=ISLD112=HELLO
+E8=FIXT.1.19=5935=034=549=ISLD52=00000000-00:00:00.00056=TW112=HELLO10=0
+
+# 34 is second, should be third
+I8=FIXT.1.134=835=049=TW52=<TIME>56=ISLD
+# expect Reject msg
+E8=FIXT.1.19=5935=334=649=ISLD52=00000000-00:00:00.00056=TW45=858=Message failed basic validity check372=010=0
+# check seqnums are in sync
+I8=FIXT.1.135=134=949=TW52=<TIME>56=ISLD112=HELLO
+E8=FIXT.1.19=5935=034=749=ISLD52=00000000-00:00:00.00056=TW112=HELLO10=0
+
+# missing msgtype
+I8=FIXT.1.134=1049=TW52=<TIME>56=ISLD
+# expect Reject msg
+E8=FIXT.1.19=5935=334=849=ISLD52=00000000-00:00:00.00056=TW45=1058=Message failed basic validity check10=0
+
+# check seqnums are in sync
+I8=FIXT.1.135=134=1149=TW52=<TIME>56=ISLD112=HELLO
+E8=FIXT.1.19=5935=034=949=ISLD52=00000000-00:00:00.00056=TW112=HELLO10=0
+
+# logout message and response
+I8=FIXT.1.135=534=1249=TW52=<TIME>56=ISLD
+E8=FIXT.1.19=4935=534=1049=ISLD52=00000000-00:00:00.00056=TW10=0
+
+eDISCONNECT


### PR DESCRIPTION
Provide configuration to have garbled messages rejected instead of ignored.