### PR TITLE
QFJ-636 - Custom fields in component blocks are not added to parent

### DIFF
--- a/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/MessageSubclass.xsl
+++ b/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/MessageSubclass.xsl
@@ -271,18 +271,44 @@ import quickfix.Group;</xsl:if>
 
 <xsl:template name="component-accessor-template">
 	<xsl:variable name="type" select="concat($messagePackage,'.component.',@name)"/>
-	public void set(<xsl:value-of select="$type"/> component) {
-		setComponent(component);
-	}
+`    public void set(<xsl:value-of select="$type"/> component) {
+        setComponent(component);
+    }
 
-	public <xsl:value-of select="$type"/> get(<xsl:value-of select="$type"/> component) throws FieldNotFound {
-		getComponent(component);
-		return component;
-	}
+    public void set(<xsl:value-of select="$type"/> component, boolean includeAllFields, boolean includeAllGroups) {
+        setComponent(component, includeAllFields, includeAllGroups);
+    }
 
-	public <xsl:value-of select="$type"/> get<xsl:value-of select="@name"/>() throws FieldNotFound {
-		return get(new <xsl:value-of select="$type"/>());
-	}
+    public void set(<xsl:value-of select="$type"/> component, int[] includeFields, int[] includeGroups) {
+        setComponent(component, includeFields, includeGroups);
+    }
+
+    public <xsl:value-of select="$type"/> get(<xsl:value-of select="$type"/> component) throws FieldNotFound {
+        getComponent(component);
+        return component;
+    }
+
+    public <xsl:value-of select="$type"/> get(<xsl:value-of select="$type"/> component, boolean includeAllFields, boolean includeAllGroups) throws FieldNotFound {
+        getComponent(component, includeAllFields, includeAllGroups);
+        return component;
+    }
+
+    public <xsl:value-of select="$type"/> get(<xsl:value-of select="$type"/> component, int[] includeFields, int[] includeGroups) throws FieldNotFound {
+        getComponent(component, includeFields, includeGroups);
+        return component;
+    }
+
+    public <xsl:value-of select="$type"/> get<xsl:value-of select="@name"/>() throws FieldNotFound {
+        return get(new <xsl:value-of select="$type"/>());
+    }
+
+    public <xsl:value-of select="$type"/> get<xsl:value-of select="@name"/>(boolean includeAllFields, boolean includeAllGroups) throws FieldNotFound {
+        return get(new <xsl:value-of select="$type"/>(), includeAllFields, includeAllGroups);
+    }
+
+    public <xsl:value-of select="$type"/> get<xsl:value-of select="@name"/>(int[] includeFields, int[] includeGroups) throws FieldNotFound {
+        return get(new <xsl:value-of select="$type"/>(), includeFields, includeGroups);
+    }
 </xsl:template>
 
 <xsl:template mode="field-accessors" match="component">

--- a/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/MessageSubclass.xsl
+++ b/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/MessageSubclass.xsl
@@ -271,7 +271,7 @@ import quickfix.Group;</xsl:if>
 
 <xsl:template name="component-accessor-template">
 	<xsl:variable name="type" select="concat($messagePackage,'.component.',@name)"/>
-`    public void set(<xsl:value-of select="$type"/> component) {
+    public void set(<xsl:value-of select="$type"/> component) {
         setComponent(component);
     }
 

--- a/quickfixj-core/src/main/java/quickfix/FieldMap.java
+++ b/quickfixj-core/src/main/java/quickfix/FieldMap.java
@@ -139,9 +139,27 @@ public abstract class FieldMap implements Serializable {
         component.copyTo(this);
     }
 
+    protected void setComponent(MessageComponent component, boolean includeAllFields, boolean includeAllGroups) {
+        component.copyTo(this, includeAllFields, includeAllGroups);
+    }
+
+    protected void setComponent(MessageComponent component, int[] includeFields, int[] includeGroups) {
+        component.copyTo(this, includeFields, includeGroups);
+    }
+
     protected void getComponent(MessageComponent component) {
         component.clear();
         component.copyFrom(this);
+    }
+
+    protected void getComponent(MessageComponent component, boolean includeAllFields, boolean includeAllGroups) {
+        component.clear();
+        component.copyFrom(this, includeAllFields, includeAllGroups);
+    }
+
+    protected void getComponent(MessageComponent component, int[] includeFields, int[] includeGroups) {
+        component.clear();
+        component.copyFrom(this, includeFields, includeGroups);
     }
 
     public void setGroups(FieldMap fieldMap) {
@@ -244,6 +262,28 @@ public abstract class FieldMap implements Serializable {
         } else {
             return Optional.of(f.getValue());
         }
+    }
+
+    protected int[] getAllFields() {
+        int[] allFields = new int[fields.size()];
+        Integer[] allFieldsBoxed = fields.keySet().toArray(new Integer[allFields.length]);
+
+        for (int i = 0; i < allFields.length; i++) {
+            allFields[i] = allFieldsBoxed[i].intValue();
+        }
+
+       return allFields;
+    }
+
+    protected int[] getAllGroups() {
+        int[] allGroups = new int[groups.size()];
+        Integer[] allGroupsBoxed = groups.keySet().toArray(new Integer[allGroups.length]);
+
+        for (int i = 0; i < allGroups.length; i++) {
+            allGroups[i] = allGroupsBoxed[i].intValue();
+        }
+
+        return allGroups;
     }
 
     public boolean getBoolean(int field) throws FieldNotFound {

--- a/quickfixj-core/src/main/java/quickfix/MessageComponent.java
+++ b/quickfixj-core/src/main/java/quickfix/MessageComponent.java
@@ -1,5 +1,7 @@
 package quickfix;
 
+import java.util.Arrays;
+
 /**
  * Represents a FIX message component.
  */
@@ -18,13 +20,21 @@ public abstract class MessageComponent extends FieldMap {
     }
 
     public void copyFrom(FieldMap fields) {
+        copyFrom(fields, false, false);
+    }
+
+    public void copyFrom(FieldMap fields, boolean includeAllFields, boolean includeAllGroups) {
+        copyFrom(fields, includeAllFields ? fields.getAllFields() : getFields(), includeAllGroups ? fields.getAllGroups() : getGroupFields());
+    }
+
+    public void copyFrom(FieldMap fields, int[] includeFields, int[] includeGroups) {
         try {
-            for (int componentField : getFields()) {
+            for (int componentField : includeFields) {
                 if (fields.isSetField(componentField)) {
                     setField(componentField, fields.getField(componentField));
                 }
             }
-            for (int groupField : getGroupFields()) {
+            for (int groupField : includeGroups) {
                 if (fields.isSetField(groupField)) {
                     setField(groupField, fields.getField(groupField));
                     setGroups(groupField, fields.getGroups(groupField));
@@ -36,13 +46,21 @@ public abstract class MessageComponent extends FieldMap {
     }
 
     public void copyTo(FieldMap fields) {
+        copyTo(fields, false, false);
+    }
+
+    public void copyTo(FieldMap fields, boolean includeAllFields, boolean includeAllGroups) {
+        copyTo(fields, includeAllFields ? getAllFields() : getFields(), includeAllGroups ? getAllGroups() : getGroupFields());
+    }
+
+    public void copyTo(FieldMap fields, int[] includeFields, int[] includeGroups) {
         try {
-            for (int componentField : getFields()) {
+            for (int componentField : includeFields) {
                 if (isSetField(componentField)) {
                     fields.setField(componentField, getField(componentField));
                 }
             }
-            for (int groupField : getGroupFields()) {
+            for (int groupField : includeGroups) {
                 if (isSetField(groupField)) {
                     fields.setField(groupField, getField(groupField));
                     fields.setGroups(groupField, getGroups(groupField));
@@ -52,5 +70,4 @@ public abstract class MessageComponent extends FieldMap {
             // should not happen
         }
     }
-
 }

--- a/quickfixj-core/src/main/java/quickfix/MessageComponent.java
+++ b/quickfixj-core/src/main/java/quickfix/MessageComponent.java
@@ -20,7 +20,7 @@ public abstract class MessageComponent extends FieldMap {
     }
 
     public void copyFrom(FieldMap fields) {
-        copyFrom(fields, false, false);
+        copyFrom(fields, true, true);
     }
 
     public void copyFrom(FieldMap fields, boolean includeAllFields, boolean includeAllGroups) {
@@ -46,7 +46,7 @@ public abstract class MessageComponent extends FieldMap {
     }
 
     public void copyTo(FieldMap fields) {
-        copyTo(fields, false, false);
+        copyTo(fields, true, true);
     }
 
     public void copyTo(FieldMap fields, boolean includeAllFields, boolean includeAllGroups) {

--- a/quickfixj-core/src/test/java/quickfix/MessageComponentTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageComponentTest.java
@@ -18,50 +18,50 @@ import static org.junit.Assert.assertEquals;
 public class MessageComponentTest {
 
     @Test
-    public void shouldNotCopyToCustomComponentFieldsAndGroupsWhenUsingDefaultMethod() throws FieldNotFound {
+    public void shouldNotCopyToCustomComponentFieldsAndGroupsWhenFlagsAreDisabled() throws FieldNotFound {
+        Instrument srcInstrument = createInstrumentComponent();
+        Instrument dstInstrument = new Instrument();
+        srcInstrument.copyTo(dstInstrument, false, false);
+
+        assertEquals("EUR/USD", dstInstrument.getSymbol().getValue());
+        assertEquals(false, dstInstrument.isSetField(10_000));
+        assertEquals(false, dstInstrument.isSetField(10_001));
+
+        assertEquals(1, dstInstrument.getGroups(454).size());
+        assertEquals("security-id", dstInstrument.getGroups(454).get(0).getString(455));
+        assertEquals("ccc", dstInstrument.getGroups(454).get(0).getString(20_000));
+        assertEquals("ddd", dstInstrument.getGroups(454).get(0).getString(20_001));
+
+        assertEquals(0, dstInstrument.getGroups(30_000).size());
+
+        assertEquals(0, dstInstrument.getGroups(40_000).size());
+    }
+
+    @Test
+    public void shouldNotCopyFromCustomComponentFieldsAndGroupsWhenFlagsAreDisabled() throws FieldNotFound {
+        Instrument srcInstrument = createInstrumentComponent();
+        Instrument dstInstrument = new Instrument();
+        dstInstrument.copyFrom(srcInstrument, false, false);
+
+        assertEquals("EUR/USD", dstInstrument.getSymbol().getValue());
+        assertEquals(false, dstInstrument.isSetField(10_000));
+        assertEquals(false, dstInstrument.isSetField(10_001));
+
+        assertEquals(1, dstInstrument.getGroups(454).size());
+        assertEquals("security-id", dstInstrument.getGroups(454).get(0).getString(455));
+        assertEquals("ccc", dstInstrument.getGroups(454).get(0).getString(20_000));
+        assertEquals("ddd", dstInstrument.getGroups(454).get(0).getString(20_001));
+
+        assertEquals(0, dstInstrument.getGroups(30_000).size());
+
+        assertEquals(0, dstInstrument.getGroups(40_000).size());
+    }
+
+    @Test
+    public void shouldCopyToAllComponentFieldsAndGroupsWhenUsingDefaultMethod() throws FieldNotFound {
         Instrument srcInstrument = createInstrumentComponent();
         Instrument dstInstrument = new Instrument();
         srcInstrument.copyTo(dstInstrument);
-
-        assertEquals("EUR/USD", dstInstrument.getSymbol().getValue());
-        assertEquals(false, dstInstrument.isSetField(10_000));
-        assertEquals(false, dstInstrument.isSetField(10_001));
-
-        assertEquals(1, dstInstrument.getGroups(454).size());
-        assertEquals("security-id", dstInstrument.getGroups(454).get(0).getString(455));
-        assertEquals("ccc", dstInstrument.getGroups(454).get(0).getString(20_000));
-        assertEquals("ddd", dstInstrument.getGroups(454).get(0).getString(20_001));
-
-        assertEquals(0, dstInstrument.getGroups(30_000).size());
-
-        assertEquals(0, dstInstrument.getGroups(40_000).size());
-    }
-
-    @Test
-    public void shouldNotCopyFromCustomComponentFieldsAndGroupsWhenUsingDefaultMethod() throws FieldNotFound {
-        Instrument srcInstrument = createInstrumentComponent();
-        Instrument dstInstrument = new Instrument();
-        dstInstrument.copyFrom(srcInstrument);
-
-        assertEquals("EUR/USD", dstInstrument.getSymbol().getValue());
-        assertEquals(false, dstInstrument.isSetField(10_000));
-        assertEquals(false, dstInstrument.isSetField(10_001));
-
-        assertEquals(1, dstInstrument.getGroups(454).size());
-        assertEquals("security-id", dstInstrument.getGroups(454).get(0).getString(455));
-        assertEquals("ccc", dstInstrument.getGroups(454).get(0).getString(20_000));
-        assertEquals("ddd", dstInstrument.getGroups(454).get(0).getString(20_001));
-
-        assertEquals(0, dstInstrument.getGroups(30_000).size());
-
-        assertEquals(0, dstInstrument.getGroups(40_000).size());
-    }
-
-    @Test
-    public void shouldCopyToAllComponentFieldsAndGroupsWhenFlagsAreEnabled() throws FieldNotFound {
-        Instrument srcInstrument = createInstrumentComponent();
-        Instrument dstInstrument = new Instrument();
-        srcInstrument.copyTo(dstInstrument, true, true);
 
         assertEquals("EUR/USD", dstInstrument.getSymbol().getValue());
         assertEquals("aaa", dstInstrument.getString(10_000));
@@ -84,10 +84,10 @@ public class MessageComponentTest {
     }
 
     @Test
-    public void shouldCopyFromAllComponentFieldsAndGroupsWhenFlagsAreEnabled() throws FieldNotFound {
+    public void shouldCopyFromAllComponentFieldsAndGroupsWhenUsingDefaultMethod() throws FieldNotFound {
         Instrument srcInstrument = createInstrumentComponent();
         Instrument dstInstrument = new Instrument();
-        dstInstrument.copyFrom(srcInstrument, true, true);
+        dstInstrument.copyFrom(srcInstrument);
 
         assertEquals("EUR/USD", dstInstrument.getSymbol().getValue());
         assertEquals("aaa", dstInstrument.getString(10_000));
@@ -150,10 +150,10 @@ public class MessageComponentTest {
     }
 
     @Test
-    public void shouldGetAndSetAllComponentFieldsAndGroupsWhenFlagsAreEnabled() throws FieldNotFound {
+    public void shouldGetAndSetAllComponentFieldsAndGroupsWhenUsingDefaultMethod() throws FieldNotFound {
         NoRelatedSym noRelatedSym = new NoRelatedSym();
-        noRelatedSym.set(createInstrumentComponent(), true, true);
-        Instrument instrument = noRelatedSym.getInstrument(true, true);
+        noRelatedSym.set(createInstrumentComponent());
+        Instrument instrument = noRelatedSym.getInstrument();
 
         assertEquals("EUR/USD", instrument.getSymbol().getValue());
         assertEquals("aaa", instrument.getString(10_000));
@@ -196,10 +196,10 @@ public class MessageComponentTest {
     }
 
     @Test
-    public void shouldNotGetAndSetAllComponentFieldsAndGroupsWhenUsingDefaultMethod() throws FieldNotFound {
+    public void shouldNotGetAndSetAllComponentFieldsAndGroupsWhenFlagsAreDisabled() throws FieldNotFound {
         NoRelatedSym noRelatedSym = new NoRelatedSym();
-        noRelatedSym.set(createInstrumentComponent());
-        Instrument instrument = noRelatedSym.getInstrument();
+        noRelatedSym.set(createInstrumentComponent(), false, false);
+        Instrument instrument = noRelatedSym.getInstrument(false, false);
 
         assertEquals("EUR/USD", instrument.getSymbol().getValue());
         assertEquals(false, instrument.isSetField(10_000));

--- a/quickfixj-core/src/test/java/quickfix/MessageComponentTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageComponentTest.java
@@ -1,0 +1,251 @@
+package quickfix;
+
+import org.junit.Assert;
+import org.junit.Test;
+import quickfix.field.SecurityAltID;
+import quickfix.field.Side;
+import quickfix.field.Symbol;
+import quickfix.fix44.QuoteRequest;
+import quickfix.fix44.QuoteRequest.NoRelatedSym;
+import quickfix.fix44.component.Instrument;
+
+import java.security.Security;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class MessageComponentTest {
+
+    @Test
+    public void shouldNotCopyToCustomComponentFieldsAndGroupsWhenUsingDefaultMethod() throws FieldNotFound {
+        Instrument srcInstrument = createInstrumentComponent();
+        Instrument dstInstrument = new Instrument();
+        srcInstrument.copyTo(dstInstrument);
+
+        assertEquals("EUR/USD", dstInstrument.getSymbol().getValue());
+        assertEquals(false, dstInstrument.isSetField(10_000));
+        assertEquals(false, dstInstrument.isSetField(10_001));
+
+        assertEquals(1, dstInstrument.getGroups(454).size());
+        assertEquals("security-id", dstInstrument.getGroups(454).get(0).getString(455));
+        assertEquals("ccc", dstInstrument.getGroups(454).get(0).getString(20_000));
+        assertEquals("ddd", dstInstrument.getGroups(454).get(0).getString(20_001));
+
+        assertEquals(0, dstInstrument.getGroups(30_000).size());
+
+        assertEquals(0, dstInstrument.getGroups(40_000).size());
+    }
+
+    @Test
+    public void shouldNotCopyFromCustomComponentFieldsAndGroupsWhenUsingDefaultMethod() throws FieldNotFound {
+        Instrument srcInstrument = createInstrumentComponent();
+        Instrument dstInstrument = new Instrument();
+        dstInstrument.copyFrom(srcInstrument);
+
+        assertEquals("EUR/USD", dstInstrument.getSymbol().getValue());
+        assertEquals(false, dstInstrument.isSetField(10_000));
+        assertEquals(false, dstInstrument.isSetField(10_001));
+
+        assertEquals(1, dstInstrument.getGroups(454).size());
+        assertEquals("security-id", dstInstrument.getGroups(454).get(0).getString(455));
+        assertEquals("ccc", dstInstrument.getGroups(454).get(0).getString(20_000));
+        assertEquals("ddd", dstInstrument.getGroups(454).get(0).getString(20_001));
+
+        assertEquals(0, dstInstrument.getGroups(30_000).size());
+
+        assertEquals(0, dstInstrument.getGroups(40_000).size());
+    }
+
+    @Test
+    public void shouldCopyToAllComponentFieldsAndGroupsWhenFlagsAreEnabled() throws FieldNotFound {
+        Instrument srcInstrument = createInstrumentComponent();
+        Instrument dstInstrument = new Instrument();
+        srcInstrument.copyTo(dstInstrument, true, true);
+
+        assertEquals("EUR/USD", dstInstrument.getSymbol().getValue());
+        assertEquals("aaa", dstInstrument.getString(10_000));
+        assertEquals("bbb", dstInstrument.getString(10_001));
+
+        assertEquals(1, dstInstrument.getGroups(454).size());
+        assertEquals("security-id", dstInstrument.getGroups(454).get(0).getString(455));
+        assertEquals("ccc", dstInstrument.getGroups(454).get(0).getString(20_000));
+        assertEquals("ddd", dstInstrument.getGroups(454).get(0).getString(20_001));
+
+        assertEquals(1, dstInstrument.getGroups(30_000).size());
+        assertEquals("eee", dstInstrument.getGroups(30_000).get(0).getString(30_001));
+        assertEquals("fff", dstInstrument.getGroups(30_000).get(0).getString(30_002));
+        assertEquals("ggg", dstInstrument.getGroups(30_000).get(0).getString(30_003));
+
+        assertEquals(1, dstInstrument.getGroups(40_000).size());
+        assertEquals("hhh", dstInstrument.getGroups(40_000).get(0).getString(40_001));
+        assertEquals("iii", dstInstrument.getGroups(40_000).get(0).getString(40_002));
+        assertEquals("jjj", dstInstrument.getGroups(40_000).get(0).getString(40_003));
+    }
+
+    @Test
+    public void shouldCopyFromAllComponentFieldsAndGroupsWhenFlagsAreEnabled() throws FieldNotFound {
+        Instrument srcInstrument = createInstrumentComponent();
+        Instrument dstInstrument = new Instrument();
+        dstInstrument.copyFrom(srcInstrument, true, true);
+
+        assertEquals("EUR/USD", dstInstrument.getSymbol().getValue());
+        assertEquals("aaa", dstInstrument.getString(10_000));
+        assertEquals("bbb", dstInstrument.getString(10_001));
+
+        assertEquals(1, dstInstrument.getGroups(454).size());
+        assertEquals("security-id", dstInstrument.getGroups(454).get(0).getString(455));
+        assertEquals("ccc", dstInstrument.getGroups(454).get(0).getString(20_000));
+        assertEquals("ddd", dstInstrument.getGroups(454).get(0).getString(20_001));
+
+        assertEquals(1, dstInstrument.getGroups(30_000).size());
+        assertEquals("eee", dstInstrument.getGroups(30_000).get(0).getString(30_001));
+        assertEquals("fff", dstInstrument.getGroups(30_000).get(0).getString(30_002));
+        assertEquals("ggg", dstInstrument.getGroups(30_000).get(0).getString(30_003));
+
+        assertEquals(1, dstInstrument.getGroups(40_000).size());
+        assertEquals("hhh", dstInstrument.getGroups(40_000).get(0).getString(40_001));
+        assertEquals("iii", dstInstrument.getGroups(40_000).get(0).getString(40_002));
+        assertEquals("jjj", dstInstrument.getGroups(40_000).get(0).getString(40_003));
+    }
+
+    @Test
+    public void shouldCopyToSelectedComponentFieldsAndGroupsWhenCriteriaSpecified() throws FieldNotFound {
+        Instrument srcInstrument = createInstrumentComponent();
+        Instrument dstInstrument = new Instrument();
+        srcInstrument.copyTo(dstInstrument, new int[]{55, 10_001}, new int[]{40_000});
+
+        assertEquals("EUR/USD", dstInstrument.getSymbol().getValue());
+        assertEquals(false, dstInstrument.isSetField(10_000));
+        assertEquals("bbb", dstInstrument.getString(10_001));
+
+        assertEquals(0, dstInstrument.getGroups(454).size());
+
+        assertEquals(0, dstInstrument.getGroups(30_000).size());
+
+        assertEquals(1, dstInstrument.getGroups(40_000).size());
+        assertEquals("hhh", dstInstrument.getGroups(40_000).get(0).getString(40_001));
+        assertEquals("iii", dstInstrument.getGroups(40_000).get(0).getString(40_002));
+        assertEquals("jjj", dstInstrument.getGroups(40_000).get(0).getString(40_003));
+    }
+
+    @Test
+    public void shouldCopyFromSelectedComponentFieldsAndGroupsWhenCriteriaSpecified() throws FieldNotFound {
+        Instrument srcInstrument = createInstrumentComponent();
+        Instrument dstInstrument = new Instrument();
+        dstInstrument.copyFrom(srcInstrument, new int[]{55, 10_001}, new int[]{40_000});
+
+        assertEquals("EUR/USD", dstInstrument.getSymbol().getValue());
+        assertEquals(false, dstInstrument.isSetField(10_000));
+        assertEquals("bbb", dstInstrument.getString(10_001));
+
+        assertEquals(0, dstInstrument.getGroups(454).size());
+
+        assertEquals(0, dstInstrument.getGroups(30_000).size());
+
+        assertEquals(1, dstInstrument.getGroups(40_000).size());
+        assertEquals("hhh", dstInstrument.getGroups(40_000).get(0).getString(40_001));
+        assertEquals("iii", dstInstrument.getGroups(40_000).get(0).getString(40_002));
+        assertEquals("jjj", dstInstrument.getGroups(40_000).get(0).getString(40_003));
+    }
+
+    @Test
+    public void shouldGetAndSetAllComponentFieldsAndGroupsWhenFlagsAreEnabled() throws FieldNotFound {
+        NoRelatedSym noRelatedSym = new NoRelatedSym();
+        noRelatedSym.set(createInstrumentComponent(), true, true);
+        Instrument instrument = noRelatedSym.getInstrument(true, true);
+
+        assertEquals("EUR/USD", instrument.getSymbol().getValue());
+        assertEquals("aaa", instrument.getString(10_000));
+        assertEquals("bbb", instrument.getString(10_001));
+
+        assertEquals(1, instrument.getGroups(454).size());
+        assertEquals("security-id", instrument.getGroups(454).get(0).getString(455));
+        assertEquals("ccc", instrument.getGroups(454).get(0).getString(20_000));
+        assertEquals("ddd", instrument.getGroups(454).get(0).getString(20_001));
+
+        assertEquals(1, instrument.getGroups(30_000).size());
+        assertEquals("eee", instrument.getGroups(30_000).get(0).getString(30_001));
+        assertEquals("fff", instrument.getGroups(30_000).get(0).getString(30_002));
+        assertEquals("ggg", instrument.getGroups(30_000).get(0).getString(30_003));
+
+        assertEquals(1, instrument.getGroups(40_000).size());
+        assertEquals("hhh", instrument.getGroups(40_000).get(0).getString(40_001));
+        assertEquals("iii", instrument.getGroups(40_000).get(0).getString(40_002));
+        assertEquals("jjj", instrument.getGroups(40_000).get(0).getString(40_003));
+    }
+
+    @Test
+    public void shouldGetAndSetSelectedComponentFieldsAndGroupsWhenCriteriaSpecified() throws FieldNotFound {
+        NoRelatedSym noRelatedSym = new NoRelatedSym();
+        noRelatedSym.set(createInstrumentComponent(), new int[]{55, 10_001}, new int[]{40_000});
+        Instrument instrument = noRelatedSym.getInstrument(new int[]{55, 10_001}, new int[]{40_000});
+
+        assertEquals("EUR/USD", instrument.getSymbol().getValue());
+        assertEquals(false, instrument.isSetField(10_000));
+        assertEquals("bbb", instrument.getString(10_001));
+
+        assertEquals(0, instrument.getGroups(454).size());
+
+        assertEquals(0, instrument.getGroups(30_000).size());
+
+        assertEquals(1, instrument.getGroups(40_000).size());
+        assertEquals("hhh", instrument.getGroups(40_000).get(0).getString(40_001));
+        assertEquals("iii", instrument.getGroups(40_000).get(0).getString(40_002));
+        assertEquals("jjj", instrument.getGroups(40_000).get(0).getString(40_003));
+    }
+
+    @Test
+    public void shouldNotGetAndSetAllComponentFieldsAndGroupsWhenUsingDefaultMethod() throws FieldNotFound {
+        NoRelatedSym noRelatedSym = new NoRelatedSym();
+        noRelatedSym.set(createInstrumentComponent());
+        Instrument instrument = noRelatedSym.getInstrument();
+
+        assertEquals("EUR/USD", instrument.getSymbol().getValue());
+        assertEquals(false, instrument.isSetField(10_000));
+        assertEquals(false, instrument.isSetField(10_001));
+
+        assertEquals(1, instrument.getGroups(454).size());
+        assertEquals("security-id", instrument.getGroups(454).get(0).getString(455));
+        assertEquals("ccc", instrument.getGroups(454).get(0).getString(20_000));
+        assertEquals("ddd", instrument.getGroups(454).get(0).getString(20_001));
+
+        assertEquals(0, instrument.getGroups(30_000).size());
+
+        assertEquals(0, instrument.getGroups(40_000).size());
+    }
+
+    private Instrument createInstrumentComponent() {
+        Instrument.NoSecurityAltID noSecurityAltIDGroup = new Instrument.NoSecurityAltID();
+        noSecurityAltIDGroup.set(new SecurityAltID("security-id"));
+        noSecurityAltIDGroup.setString(20_000, "ccc");
+        noSecurityAltIDGroup.setString(20_001, "ddd");
+
+        Group customGroup1 = new Group(30_000, 30_001, new int[]{30_001, 30_002});
+        customGroup1.setString(30_001, "eee");
+        customGroup1.setString(30_002, "fff");
+        customGroup1.setString(30_003, "ggg");
+
+        Group customGroup2 = new Group(40_000, 40_001, new int[]{40_001, 40_002});
+        customGroup2.setString(40_001, "hhh");
+        customGroup2.setString(40_002, "iii");
+        customGroup2.setString(40_003, "jjj");
+
+        Instrument instrument = new Instrument();
+        instrument.set(new Symbol("EUR/USD"));
+        instrument.setString(10_000, "aaa");
+        instrument.setString(10_001, "bbb");
+        instrument.addGroup(noSecurityAltIDGroup);
+        instrument.addGroup(customGroup1);
+        instrument.addGroup(customGroup2);
+
+        QuoteRequest.NoRelatedSym noRelatedSymGroup = new QuoteRequest.NoRelatedSym();
+        noRelatedSymGroup.set(instrument);
+
+        QuoteRequest quoteRequest = new QuoteRequest();
+        quoteRequest.addGroup(noRelatedSymGroup);
+
+        return instrument;
+    }
+
+}


### PR DESCRIPTION
Hi @chrjohn,

Custom fields and groups are added to parent now (ie. setting, getting and copying is supported). Please keep in mind that when support of custom fields and groups is required new methods must be used. Previous methods:

- quickfix.FieldMap#setComponent(MessageComponent component)
- quickfix.FieldMap#getComponent(MessageComponent component)
- quickfix.MessageComponent#copyFrom(FieldMap fields)
- quickfix.MessageComponent#copyTo(FieldMap fields)

are backwards compatible - we don't want to break existing behaviour on production + there is an extra array creation required to copy all or selected fields/groups.

There are new methods that allow copying all fields and groups:

- quickfix.FieldMap#getComponent(MessageComponent component, boolean includeAllFields, boolean includeAllGroups)
- quickfix.FieldMap#getComponent(MessageComponent component, int[] includeFields, int[] includeGroups)
- quickfix.FieldMap#setComponent(MessageComponent component, boolean includeAllFields, boolean includeAllGroups)
- quickfix.FieldMap#setComponent(MessageComponent component, int[] includeFields, int[] includeGroups)
- quickfix.MessageComponent#copyFrom(FieldMap fields, boolean includeAllFields, boolean includeAllGroups)
- quickfix.MessageComponent#copyFrom(FieldMap fields, boolean includeAllFields, boolean includeAllGroups)
- quickfix.MessageComponent#copyTo(FieldMap fields, boolean includeAllFields, boolean includeAllGroups)
- quickfix.MessageComponent#copyTo(FieldMap fields, boolean includeAllFields, boolean includeAllGroups)

Also new methods are generated for each component, message and fix dictionary:

- #set(XXX component, boolean includeAllFields, boolean includeAllGroups)
- #set(XXX component, int[] includeFields, int[] includeGroups)
- #get(XXX component, boolean includeAllFields, boolean includeAllGroups)
- #get(XXX component, int[] includeFields, int[] includeGroups)
- #getXXX(boolean includeAllFields, boolean includeAllGroups)
- #getXXX(int[] includeFields, int[] includeGroups)

It seems that quickfixj-all.jar file is 1.2MB larger (size 22.6 MB, compared to quickfixj-all-2.1.0.jar which is 21.4 MB)