### PR TITLE
QFJ-965 Fixed regression when using non-default charset

### DIFF
--- a/quickfixj-core/src/main/java/org/quickfixj/CharsetSupport.java
+++ b/quickfixj-core/src/main/java/org/quickfixj/CharsetSupport.java
@@ -29,6 +29,7 @@ public class CharsetSupport {
 
     private static String charset = getDefaultCharset();
     private static Charset charsetInstance = Charset.forName(charset);
+    private static boolean isStringEquivalent = isStringEquivalent(charsetInstance);
 
     public static String getDefaultCharset() {
         return "ISO-8859-1";
@@ -47,9 +48,20 @@ public class CharsetSupport {
         return charset.equals(CHARSET_ISO_8859_1) || charset.equals(CHARSET_ASCII);
     }
 
+    /**
+     * Returns whether the current charset's byte representation of a string
+     * is equivalent (as unsigned values) to the string characters themselves.
+     *
+     * @return whether the charset encoding is string-equivalent
+     */
+    public static boolean isStringEquivalent() {
+        return isStringEquivalent;
+    }
+
     public static void setCharset(String charset) throws UnsupportedEncodingException {
         CharsetSupport.charset = validate(charset);
         CharsetSupport.charsetInstance = Charset.forName(charset);
+        CharsetSupport.isStringEquivalent = isStringEquivalent(charsetInstance);
     }
 
     public static String getCharset() {

--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -142,8 +142,6 @@ public class Message extends FieldMap {
         }
     };
 
-    protected static boolean IS_STRING_EQUIVALENT = CharsetSupport.isStringEquivalent(CharsetSupport.getCharsetInstance());
-
     /**
      * Do not call this method concurrently while modifying the contents of the message.
      * This is likely to produce unexpected results or will fail with a ConcurrentModificationException
@@ -156,7 +154,7 @@ public class Message extends FieldMap {
     @Override
     public String toString() {
         Context context = stringContexts.get();
-        if (IS_STRING_EQUIVALENT) { // length & checksum can easily be calculated after message is built
+        if (CharsetSupport.isStringEquivalent()) { // length & checksum can easily be calculated after message is built
             header.setField(context.bodyLength);
             trailer.setField(context.checkSum);
         } else {
@@ -168,7 +166,7 @@ public class Message extends FieldMap {
             header.calculateString(stringBuilder, null, null);
             calculateString(stringBuilder, null, null);
             trailer.calculateString(stringBuilder, null, null);
-            if (IS_STRING_EQUIVALENT) {
+            if (CharsetSupport.isStringEquivalent()) {
                 setBodyLength(stringBuilder);
                 setChecksum(stringBuilder);
             }

--- a/quickfixj-core/src/test/java/quickfix/MessageTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageTest.java
@@ -303,16 +303,14 @@ public class MessageTest {
 
     private void doTestMessageWithEncodedField(String charset, String text) throws Exception {
         CharsetSupport.setCharset(charset);
-        NewOrderSingle order = createNewOrderSingle();
-        NewOrderSingle.IS_STRING_EQUIVALENT = CharsetSupport.isStringEquivalent(CharsetSupport.getCharsetInstance());
         try {
+            NewOrderSingle order = createNewOrderSingle();
             order.set(new EncodedTextLen(MessageUtils.length(CharsetSupport.getCharsetInstance(), text)));
             order.set(new EncodedText(text));
             final Message msg = new Message(order.toString(), DataDictionaryTest.getDictionary());
             assertEquals(charset + " encoded field", text, msg.getString(EncodedText.FIELD));
         } finally {
             CharsetSupport.setCharset(CharsetSupport.getDefaultCharset());
-            NewOrderSingle.IS_STRING_EQUIVALENT = CharsetSupport.isStringEquivalent(CharsetSupport.getCharsetInstance());
         }
     }
 


### PR DESCRIPTION
The optimizations in commit 6229d0722d8c6f6e7b2b251772a92caf2f4bdc25 cause a regression where using fields with a non-default charset such as UTF-8 causes message corruption (even if the charset is properly set via CharsetSupport.setCharset()).

Further, the test that caught this regression (MessageTest.testMessageWithEncodedField via its helper method) was modified in the same commit to work around the test failure, so that the test passes but the bug still occurs in real applications.