### PR TITLE
Functional adapters for Application and ApplicationExtended interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,40 @@ Message crackers for each FIX version are still generated for backward compatibi
 
 The generated classes define handlers for all messages defined by that version of FIX. This requires the JVM to load those classes when the cracker is loaded. Most applications only need to handle a small subset of the messages defined by a FIX version so loading all the messages classes is excessive overhead in those cases.
 
+#### Functional interfaces for receiving messages
+
+If you prefer to using lambda expressions in handling received messages, then<code>ApplicationFunctionalAdapter</code> or <code>ApplicationExtendedFunctionalAdapter</code> can be used to register reaction to events the application is interested in.
+
+They also allows registering the interests to a given message type in a type-safe manner.
+
+```
+import quickfix.ApplicationFunctionalAdapter;
+import quickfix.SessionID;
+
+public class EmailForwarder {
+    public void init(ApplicationFunctionalAdapter adapter) {
+        adapter.addOnLogonListener(this::captureUsername);
+        adapter.addFromAppListener(quickfix.fix44.Email.class, (e , s) -> forward(e));
+    }
+
+    private void forward(quickfix.fix44.Email email) {
+        // implementation
+    }
+
+    private void captureUsername(SessionID sessionID) {
+        // implementation
+    }
+}
+```
+<code>ApplicationFunctionalAdapter</code> and <code>ApplicationExtendedFunctionalAdapter</code> support multiple registration of the same event, and the registered callbacks are invoked in the FIFO manner. 
+
+However FIFO cannot be guaranteed between registration with specific message type (e.g. <code>quickfix.fix44.Email</code>) and that without specific message type. For example, there is no invocation order guarantee between the following two callbacks:
+
+```
+    adapter.addFromAppListener((e , s) -> handleGeneral(e));
+
+    adapter.addFromAppListener(quickfix.fix44.Email.class, (e , s) -> handleSpecific(e));
+```
 
 ### Sending messages
 

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ The generated classes define handlers for all messages defined by that version o
 
 #### Functional interfaces for receiving messages
 
-If you prefer to using lambda expressions in handling received messages, then<code>ApplicationFunctionalAdapter</code> or <code>ApplicationExtendedFunctionalAdapter</code> can be used to register reaction to events the application is interested in.
+If you prefer using lambda expressions in handling received messages, then <code>ApplicationFunctionalAdapter</code> or <code>ApplicationExtendedFunctionalAdapter</code> can be used to register reactions to events the application is interested in.
 
-They also allows registering the interests to a given message type in a type-safe manner.
+They also allow registering the interests in a given message type in a type-safe manner.
 
 ```
 import quickfix.ApplicationFunctionalAdapter;
@@ -207,7 +207,7 @@ public class EmailForwarder {
     }
 }
 ```
-<code>ApplicationFunctionalAdapter</code> and <code>ApplicationExtendedFunctionalAdapter</code> support multiple registration of the same event, and the registered callbacks are invoked in the FIFO manner. 
+<code>ApplicationFunctionalAdapter</code> and <code>ApplicationExtendedFunctionalAdapter</code> support multiple registration to the same event, and the registered callbacks are invoked in the FIFO manner. 
 
 However FIFO cannot be guaranteed between registration with specific message type (e.g. <code>quickfix.fix44.Email</code>) and that without specific message type. For example, there is no invocation order guarantee between the following two callbacks:
 

--- a/quickfixj-core/src/main/doc/usermanual/usage/receiving_messages.html
+++ b/quickfixj-core/src/main/doc/usermanual/usage/receiving_messages.html
@@ -152,9 +152,9 @@ a FIX version so loading all the messages classes is excessive overhead in those
 
 <H3>Support for Functional Interfaces</H3>
 <p>
-    If you prefer to using lambda expressions in handling received messages, then
+    If you prefer using lambda expressions in handling received messages, then
     <code>ApplicationFunctionalAdapter</code> or <code>ApplicationExtendedFunctionalAdapter</code> can be used to
-    register reaction to events the application is interested in. They also allows registering the interests to a given
+    register reactions to events the application is interested in. They also allow registering the interests in a given
     message type in a type-safe manner.
 <p>
 
