### PR TITLE
Make DecimalFormat ThreadLocal to fix potential thread safety problems

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Application.java
+++ b/quickfixj-core/src/main/java/quickfix/Application.java
@@ -67,7 +67,7 @@ public interface Application {
 
     /**
      * This callback notifies you when an administrative message is sent from a
-     * counterparty to your FIX engine. This can be usefull for doing extra
+     * counterparty to your FIX engine. This can be useful for doing extra
      * validation on logon messages such as for checking passwords. Throwing a
      * RejectLogon exception will disconnect the counterparty.
      *

--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -218,10 +218,10 @@ public class Message extends FieldMap {
         return header.calculateLength() + calculateLength() + trailer.calculateLength();
     }
 
-    private static final DecimalFormat checksumFormat = new DecimalFormat("000");
+    private static final ThreadLocal<DecimalFormat> checksumFormat = ThreadLocal.withInitial(() -> new DecimalFormat("000"));
 
     private String checksum() {
-        return checksumFormat.format(
+        return checksumFormat.get().format(
             (header.calculateChecksum() + calculateChecksum() + trailer.calculateChecksum()) & 0xFF);
     }
 


### PR DESCRIPTION
This addresses the longstanding thread safety issue with DecimalFormat: http://sourceforge.net/mailarchive/forum.php?thread_name=1F6BAA78-6704-418C-8EDE-88FDCFFB9938%40parityenergy.com&forum_name=quickfixj-users

In the event it's already being used by people in a multi-threaded fashion this should make it more performant too because there's now one per thread rather than just one.