### PR TITLE
QFJ-960 Watermarks should not be activated when neither queue size no…

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/SingleThreadedEventHandlingStrategy.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/SingleThreadedEventHandlingStrategy.java
@@ -55,8 +55,12 @@ public class SingleThreadedEventHandlingStrategy implements EventHandlingStrateg
     public SingleThreadedEventHandlingStrategy(SessionConnector connector, int queueLowerWatermark, int queueUpperWatermark) {
         sessionConnector = connector;
         eventQueue = new LinkedBlockingQueue<>();
-        queueTracker = newMultiSessionWatermarkTracker(eventQueue, queueLowerWatermark, queueUpperWatermark,
-                evt -> evt.quickfixSession);
+        if (queueLowerWatermark > 0 && queueUpperWatermark > 0) {
+            queueTracker = newMultiSessionWatermarkTracker(eventQueue, queueLowerWatermark, queueUpperWatermark,
+                    evt -> evt.quickfixSession);
+        } else {
+            queueTracker = newDefaultQueueTracker(eventQueue);
+        }
     }
 
     public void setExecutor(Executor executor) {

--- a/quickfixj-core/src/test/java/quickfix/mina/SingleThreadedEventHandlingStrategyTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/SingleThreadedEventHandlingStrategyTest.java
@@ -45,7 +45,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import org.junit.AfterClass;
+import quickfix.test.util.ReflectionUtil;
+
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static quickfix.test.util.ReflectionUtil.getField;
 
 /**
  *
@@ -293,6 +297,24 @@ public class SingleThreadedEventHandlingStrategyTest {
         assertQFJMessageProcessorThreads(0);
 
         initiatorThread.join();
+    }
+
+    @Test
+    public void shouldCreateCorrectTypeOfQueueTracker() throws Exception {
+        assertFalse(getField(
+                new SingleThreadedEventHandlingStrategy(null, 42),
+                "queueTracker",
+                QueueTracker.class) instanceof WatermarkTracker);
+
+        assertTrue(getField(
+                new SingleThreadedEventHandlingStrategy(null, 42, 43),
+                "queueTracker",
+                QueueTracker.class) instanceof WatermarkTracker);
+
+        assertFalse(getField(
+                new SingleThreadedEventHandlingStrategy(null, -1, -1),
+                "queueTracker",
+                QueueTracker.class) instanceof WatermarkTracker);
     }
 
     private SocketAcceptor createAcceptor(int i) throws ConfigError {


### PR DESCRIPTION
When creating an initiator or an acceptor (both synchronous and thread-per-session) without specifying either queue size or watermarks, the watermark tracker is still created and is working incorrectly immediately blocking the reads (queue size 0 is > upper watermark of -1).

Watermarks should only be activated when the queue size is not specified and both lower and upper watermarks are configured to values > 0.