### PR TITLE
QFJ-976: GarbledMessage without MsgType

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/acceptor/AcceptorIoHandler.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/acceptor/AcceptorIoHandler.java
@@ -19,12 +19,7 @@
 
 package quickfix.mina.acceptor;
 
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
-
 import org.apache.mina.core.session.IoSession;
-
 import quickfix.Log;
 import quickfix.Message;
 import quickfix.MessageUtils;
@@ -39,6 +34,11 @@ import quickfix.mina.EventHandlingStrategy;
 import quickfix.mina.IoSessionResponder;
 import quickfix.mina.NetworkingOptions;
 import quickfix.mina.SessionConnector;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Optional;
 
 class AcceptorIoHandler extends AbstractIoHandler {
     private final EventHandlingStrategy eventHandlingStrategy;
@@ -61,7 +61,8 @@ class AcceptorIoHandler extends AbstractIoHandler {
     protected void processMessage(IoSession protocolSession, Message message) throws Exception {
         Session qfSession = (Session) protocolSession.getAttribute(SessionConnector.QF_SESSION);
         if (qfSession == null) {
-            if (message.getHeader().getString(MsgType.FIELD).equals(MsgType.LOGON)) {
+            final Optional<String> msgTypeField = message.getHeader().getOptionalString(MsgType.FIELD);
+            if (msgTypeField.isPresent() && msgTypeField.get().equals(MsgType.LOGON)) {
                 final SessionID sessionID = MessageUtils.getReverseSessionID(message);
                 qfSession = sessionProvider.getSession(sessionID, eventHandlingStrategy.getSessionConnector());
                 if (qfSession != null) {

--- a/quickfixj-core/src/main/java/quickfix/mina/initiator/InitiatorIoHandler.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/initiator/InitiatorIoHandler.java
@@ -34,6 +34,8 @@ import quickfix.mina.IoSessionResponder;
 import quickfix.mina.NetworkingOptions;
 import quickfix.mina.SessionConnector;
 
+import java.util.Optional;
+
 class InitiatorIoHandler extends AbstractIoHandler {
     private final Session quickfixSession;
     private final EventHandlingStrategy eventHandlingStrategy;
@@ -61,7 +63,8 @@ class InitiatorIoHandler extends AbstractIoHandler {
 
     @Override
     protected void processMessage(IoSession protocolSession, Message message) throws Exception {
-        if (message.getHeader().getString(MsgType.FIELD).equals(MsgType.LOGON)) {
+        final Optional<String> msgTypeField = message.getHeader().getOptionalString(MsgType.FIELD);
+        if (msgTypeField.isPresent() && msgTypeField.get().equals(MsgType.LOGON)) {
             final SessionID sessionID = MessageUtils.getReverseSessionID(message);
             if (sessionID.isFIXT()) {
                 if (message.isSetField(DefaultApplVerID.FIELD)) {

--- a/quickfixj-core/src/test/java/quickfix/mina/SessionConnectorStub.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/SessionConnectorStub.java
@@ -1,0 +1,21 @@
+package quickfix.mina;
+
+import quickfix.ConfigError;
+import quickfix.RuntimeError;
+import quickfix.SessionSettings;
+
+public class SessionConnectorStub extends SessionConnector {
+
+    public SessionConnectorStub(final SessionSettings settings) throws ConfigError {
+        super(settings, null);
+    }
+
+    @Override
+    public void start() throws RuntimeError {
+    }
+
+    @Override
+    public void stop(final boolean force) {
+    }
+
+}

--- a/quickfixj-core/src/test/java/quickfix/mina/acceptor/AcceptorIoHandlerTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/acceptor/AcceptorIoHandlerTest.java
@@ -19,29 +19,38 @@
 
 package quickfix.mina.acceptor;
 
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import org.apache.mina.core.session.IoSession;
 import org.junit.Test;
 import quickfix.FixVersions;
+import quickfix.Message;
+import quickfix.Responder;
 import quickfix.Session;
 import quickfix.SessionFactoryTestSupport;
 import quickfix.SessionID;
+import quickfix.SessionSettings;
+import quickfix.SessionSettingsTest;
 import quickfix.UnitTestApplication;
 import quickfix.field.ApplVerID;
 import quickfix.field.DefaultApplVerID;
 import quickfix.field.EncryptMethod;
 import quickfix.field.HeartBtInt;
 import quickfix.field.MsgSeqNum;
+import quickfix.field.MsgType;
 import quickfix.field.SenderCompID;
 import quickfix.field.SendingTime;
 import quickfix.field.TargetCompID;
+import quickfix.field.Text;
 import quickfix.fix44.Logout;
 import quickfix.fixt11.Logon;
 import quickfix.mina.EventHandlingStrategy;
 import quickfix.mina.NetworkingOptions;
+import quickfix.mina.SessionConnector;
+import quickfix.mina.SessionConnectorStub;
+import quickfix.mina.SingleThreadedEventHandlingStrategy;
 import quickfix.mina.acceptor.AbstractSocketAcceptor.StaticAcceptorSessionProvider;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Properties;
 
@@ -50,16 +59,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.stub;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import quickfix.ConfigError;
-import quickfix.Message;
-import quickfix.Responder;
-import quickfix.RuntimeError;
-import quickfix.SessionSettings;
-import quickfix.SessionSettingsTest;
-import quickfix.field.MsgType;
-import quickfix.field.Text;
-import quickfix.mina.SessionConnector;
-import quickfix.mina.SingleThreadedEventHandlingStrategy;
 
 public class AcceptorIoHandlerTest {
 
@@ -217,13 +216,7 @@ public class AcceptorIoHandlerTest {
     @Test
     public void testRejectGarbledMessage() throws Exception {
         SessionSettings settings = SessionSettingsTest.setUpSession(null);
-        SessionConnector connector = new SessionConnector(settings, null) {
-            @Override
-            public void start() throws ConfigError, RuntimeError {}
-            
-            @Override
-            public void stop(boolean force) {}
-        };
+        SessionConnector connector = new SessionConnectorStub(settings);
         SingleThreadedEventHandlingStrategy eventHandlingStrategy = new SingleThreadedEventHandlingStrategy(connector, 1000);
         IoSession mockIoSession = mock(IoSession.class);
 

--- a/quickfixj-core/src/test/java/quickfix/mina/initiator/InitiatorIoHandlerTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/initiator/InitiatorIoHandlerTest.java
@@ -1,0 +1,143 @@
+package quickfix.mina.initiator;
+
+import org.apache.mina.core.session.IoSession;
+import org.junit.Test;
+import quickfix.FixVersions;
+import quickfix.Message;
+import quickfix.Responder;
+import quickfix.Session;
+import quickfix.SessionFactoryTestSupport;
+import quickfix.SessionID;
+import quickfix.SessionSettings;
+import quickfix.SessionSettingsTest;
+import quickfix.UnitTestApplication;
+import quickfix.field.ApplVerID;
+import quickfix.field.DefaultApplVerID;
+import quickfix.field.EncryptMethod;
+import quickfix.field.HeartBtInt;
+import quickfix.field.MsgSeqNum;
+import quickfix.field.MsgType;
+import quickfix.field.SenderCompID;
+import quickfix.field.SendingTime;
+import quickfix.field.TargetCompID;
+import quickfix.field.Text;
+import quickfix.fixt11.Logon;
+import quickfix.mina.EventHandlingStrategy;
+import quickfix.mina.NetworkingOptions;
+import quickfix.mina.SessionConnector;
+import quickfix.mina.SessionConnectorStub;
+import quickfix.mina.SingleThreadedEventHandlingStrategy;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.stub;
+
+public class InitiatorIoHandlerTest {
+
+    // QFJ-976
+    @Test
+    public void testRejectGarbledMessage() throws Exception {
+        final SessionSettings settings = SessionSettingsTest.setUpSession(null);
+        final SessionConnector connector = new SessionConnectorStub(settings);
+        final SingleThreadedEventHandlingStrategy eventHandlingStrategy =
+                new SingleThreadedEventHandlingStrategy(connector, 1000);
+        final IoSession mockIoSession = mock(IoSession.class);
+        final Responder responder = mock(Responder.class);
+
+        final SessionID sessionID = new SessionID(FixVersions.BEGINSTRING_FIXT11, "SENDER",
+                "TARGET");
+        final UnitTestApplication unitTestApplication = new UnitTestApplication();
+
+        try (Session session = SessionFactoryTestSupport
+                .createSession(sessionID, unitTestApplication, false, true, true, true, new DefaultApplVerID(
+                        ApplVerID.FIX50SP2))) {
+            session.setRejectGarbledMessage(true);
+            eventHandlingStrategy.blockInThread();
+            stub(mockIoSession.getAttribute("QF_SESSION")).toReturn(null); // to create a new Session
+
+            final InitiatorIoHandler handler = new InitiatorIoHandler(session,
+                    new NetworkingOptions(new Properties()), eventHandlingStrategy);
+
+            final DefaultApplVerID defaultApplVerID = new DefaultApplVerID(ApplVerID.FIX50SP2);
+            final Logon message = new Logon(new EncryptMethod(EncryptMethod.NONE_OTHER),
+                    new HeartBtInt(30), defaultApplVerID);
+            message.getHeader().setString(TargetCompID.FIELD, sessionID.getSenderCompID());
+            message.getHeader().setString(SenderCompID.FIELD, sessionID.getTargetCompID());
+            message.getHeader().setField(new SendingTime(LocalDateTime.now(ZoneOffset.UTC)));
+            message.getHeader().setInt(MsgSeqNum.FIELD, 1);
+
+            handler.messageReceived(mockIoSession, message.toString());
+            session.setResponder(responder);
+            // wait some time for EventHandlingStrategy to poll the message
+            Thread.sleep(EventHandlingStrategy.THREAD_WAIT_FOR_MESSAGE_MS * 2);
+
+            assertEquals(2, session.getStore().getNextTargetMsgSeqNum());
+            assertEquals(2, session.getStore().getNextSenderMsgSeqNum());
+            stub(mockIoSession.getAttribute("QF_SESSION")).toReturn(session);
+
+            // garbled: character as group count
+            String fixString = "8=FIXT.1.19=6835=B34=249=TARGET52=20180623-22:06:28.97756=SENDER148=foo33=a10=248";
+            handler.messageReceived(mockIoSession, fixString);
+            // wait some time for EventHandlingStrategy to poll the message
+            Thread.sleep(EventHandlingStrategy.THREAD_WAIT_FOR_MESSAGE_MS * 2);
+
+            // ensure that seqnums are incremented (i.e. message is not ignored)
+            assertEquals(3, session.getStore().getNextTargetMsgSeqNum());
+            assertEquals(3, session.getStore().getNextSenderMsgSeqNum());
+
+            Message lastToAdminMessage = unitTestApplication.lastToAdminMessage();
+            assertEquals(MsgType.REJECT, lastToAdminMessage.getHeader().getString(MsgType.FIELD));
+            assertEquals("Message failed basic validity check", lastToAdminMessage.getString(Text.FIELD));
+
+            // garbled: missing msgtype
+            fixString = "8=FIXT.1.19=6834=349=TARGET52=20180623-22:06:28.97756=SENDER148=foo33=a10=248";
+            handler.messageReceived(mockIoSession, fixString);
+            // wait some time for EventHandlingStrategy to poll the message
+            Thread.sleep(EventHandlingStrategy.THREAD_WAIT_FOR_MESSAGE_MS * 2);
+
+            // ensure that seqnums are incremented (i.e. message is not ignored)
+            assertEquals(4, session.getStore().getNextTargetMsgSeqNum());
+            assertEquals(4, session.getStore().getNextSenderMsgSeqNum());
+
+            lastToAdminMessage = unitTestApplication.lastToAdminMessage();
+            assertEquals(MsgType.REJECT, lastToAdminMessage.getHeader().getString(MsgType.FIELD));
+            assertEquals("Message failed basic validity check", lastToAdminMessage.getString(Text.FIELD));
+
+            // garbled: wrong checksum
+            fixString = "8=FIXT.1.19=6835=B34=449=TARGET52=20180623-22:06:28.97756=SENDER148=foo33=110=256";
+            handler.messageReceived(mockIoSession, fixString);
+            // wait some time for EventHandlingStrategy to poll the message
+            Thread.sleep(EventHandlingStrategy.THREAD_WAIT_FOR_MESSAGE_MS * 2);
+
+            // ensure that seqnums are incremented (i.e. message is not ignored)
+            assertEquals(5, session.getStore().getNextTargetMsgSeqNum());
+            assertEquals(5, session.getStore().getNextSenderMsgSeqNum());
+
+            lastToAdminMessage = unitTestApplication.lastToAdminMessage();
+            assertEquals(MsgType.REJECT, lastToAdminMessage.getHeader().getString(MsgType.FIELD));
+            assertEquals("Message failed basic validity check", lastToAdminMessage.getString(Text.FIELD));
+
+            // garbled: invalid tag 49garbled
+            fixString = "8=FIXT.1.19=6835=B34=549garbled=TARGET52=20180623-22:06:28.97756=SENDER148=foo33=110=256";
+            handler.messageReceived(mockIoSession, fixString);
+            // wait some time for EventHandlingStrategy to poll the message
+            Thread.sleep(EventHandlingStrategy.THREAD_WAIT_FOR_MESSAGE_MS * 2);
+
+            // ensure that seqnums are incremented (i.e. message is not ignored)
+            assertEquals(6, session.getStore().getNextTargetMsgSeqNum());
+            assertEquals(6, session.getStore().getNextSenderMsgSeqNum());
+
+            lastToAdminMessage = unitTestApplication.lastToAdminMessage();
+            assertEquals(MsgType.REJECT, lastToAdminMessage.getHeader().getString(MsgType.FIELD));
+            assertEquals("Message failed basic validity check", lastToAdminMessage.getString(Text.FIELD));
+
+        } finally {
+            eventHandlingStrategy.stopHandlingMessages(true);
+        }
+    }
+
+}


### PR DESCRIPTION
* Added the same test for all garbled messages that we have in AcceptorIoHandler
* I used Optional, but I couldn't use ifPresent block because this block of code is throwing checked exception
* In AcceptorIoHandler theoretically we could have the same issue, but check for message type is 'guarded' by session check 

```java
Session qfSession = (Session) protocolSession.getAttribute(SessionConnector.QF_SESSION);
        if (qfSession == null) {
            if (message.getHeader().getString(MsgType.FIELD).equals(MsgType.LOGON)) {
```

I don't know if it is valid use case that we could receive GarbledMessage before Logon message. If it is valid then I can adjust this class as well. 