@@ -179,7 +179,7 @@ public class EmailForwarder {
 </pre>
 <p>
     <code>ApplicationFunctionalAdapter</code> and <code>ApplicationExtendedFunctionalAdapter</code> support multiple
-    registration of the same event, and the registered callbacks are invoked in the FIFO manner. However FIFO
+    registration to the same event, and the registered callbacks are invoked in the FIFO manner. However FIFO
     cannot be guaranteed between registration with specific message type (e.g. <code>quickfix.fix44.Email</code>) and
     that without specific message type. For example, there is no invocation order guarantee between the following two
     callbacks:

--- a/quickfixj-core/src/main/doc/usermanual/usage/receiving_messages.html
+++ b/quickfixj-core/src/main/doc/usermanual/usage/receiving_messages.html
@@ -149,6 +149,48 @@ but it's more efficient to define the specific handlers you need. The generated 
 This requires the JVM to load those classes when the cracker is loaded. Most applications only need to handle a small subset of the messages defined by
 a FIX version so loading all the messages classes is excessive overhead in those cases.
 <p>
+
+<H3>Support for Functional Interfaces</H3>
+<p>
+    If you prefer to using lambda expressions in handling received messages, then
+    <code>ApplicationFunctionalAdapter</code> or <code>ApplicationExtendedFunctionalAdapter</code> can be used to
+    register reaction to events the application is interested in. They also allows registering the interests to a given
+    message type in a type-safe manner.
+<p>
+
+<pre class="code">
+import quickfix.ApplicationFunctionalAdapter;
+import quickfix.SessionID;
+
+public class EmailForwarder {
+    public void init(ApplicationFunctionalAdapter adapter) {
+        adapter.addOnLogonListener(this::captureUsername);
+        adapter.addFromAppListener(quickfix.fix44.Email.class, (e , s) -> forward(e));
+    }
+
+    private void forward(quickfix.fix44.Email email) {
+        // implementation
+    }
+
+    private void captureUsername(SessionID sessionID) {
+        // implementation
+    }
+}
+</pre>
+<p>
+    <code>ApplicationFunctionalAdapter</code> and <code>ApplicationExtendedFunctionalAdapter</code> support multiple
+    registration of the same event, and the registered callbacks are invoked in the FIFO manner. However FIFO
+    cannot be guaranteed between registration with specific message type (e.g. <code>quickfix.fix44.Email</code>) and
+    that without specific message type. For example, there is no invocation order guarantee between the following two
+    callbacks:
+<p>
+
+<pre class="code">
+    adapter.addFromAppListener((e , s) -> handleGeneral(e));
+
+    adapter.addFromAppListener(quickfix.fix44.Email.class, (e , s) -> handleSpecific(e));
+</pre>
+
 <div class="footer">More information at <a href="http://www.quickfixj.org/">www.quickfixj.org</a></div>
 
 </body>

--- a/quickfixj-core/src/main/java/quickfix/ApplicationExtendedFunctionalAdapter.java
+++ b/quickfixj-core/src/main/java/quickfix/ApplicationExtendedFunctionalAdapter.java
@@ -1,0 +1,72 @@
+package quickfix;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * This is an adapter implementation of ApplicationExtended interface, and that transforms the usage into more
+ * functional style. It breaks down each interface method into a number of single-method interfaces, which can be
+ * supplied by lambda expressions. Each single-method interface has its own add and remove listener method.
+ *
+ * <ol>
+ *     <li>Support multiple listeners of the same operation, e.g. onLogon. The method of the listeners will be invoked
+ *     in the same order of when add method was invoked, i.e. FIFO</li>
+ *     <li>Support fail fast evaluation of canLogOn listeners. False will be returned for the first false value returned
+ *     from the predicate of canLogOn. Otherwise return true.</li>
+ *     <li>Provides a thread-safe way to delegate to, add and remove listeners, by the means of CopyOnWriteArrayList,
+ *     under the assumption that adding and removing listeners are rare.</li>
+ * </ol>
+ */
+public class ApplicationExtendedFunctionalAdapter extends ApplicationFunctionalAdapter implements ApplicationExtended {
+    private final CopyOnWriteArrayList<Predicate<SessionID>> canLogonPredicates = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<Consumer<SessionID>> onBeforeSessionResetListeners = new CopyOnWriteArrayList<>();
+
+    /**
+     * Add a Predicate of Session to the canLogon evaluation.
+     *
+     * @param canlogon the Predicate of Session to the canLogon evaluation.
+     */
+    public void addCanLogOnPredicate(Predicate<SessionID> canlogon) {
+        canLogonPredicates.add(canlogon);
+    }
+
+    /**
+     * Remove a Predicate of Session from the canLogon evaluation.
+     *
+     * @param canlogon the Predicate of Session to the canLogon evaluation.
+     */
+    public void removeCanLogOnPredicate(Predicate<SessionID> canlogon) {
+        canLogonPredicates.remove(canlogon);
+    }
+
+    /**
+     * Add a Consumer of SessionID to listen to onBeforeSessionReset operation.
+     *
+     * @param onBeforeSessionReset the Consumer of SessionID to listen to onBeforeSessionReset operation.
+     */
+    public void addOnBeforeSessionResetListener(Consumer<SessionID> onBeforeSessionReset) {
+        onBeforeSessionResetListeners.add(onBeforeSessionReset);
+    }
+
+    /**
+     * Remove a Consumer of SessionID from onBeforeSessionReset operation.
+     *
+     * @param onBeforeSessionReset the Consumer of SessionID to listen to onBeforeSessionReset operation.
+     */
+    public void removeBeforeSessionResetListener(Consumer<SessionID> onBeforeSessionReset) {
+        onBeforeSessionResetListeners.remove(onBeforeSessionReset);
+    }
+
+    @Override
+    public boolean canLogon(SessionID sessionID) {
+        return canLogonPredicates.stream()
+                .allMatch(p -> p.test(sessionID));
+    }
+
+    @Override
+    public void onBeforeSessionReset(SessionID sessionID) {
+        onBeforeSessionResetListeners.forEach(c -> c.accept(sessionID));
+    }
+
+}

--- a/quickfixj-core/src/main/java/quickfix/ApplicationExtendedFunctionalAdapter.java
+++ b/quickfixj-core/src/main/java/quickfix/ApplicationExtendedFunctionalAdapter.java
@@ -1,26 +1,27 @@
 package quickfix;
 
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 /**
- * This is an adapter implementation of ApplicationExtended interface, and that transforms the usage into more
+ * This is an adapter implementation of ApplicationExtended interface that transforms the usage into more
  * functional style. It breaks down each interface method into a number of single-method interfaces, which can be
- * supplied by lambda expressions. Each single-method interface has its own add and remove listener method.
+ * supplied with lambda expressions. Each single-method interface has its own add and remove listener method.
  *
  * <ol>
  *     <li>Support multiple listeners of the same operation, e.g. onLogon. The method of the listeners will be invoked
  *     in the same order of when add method was invoked, i.e. FIFO</li>
  *     <li>Support fail fast evaluation of canLogOn listeners. False will be returned for the first false value returned
  *     from the predicate of canLogOn. Otherwise return true.</li>
- *     <li>Provides a thread-safe way to delegate to, add and remove listeners, by the means of CopyOnWriteArrayList,
- *     under the assumption that adding and removing listeners are rare.</li>
+ *     <li>Provides a thread-safe way to delegate to, add and remove listeners under the assumption that adding and
+ *     removing listeners are rare.</li>
  * </ol>
  */
 public class ApplicationExtendedFunctionalAdapter extends ApplicationFunctionalAdapter implements ApplicationExtended {
-    private final CopyOnWriteArrayList<Predicate<SessionID>> canLogonPredicates = new CopyOnWriteArrayList<>();
-    private final CopyOnWriteArrayList<Consumer<SessionID>> onBeforeSessionResetListeners = new CopyOnWriteArrayList<>();
+    private final List<Predicate<SessionID>> canLogonPredicates = new CopyOnWriteArrayList<>();
+    private final List<Consumer<SessionID>> onBeforeSessionResetListeners = new CopyOnWriteArrayList<>();
 
     /**
      * Add a Predicate of Session to the canLogon evaluation.

--- a/quickfixj-core/src/main/java/quickfix/ApplicationFunctionalAdapter.java
+++ b/quickfixj-core/src/main/java/quickfix/ApplicationFunctionalAdapter.java
@@ -1,0 +1,197 @@
+package quickfix;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * This is an adapter implementation of Application interface, and that transforms the usage into more functional style.
+ * It breaks down each interface method into a number of single-method interfaces, which can be supplied by lambda
+ * expressions. Each single-method interface has its own add and remove listener method.
+ *
+ * <ol>
+ *     <li>Support multiple listeners of the same operation, e.g. onLogon. The method of the listeners will be invoked
+ *     in the same order of when add method was invoked, i.e. FIFO</li>
+ *     <li>Support fail fast exception propagation for fromAdmin, toApp, and fromApp. The exception will be thrown for
+ *     the first encountered exception.</li>
+ *     <li>Provides a thread-safe way to delegate to, add and remove listeners, by the means of CopyOnWriteArrayList,
+ *     under the assumption that adding and removing listeners are rare.</li>
+ * </ol>
+ */
+public class ApplicationFunctionalAdapter implements Application {
+    private final CopyOnWriteArrayList<Consumer<SessionID>> onCreateListeners = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<Consumer<SessionID>> onLogonListeners = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<Consumer<SessionID>> onLogoutListeners = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<BiConsumer<Message, SessionID>> toAdminListeners = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<FromAdminListener> fromAdminListeners = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<ToAppListener> toAppListeners = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<FromAppListener> fromAppListeners = new CopyOnWriteArrayList<>();
+
+    /**
+     * Add a Consumer of SessionID to listen to onCreate operation.
+     *
+     * @param onCreateListener the Consumer of Session for onCreate operation.
+     */
+    public void addOnCreateListener(Consumer<SessionID> onCreateListener) {
+        onCreateListeners.add(onCreateListener);
+    }
+
+    /**
+     * Remove a Consumer of SessionID from onCreate operation.
+     *
+     * @param onCreateListener the Consumer of Session for onCreate operation.
+     */
+    public void removeOnCreateListener(Consumer<SessionID> onCreateListener) {
+        onCreateListeners.remove(onCreateListener);
+    }
+
+    /**
+     * Add a Consumer of SessionID to listen to onLogon operation.
+     *
+     * @param onLogonListener the Consumer of Session for onLogon operation.
+     */
+    public void addOnLogonListener(Consumer<SessionID> onLogonListener) {
+        onLogonListeners.add(onLogonListener);
+    }
+
+    /**
+     * Remove a Consumer of SessionID from onLogon operation.
+     *
+     * @param onLogonListener the Consumer of Session for onLogon operation.
+     */
+    public void removeOnLogonListener(Consumer<SessionID> onLogonListener) {
+        onLogonListeners.remove(onLogonListener);
+    }
+
+    /**
+     * Add a Consumer of SessionID to listen to onLogout operation.
+     *
+     * @param onLogoutListener the Consumer of Session for onLogout operation.
+     */
+    public void addOnLogoutListener(Consumer<SessionID> onLogoutListener) {
+        onLogoutListeners.add(onLogoutListener);
+    }
+
+    /**
+     * Remove a Consumer of SessionID from onLogout operation.
+     *
+     * @param onLogoutListener the Consumer of Session for onLogout operation.
+     */
+    public void removeOnLogoutListener(Consumer<SessionID> onLogoutListener) {
+        onLogoutListeners.remove(onLogoutListener);
+    }
+
+    /**
+     * Add a BiConsumer of SessionID to listen to toAdmin operation.
+     *
+     * @param toAdminListener the BiConsumer of Session for toAdmin operation.
+     */
+    public void addToAdminListener(BiConsumer<Message, SessionID> toAdminListener) {
+        toAdminListeners.add(toAdminListener);
+    }
+
+    /**
+     * Remove a BiConsumer of SessionID from toAdmin operation.
+     *
+     * @param toAdminListener the BiConsumer of Session for toAdmin operation.
+     */
+    public void removeToAdminListener(BiConsumer<Message, SessionID> toAdminListener) {
+        toAdminListeners.remove(toAdminListener);
+    }
+
+    /**
+     * Add a listener of fromAdmin operation.
+     *
+     * @param fromAdminListener the listener of fromAdmin operation.
+     */
+    public void addFromAdminListener(FromAdminListener fromAdminListener) {
+        fromAdminListeners.add(fromAdminListener);
+    }
+
+    /**
+     * Remove a listener of fromAdmin operation.
+     *
+     * @param fromAdminListener the listener of fromAdmin operation.
+     */
+    public void removeFromAdminListener(FromAdminListener fromAdminListener) {
+        fromAdminListeners.remove(fromAdminListener);
+    }
+
+    /**
+     * Add a listener of toApp operation.
+     *
+     * @param toAppListener the listener of fromAdmin operation.
+     */
+    public void addToAppListener(ToAppListener toAppListener) {
+        toAppListeners.add(toAppListener);
+    }
+
+    /**
+     * Remove a listener of toApp operation.
+     *
+     * @param toAppListener the listener of toApp operation.
+     */
+    public void removeToAppListener(ToAppListener toAppListener) {
+        toAppListeners.remove(toAppListener);
+    }
+
+    /**
+     * Add a listener of fromApp operation.
+     *
+     * @param fromAppListener the listener of fromApp operation.
+     */
+    public void addFromAppListener(FromAppListener fromAppListener) {
+        fromAppListeners.add(fromAppListener);
+    }
+
+    /**
+     * Remove a listener of fromApp operation.
+     *
+     * @param fromAppListener the listener of fromApp operation.
+     */
+    public void removeFromAppListener(FromAppListener fromAppListener) {
+        fromAppListeners.remove(fromAppListener);
+    }
+
+    @Override
+    public void onCreate(SessionID sessionId) {
+        onCreateListeners.forEach(c -> c.accept(sessionId));
+    }
+
+    @Override
+    public void onLogon(SessionID sessionId) {
+        onLogonListeners.forEach(c -> c.accept(sessionId));
+    }
+
+    @Override
+    public void onLogout(SessionID sessionId) {
+        onLogoutListeners.forEach(c -> c.accept(sessionId));
+    }
+
+    @Override
+    public void toAdmin(Message message, SessionID sessionId) {
+        toAdminListeners.forEach(c -> c.accept(message, sessionId));
+    }
+
+    @Override
+    public void fromAdmin(Message message, SessionID sessionId) throws FieldNotFound, IncorrectDataFormat, IncorrectTagValue, RejectLogon {
+        for (FromAdminListener listener : fromAdminListeners) {
+            listener.accept(message, sessionId);
+        }
+    }
+
+    @Override
+    public void toApp(Message message, SessionID sessionId) throws DoNotSend {
+        for (ToAppListener listener : toAppListeners) {
+            listener.accept(message, sessionId);
+        }
+    }
+
+    @Override
+    public void fromApp(Message message, SessionID sessionId) throws FieldNotFound, IncorrectDataFormat, IncorrectTagValue, UnsupportedMessageType {
+        for (FromAppListener listener : fromAppListeners) {
+            listener.accept(message, sessionId);
+        }
+    }
+
+}

--- a/quickfixj-core/src/main/java/quickfix/ApplicationFunctionalAdapter.java
+++ b/quickfixj-core/src/main/java/quickfix/ApplicationFunctionalAdapter.java
@@ -123,7 +123,7 @@ public class ApplicationFunctionalAdapter implements Application {
         toAdminListeners.remove(toAdminListener);
         toAdminTypeSafeListeners
                 .values()
-                .forEach(queue -> queue.remove(toAdminListener));
+                .forEach(list -> list.remove(toAdminListener));
     }
 
     /**
@@ -155,7 +155,7 @@ public class ApplicationFunctionalAdapter implements Application {
         fromAdminListeners.remove(fromAdminListener);
         fromAdminTypeSafeListeners
                 .values()
-                .forEach(queue -> queue.remove(fromAdminListener));
+                .forEach(list -> list.remove(fromAdminListener));
     }
 
     /**
@@ -187,7 +187,7 @@ public class ApplicationFunctionalAdapter implements Application {
         toAppListeners.remove(toAppListener);
         toAppTypeSafeListeners
                 .values()
-                .forEach(queue -> queue.remove(toAppListener));
+                .forEach(list -> list.remove(toAppListener));
     }
 
     /**
@@ -219,7 +219,7 @@ public class ApplicationFunctionalAdapter implements Application {
         fromAppListeners.remove(fromAppListener);
         fromAppTypeSafeListeners
                 .values()
-                .forEach(queue -> queue.remove(fromAppListener));
+                .forEach(list -> list.remove(fromAppListener));
     }
 
     @Override

--- a/quickfixj-core/src/main/java/quickfix/FromAdminListener.java
+++ b/quickfixj-core/src/main/java/quickfix/FromAdminListener.java
@@ -1,0 +1,5 @@
+package quickfix;
+
+public interface FromAdminListener {
+    void accept(Message message, SessionID sessionId) throws FieldNotFound, IncorrectDataFormat, IncorrectTagValue, RejectLogon;
+}

--- a/quickfixj-core/src/main/java/quickfix/FromAdminListener.java
+++ b/quickfixj-core/src/main/java/quickfix/FromAdminListener.java
@@ -1,5 +1,5 @@
 package quickfix;
 
-public interface FromAdminListener {
-    void accept(Message message, SessionID sessionId) throws FieldNotFound, IncorrectDataFormat, IncorrectTagValue, RejectLogon;
+public interface FromAdminListener<T extends Message> {
+    void accept(T message, SessionID sessionId) throws FieldNotFound, IncorrectDataFormat, IncorrectTagValue, RejectLogon;
 }

--- a/quickfixj-core/src/main/java/quickfix/FromAppListener.java
+++ b/quickfixj-core/src/main/java/quickfix/FromAppListener.java
@@ -1,5 +1,5 @@
 package quickfix;
 
-public interface FromAppListener {
-    void accept(Message message, SessionID sessionId) throws FieldNotFound, IncorrectDataFormat, IncorrectTagValue, UnsupportedMessageType;
+public interface FromAppListener<T extends Message> {
+    void accept(T message, SessionID sessionId) throws FieldNotFound, IncorrectDataFormat, IncorrectTagValue, UnsupportedMessageType;
 }

--- a/quickfixj-core/src/main/java/quickfix/FromAppListener.java
+++ b/quickfixj-core/src/main/java/quickfix/FromAppListener.java
@@ -1,0 +1,5 @@
+package quickfix;
+
+public interface FromAppListener {
+    void accept(Message message, SessionID sessionId) throws FieldNotFound, IncorrectDataFormat, IncorrectTagValue, UnsupportedMessageType;
+}

--- a/quickfixj-core/src/main/java/quickfix/ToAppListener.java
+++ b/quickfixj-core/src/main/java/quickfix/ToAppListener.java
@@ -1,5 +1,5 @@
 package quickfix;
 
-public interface ToAppListener {
-    void accept(Message message, SessionID sessionId) throws DoNotSend;
+public interface ToAppListener<T extends Message> {
+    void accept(T message, SessionID sessionId) throws DoNotSend;
 }

--- a/quickfixj-core/src/main/java/quickfix/ToAppListener.java
+++ b/quickfixj-core/src/main/java/quickfix/ToAppListener.java
@@ -1,0 +1,5 @@
+package quickfix;
+
+public interface ToAppListener {
+    void accept(Message message, SessionID sessionId) throws DoNotSend;
+}

--- a/quickfixj-core/src/test/java/quickfix/ApplicationExtendedFunctionalAdapterTest.java
+++ b/quickfixj-core/src/test/java/quickfix/ApplicationExtendedFunctionalAdapterTest.java
@@ -1,0 +1,153 @@
+package quickfix;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class ApplicationExtendedFunctionalAdapterTest {
+
+    @Test
+    public void testCanLogonPredicatesInvokedInOrder() {
+        ApplicationExtendedFunctionalAdapter adapter = new ApplicationExtendedFunctionalAdapter();
+        Predicate<SessionID> predicate = mock(Predicate.class);
+        Predicate<SessionID> predicate2 = mock(Predicate.class);
+
+        adapter.addCanLogOnPredicate(predicate);
+        adapter.addCanLogOnPredicate(predicate2);
+
+        SessionID sessionID = mock(SessionID.class);
+        when(predicate.test(sessionID)).thenReturn(true);
+        when(predicate2.test(sessionID)).thenReturn(true);
+
+        adapter.canLogon(sessionID);
+
+        InOrder inOrder = inOrder(predicate, predicate2);
+        inOrder.verify(predicate).test(sessionID);
+        inOrder.verify(predicate2).test(sessionID);
+        verifyNoMoreInteractions(predicate, predicate2);
+    }
+
+    @Test
+    public void testRemovedCanLogonPredicateNotInvoked() {
+        ApplicationExtendedFunctionalAdapter adapter = new ApplicationExtendedFunctionalAdapter();
+        Predicate<SessionID> predicate = mock(Predicate.class);
+        Predicate<SessionID> predicate2 = mock(Predicate.class);
+
+        adapter.addCanLogOnPredicate(predicate);
+        adapter.addCanLogOnPredicate(predicate2);
+
+        SessionID sessionID = mock(SessionID.class);
+        when(predicate.test(sessionID)).thenReturn(true);
+        when(predicate2.test(sessionID)).thenReturn(true);
+
+        adapter.removeCanLogOnPredicate(predicate);
+        adapter.canLogon(sessionID);
+
+        verify(predicate2).test(sessionID);
+        verifyNoMoreInteractions(predicate2);
+        verifyZeroInteractions(predicate);
+    }
+
+    @Test
+    public void testCanLogOnPredicatesReturnTrueIfAllPredicatesReturnTrue() {
+        ApplicationExtendedFunctionalAdapter adapter = new ApplicationExtendedFunctionalAdapter();
+        Predicate<SessionID> predicate = mock(Predicate.class);
+        Predicate<SessionID> predicate2 = mock(Predicate.class);
+
+        adapter.addCanLogOnPredicate(predicate);
+        adapter.addCanLogOnPredicate(predicate2);
+
+        SessionID sessionID = mock(SessionID.class);
+        when(predicate.test(sessionID)).thenReturn(true);
+        when(predicate2.test(sessionID)).thenReturn(true);
+
+        assertTrue(adapter.canLogon(sessionID));
+    }
+
+    @Test
+    public void testCanLogOnPredicatesReturnFalseIfTheFirstPredicateReturnFalse() {
+        ApplicationExtendedFunctionalAdapter adapter = new ApplicationExtendedFunctionalAdapter();
+        Predicate<SessionID> predicate = mock(Predicate.class);
+        Predicate<SessionID> predicate2 = mock(Predicate.class);
+
+        adapter.addCanLogOnPredicate(predicate);
+        adapter.addCanLogOnPredicate(predicate2);
+
+        SessionID sessionID = mock(SessionID.class);
+        when(predicate.test(sessionID)).thenReturn(false);
+        when(predicate2.test(sessionID)).thenReturn(true);
+
+        assertFalse(adapter.canLogon(sessionID));
+    }
+
+    @Test
+    public void testCanLogOnPredicatesReturnFalseIfTheSecondPredicateReturnFalse() {
+        ApplicationExtendedFunctionalAdapter adapter = new ApplicationExtendedFunctionalAdapter();
+        Predicate<SessionID> predicate = mock(Predicate.class);
+        Predicate<SessionID> predicate2 = mock(Predicate.class);
+
+        adapter.addCanLogOnPredicate(predicate);
+        adapter.addCanLogOnPredicate(predicate2);
+
+        SessionID sessionID = mock(SessionID.class);
+        when(predicate.test(sessionID)).thenReturn(true);
+        when(predicate2.test(sessionID)).thenReturn(false);
+
+        assertFalse(adapter.canLogon(sessionID));
+    }
+
+    @Test
+    public void testCanLogOnPredicatesReturnFalseIfAllPredicatesReturnFalse() {
+        ApplicationExtendedFunctionalAdapter adapter = new ApplicationExtendedFunctionalAdapter();
+        Predicate<SessionID> predicate = mock(Predicate.class);
+        Predicate<SessionID> predicate2 = mock(Predicate.class);
+
+        adapter.addCanLogOnPredicate(predicate);
+        adapter.addCanLogOnPredicate(predicate2);
+
+        SessionID sessionID = mock(SessionID.class);
+        when(predicate.test(sessionID)).thenReturn(false);
+        when(predicate2.test(sessionID)).thenReturn(false);
+
+        assertFalse(adapter.canLogon(sessionID));
+    }
+
+    @Test
+    public void testOnBeforeSessionResetListenersInvokedInOrder() {
+        ApplicationExtendedFunctionalAdapter adapter = new ApplicationExtendedFunctionalAdapter();
+        Consumer<SessionID> listener = mock(Consumer.class);
+        Consumer<SessionID> listener2 = mock(Consumer.class);
+
+        adapter.addOnBeforeSessionResetListener(listener);
+        adapter.addOnBeforeSessionResetListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        adapter.onBeforeSessionReset(sessionID);
+
+        InOrder inOrder = inOrder(listener, listener2);
+        inOrder.verify(listener).accept(sessionID);
+        inOrder.verify(listener2).accept(sessionID);
+        verifyNoMoreInteractions(listener, listener2);
+    }
+
+    @Test
+    public void testRemovedOnBeforeSessionResetListenersNotInvoked() {
+        ApplicationExtendedFunctionalAdapter adapter = new ApplicationExtendedFunctionalAdapter();
+        Consumer<SessionID> listener = mock(Consumer.class);
+
+        adapter.addOnBeforeSessionResetListener(listener);
+
+        SessionID sessionID = mock(SessionID.class);
+        adapter.removeBeforeSessionResetListener(listener);
+        adapter.onBeforeSessionReset(sessionID);
+
+        verifyZeroInteractions(listener);
+    }
+
+
+}

--- a/quickfixj-core/src/test/java/quickfix/ApplicationFunctionalAdapterTest.java
+++ b/quickfixj-core/src/test/java/quickfix/ApplicationFunctionalAdapterTest.java
@@ -1,0 +1,401 @@
+package quickfix;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class ApplicationFunctionalAdapterTest {
+
+    @Test
+    public void testOnCreateListenersInvokedInOrder() {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        Consumer<SessionID> listener = mock(Consumer.class);
+        Consumer<SessionID> listener2 = mock(Consumer.class);
+
+        adapter.addOnCreateListener(listener);
+        adapter.addOnCreateListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        adapter.onCreate(sessionID);
+
+        InOrder inOrder = inOrder(listener, listener2);
+        inOrder.verify(listener).accept(sessionID);
+        inOrder.verify(listener2).accept(sessionID);
+        verifyNoMoreInteractions(listener, listener2);
+    }
+
+    @Test
+    public void testRemovedOnCreateListenersNotInvoked() {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        Consumer<SessionID> listener = mock(Consumer.class);
+        Consumer<SessionID> listener2 = mock(Consumer.class);
+
+        adapter.addOnCreateListener(listener);
+        adapter.addOnCreateListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        adapter.removeOnCreateListener(listener);
+        adapter.onCreate(sessionID);
+
+        verify(listener2).accept(sessionID);
+        verifyNoMoreInteractions(listener2);
+        verifyZeroInteractions(listener);
+    }
+
+    @Test
+    public void testOnLogonListenersInvokedInOrder() {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        Consumer<SessionID> listener = mock(Consumer.class);
+        Consumer<SessionID> listener2 = mock(Consumer.class);
+
+        adapter.addOnLogonListener(listener);
+        adapter.addOnLogonListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        adapter.onLogon(sessionID);
+
+        InOrder inOrder = inOrder(listener, listener2);
+        inOrder.verify(listener).accept(sessionID);
+        inOrder.verify(listener2).accept(sessionID);
+        verifyNoMoreInteractions(listener, listener2);
+    }
+
+    @Test
+    public void testRemovedOnLogonListenersNotInvoked() {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        Consumer<SessionID> listener = mock(Consumer.class);
+        Consumer<SessionID> listener2 = mock(Consumer.class);
+
+        adapter.addOnLogonListener(listener);
+        adapter.addOnLogonListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        adapter.removeOnLogonListener(listener);
+        adapter.onLogon(sessionID);
+
+        verify(listener2).accept(sessionID);
+        verifyNoMoreInteractions(listener2);
+        verifyZeroInteractions(listener);
+    }
+
+    @Test
+    public void testOnLogoutListenersInvokedInOrder() {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        Consumer<SessionID> listener = mock(Consumer.class);
+        Consumer<SessionID> listener2 = mock(Consumer.class);
+
+        adapter.addOnLogoutListener(listener);
+        adapter.addOnLogoutListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        adapter.onLogout(sessionID);
+
+        InOrder inOrder = inOrder(listener, listener2);
+        inOrder.verify(listener).accept(sessionID);
+        inOrder.verify(listener2).accept(sessionID);
+        verifyNoMoreInteractions(listener, listener2);
+    }
+
+    @Test
+    public void testRemovedOnLogoutListenersNotInvoked() {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        Consumer<SessionID> listener = mock(Consumer.class);
+        Consumer<SessionID> listener2 = mock(Consumer.class);
+
+        adapter.addOnLogoutListener(listener);
+        adapter.addOnLogoutListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        adapter.removeOnLogoutListener(listener);
+        adapter.onLogout(sessionID);
+
+        verify(listener2).accept(sessionID);
+        verifyNoMoreInteractions(listener2);
+        verifyZeroInteractions(listener);
+    }
+
+    @Test
+    public void testToAdminListenersInvokedInOrder() {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        BiConsumer<Message, SessionID> listener = mock(BiConsumer.class);
+        BiConsumer<Message, SessionID> listener2 = mock(BiConsumer.class);
+
+        adapter.addToAdminListener(listener);
+        adapter.addToAdminListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        Message message = mock(Message.class);
+        adapter.toAdmin(message, sessionID);
+
+        InOrder inOrder = inOrder(listener, listener2);
+        inOrder.verify(listener).accept(message, sessionID);
+        inOrder.verify(listener2).accept(message, sessionID);
+        verifyNoMoreInteractions(listener, listener2);
+    }
+
+    @Test
+    public void testRemovedToAdminListenersNotInvoked() {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        BiConsumer<Message, SessionID> listener = mock(BiConsumer.class);
+        BiConsumer<Message, SessionID> listener2 = mock(BiConsumer.class);
+
+        adapter.addToAdminListener(listener);
+        adapter.addToAdminListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        Message message = mock(Message.class);
+        adapter.removeToAdminListener(listener);
+        adapter.toAdmin(message, sessionID);
+
+        verify(listener2).accept(message, sessionID);
+        verifyNoMoreInteractions(listener2);
+        verifyZeroInteractions(listener);
+    }
+
+    @Test
+    public void testFromAdminListenersInvokedInOrder() throws FieldNotFound, IncorrectTagValue, IncorrectDataFormat, RejectLogon {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        FromAdminListener listener = mock(FromAdminListener.class);
+        FromAdminListener listener2 = mock(FromAdminListener.class);
+
+        adapter.addFromAdminListener(listener);
+        adapter.addFromAdminListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        Message message = mock(Message.class);
+        adapter.fromAdmin(message, sessionID);
+
+        InOrder inOrder = inOrder(listener, listener2);
+        inOrder.verify(listener).accept(message, sessionID);
+        inOrder.verify(listener2).accept(message, sessionID);
+        verifyNoMoreInteractions(listener, listener2);
+    }
+
+    @Test
+    public void testRemovedFromAdminListenersNotInvoked() throws FieldNotFound, IncorrectTagValue, IncorrectDataFormat, RejectLogon {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        FromAdminListener listener = mock(FromAdminListener.class);
+        FromAdminListener listener2 = mock(FromAdminListener.class);
+
+        adapter.addFromAdminListener(listener);
+        adapter.addFromAdminListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        Message message = mock(Message.class);
+        adapter.removeFromAdminListener(listener);
+        adapter.fromAdmin(message, sessionID);
+
+        verify(listener2).accept(message, sessionID);
+        verifyNoMoreInteractions(listener2);
+        verifyZeroInteractions(listener);
+    }
+
+    @Test
+    public void testFromAdminListenersFailFastForFieldNotFound() throws FieldNotFound, IncorrectTagValue, IncorrectDataFormat, RejectLogon {
+        assertFromAdminListenersFailFast(new FieldNotFound(35));
+    }
+
+    @Test
+    public void testFromAdminListenersFailFastForIncorrectTagValue() throws FieldNotFound, IncorrectTagValue, IncorrectDataFormat, RejectLogon {
+        assertFromAdminListenersFailFast(new IncorrectTagValue(35));
+    }
+
+    @Test
+    public void testFromAdminListenersFailFastForIncorrectDataFormat() throws FieldNotFound, IncorrectTagValue, IncorrectDataFormat, RejectLogon {
+        assertFromAdminListenersFailFast(new IncorrectDataFormat(35));
+    }
+
+    @Test
+    public void testFromAdminListenersFailFastForRejectLogon() throws FieldNotFound, IncorrectTagValue, IncorrectDataFormat, RejectLogon {
+        assertFromAdminListenersFailFast(new RejectLogon("Log on not allowed"));
+    }
+
+    private void assertFromAdminListenersFailFast(Exception exception) throws FieldNotFound, IncorrectDataFormat, IncorrectTagValue, RejectLogon {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        FromAdminListener listener = mock(FromAdminListener.class);
+        FromAdminListener listener2 = mock(FromAdminListener.class);
+        FromAdminListener listener3 = mock(FromAdminListener.class);
+
+        adapter.addFromAdminListener(listener);
+        adapter.addFromAdminListener(listener2);
+        adapter.addFromAdminListener(listener3);
+
+        SessionID sessionID = mock(SessionID.class);
+        Message message = mock(Message.class);
+
+        doThrow(exception).when(listener2).accept(message, sessionID);
+
+        try {
+            adapter.fromAdmin(message, sessionID);
+        } catch (Exception actual)
+        {
+            assertSame(exception, actual);
+        }
+
+        verify(listener).accept(message, sessionID);
+        verify(listener2).accept(message, sessionID);
+        verifyNoMoreInteractions(listener, listener2);
+        verifyZeroInteractions(listener3);
+    }
+
+    @Test
+    public void testToAppListenersInvokedInOrder() throws DoNotSend {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        ToAppListener listener = mock(ToAppListener.class);
+        ToAppListener listener2 = mock(ToAppListener.class);
+
+        adapter.addToAppListener(listener);
+        adapter.addToAppListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        Message message = mock(Message.class);
+        adapter.toApp(message, sessionID);
+
+        InOrder inOrder = inOrder(listener, listener2);
+        inOrder.verify(listener).accept(message, sessionID);
+        inOrder.verify(listener2).accept(message, sessionID);
+        verifyNoMoreInteractions(listener, listener2);
+    }
+
+    @Test
+    public void testRemovedToAppListenersNotInvoked() throws DoNotSend {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        ToAppListener listener = mock(ToAppListener.class);
+        ToAppListener listener2 = mock(ToAppListener.class);
+
+        adapter.addToAppListener(listener);
+        adapter.addToAppListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        Message message = mock(Message.class);
+        adapter.removeToAppListener(listener);
+        adapter.toApp(message, sessionID);
+
+        verify(listener2).accept(message, sessionID);
+        verifyNoMoreInteractions(listener2);
+        verifyZeroInteractions(listener);
+    }
+
+    @Test
+    public void testToAppListenersFailFastForDoNotSend() throws DoNotSend {
+        Exception exception = new DoNotSend();
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        ToAppListener listener = mock(ToAppListener.class);
+        ToAppListener listener2 = mock(ToAppListener.class);
+        ToAppListener listener3 = mock(ToAppListener.class);
+
+        adapter.addToAppListener(listener);
+        adapter.addToAppListener(listener2);
+        adapter.addToAppListener(listener3);
+
+        SessionID sessionID = mock(SessionID.class);
+        Message message = mock(Message.class);
+
+        doThrow(exception).when(listener2).accept(message, sessionID);
+
+        try {
+            adapter.toApp(message, sessionID);
+        } catch (Exception actual)
+        {
+            assertSame(exception, actual);
+        }
+
+        verify(listener).accept(message, sessionID);
+        verify(listener2).accept(message, sessionID);
+        verifyNoMoreInteractions(listener, listener2);
+        verifyZeroInteractions(listener3);
+    }
+
+    @Test
+    public void testFromAppListenersInvokedInOrder() throws FieldNotFound, IncorrectTagValue, IncorrectDataFormat, UnsupportedMessageType {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        FromAppListener listener = mock(FromAppListener.class);
+        FromAppListener listener2 = mock(FromAppListener.class);
+
+        adapter.addFromAppListener(listener);
+        adapter.addFromAppListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        Message message = mock(Message.class);
+        adapter.fromApp(message, sessionID);
+
+        InOrder inOrder = inOrder(listener, listener2);
+        inOrder.verify(listener).accept(message, sessionID);
+        inOrder.verify(listener2).accept(message, sessionID);
+        verifyNoMoreInteractions(listener, listener2);
+    }
+
+    @Test
+    public void testRemovedFromAppListenersNotInvoked() throws FieldNotFound, IncorrectTagValue, IncorrectDataFormat, UnsupportedMessageType {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        FromAppListener listener = mock(FromAppListener.class);
+        FromAppListener listener2 = mock(FromAppListener.class);
+
+        adapter.addFromAppListener(listener);
+        adapter.addFromAppListener(listener2);
+
+        SessionID sessionID = mock(SessionID.class);
+        Message message = mock(Message.class);
+        adapter.removeFromAppListener(listener);
+        adapter.fromApp(message, sessionID);
+
+        verify(listener2).accept(message, sessionID);
+        verifyNoMoreInteractions(listener2);
+        verifyZeroInteractions(listener);
+    }
+
+    @Test
+    public void testFromAppListenersFailFastForFieldNotFound() throws FieldNotFound, IncorrectTagValue, IncorrectDataFormat, UnsupportedMessageType {
+        assertFromAppListenersFailFast(new FieldNotFound(35));
+    }
+
+    @Test
+    public void testFromAppListenersFailFastForIncorrectTagValue() throws FieldNotFound, IncorrectTagValue, IncorrectDataFormat, UnsupportedMessageType {
+        assertFromAppListenersFailFast(new IncorrectTagValue(35));
+    }
+
+    @Test
+    public void testFromAppListenersFailFastForIncorrectDataFormat() throws FieldNotFound, IncorrectTagValue, IncorrectDataFormat, UnsupportedMessageType {
+        assertFromAppListenersFailFast(new IncorrectDataFormat(35));
+    }
+
+    @Test
+    public void testFromAppListenersFailFastForRejectLogon() throws FieldNotFound, IncorrectTagValue, IncorrectDataFormat, UnsupportedMessageType {
+        assertFromAppListenersFailFast(new UnsupportedMessageType());
+    }
+
+    private void assertFromAppListenersFailFast(Exception exception) throws FieldNotFound, IncorrectDataFormat, IncorrectTagValue, UnsupportedMessageType {
+        ApplicationFunctionalAdapter adapter = new ApplicationFunctionalAdapter();
+        FromAppListener listener = mock(FromAppListener.class);
+        FromAppListener listener2 = mock(FromAppListener.class);
+        FromAppListener listener3 = mock(FromAppListener.class);
+
+        adapter.addFromAppListener(listener);
+        adapter.addFromAppListener(listener2);
+        adapter.addFromAppListener(listener3);
+
+        SessionID sessionID = mock(SessionID.class);
+        Message message = mock(Message.class);
+
+        doThrow(exception).when(listener2).accept(message, sessionID);
+
+        try {
+            adapter.fromApp(message, sessionID);
+        } catch (Exception actual)
+        {
+            assertSame(exception, actual);
+        }
+
+        verify(listener).accept(message, sessionID);
+        verify(listener2).accept(message, sessionID);
+        verifyNoMoreInteractions(listener, listener2);
+        verifyZeroInteractions(listener3);
+    }
+
+}

--- a/quickfixj-core/src/test/java/quickfix/test/acceptance/ATMessageCracker.java
+++ b/quickfixj-core/src/test/java/quickfix/test/acceptance/ATMessageCracker.java
@@ -70,7 +70,7 @@ class ATMessageCracker extends quickfix.MessageCracker {
         process(message, sessionID);
     }
 
-    public void onMessage(quickfix.fix50sp2.NewOrderSingle  message, SessionID sessionID)
+    public void onMessage(quickfix.fix50sp2.NewOrderSingle message, SessionID sessionID)
             throws FieldNotFound, UnsupportedMessageType, IncorrectTagValue {
         process(message, sessionID);
     }

--- a/quickfixj-core/src/test/java/quickfix/test/acceptance/ATMessageCracker.java
+++ b/quickfixj-core/src/test/java/quickfix/test/acceptance/ATMessageCracker.java
@@ -70,7 +70,7 @@ class ATMessageCracker extends quickfix.MessageCracker {
         process(message, sessionID);
     }
 
-    public void onMessage(quickfix.fix50sp2.NewOrderSingle message, SessionID sessionID)
+    public void onMessage(quickfix.fix50sp2.NewOrderSingle  message, SessionID sessionID)
             throws FieldNotFound, UnsupportedMessageType, IncorrectTagValue {
         process(message, sessionID);
     }


### PR DESCRIPTION
Provides adapter implementation of quickfix.Application and quickfix.ApplicationExtended that

1. allows registering multiple listeners for each operation (e.g. onLogon, onCreate) separately using Java 8's functional interfaces like Consumer, BiConsumer and Predicate. FromAdmin, FromApp and ToApp requires custom interfaces due to checked Exceptions. Also allows removing registered listeners.

2. invokes each registered listeners in a FIFO manner

3. for Predicate, it fail-fast when encounters the first Predicate returning false

4. for checked Exception listeners, it fail-fast when encounters the first Exception thrown

5. is completely optional to Quickfix users

6. is backward compatible

7. is thread-safe with the use of CopyOnWriteArrayList

8. does not add extra lib dependency