### PR TITLE
QFJ-962: FieldMap.setField(int key, Field<?> field) does not properly convert values

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/BooleanField.java
+++ b/quickfixj-core/src/main/java/quickfix/BooleanField.java
@@ -19,6 +19,8 @@
 
 package quickfix;
 
+import quickfix.field.converter.BooleanConverter;
+
 import java.lang.Boolean;
 
 public class BooleanField extends Field<Boolean> {
@@ -54,4 +56,10 @@ public class BooleanField extends Field<Boolean> {
     public boolean valueEquals(boolean value) {
         return getObject().equals(value);
     }
+
+    @Override
+    public String convertToString() {
+        return BooleanConverter.convert(getValue());
+    }
+
 }

--- a/quickfixj-core/src/main/java/quickfix/BytesField.java
+++ b/quickfixj-core/src/main/java/quickfix/BytesField.java
@@ -19,9 +19,7 @@
 
 package quickfix;
 
-import java.io.UnsupportedEncodingException;
-
-import org.quickfixj.QFJException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * BytesField enables better handling of binary data. With BytesFields binary data can
@@ -47,11 +45,12 @@ public class BytesField extends Field<byte[]> {
 
     @Override
     protected String objectAsString() {
-        try {
-            return new String(getObject(), "UTF8");
-        } catch (UnsupportedEncodingException e) {
-            throw new QFJException(e);
-        }
+        return new String(getObject(), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public String convertToString() {
+        return objectAsString();
     }
 
 }

--- a/quickfixj-core/src/main/java/quickfix/CharField.java
+++ b/quickfixj-core/src/main/java/quickfix/CharField.java
@@ -19,6 +19,8 @@
 
 package quickfix;
 
+import quickfix.field.converter.CharConverter;
+
 import java.lang.Character;
 
 /**
@@ -57,4 +59,10 @@ public class CharField extends Field<Character> {
     public boolean valueEquals(char value) {
         return getObject().equals(value);
     }
+
+    @Override
+    public String convertToString() {
+        return CharConverter.convert(getValue());
+    }
+
 }

--- a/quickfixj-core/src/main/java/quickfix/DateField.java
+++ b/quickfixj-core/src/main/java/quickfix/DateField.java
@@ -19,6 +19,8 @@
 
 package quickfix;
 
+import quickfix.field.converter.UtcTimestampConverter;
+
 import java.util.Date;
 
 /**
@@ -45,4 +47,10 @@ public class DateField extends Field<Date> {
     public boolean valueEquals(Date value) {
         return getValue().equals(value);
     }
+
+    @Override
+    public String convertToString() {
+        return UtcTimestampConverter.convert(getValue(), true);
+    }
+
 }

--- a/quickfixj-core/src/main/java/quickfix/DecimalField.java
+++ b/quickfixj-core/src/main/java/quickfix/DecimalField.java
@@ -19,6 +19,8 @@
 
 package quickfix;
 
+import quickfix.field.converter.DecimalConverter;
+
 import java.math.BigDecimal;
 
 /**
@@ -68,4 +70,10 @@ public class DecimalField extends Field<BigDecimal> {
     public boolean valueEquals(double value) {
         return getValue().compareTo(new BigDecimal(value)) == 0;
     }
+
+    @Override
+    public String convertToString() {
+        return DecimalConverter.convert(getValue(), getPadding());
+    }
+
 }

--- a/quickfixj-core/src/main/java/quickfix/DoubleField.java
+++ b/quickfixj-core/src/main/java/quickfix/DoubleField.java
@@ -19,6 +19,8 @@
 
 package quickfix;
 
+import quickfix.field.converter.DoubleConverter;
+
 /**
  * A double-values message field.
  */
@@ -78,4 +80,10 @@ public class DoubleField extends Field<Double> {
             throw new NumberFormatException("Tried to set NaN or infinite value.");
         }
     }
+
+    @Override
+    public String convertToString() {
+        return DoubleConverter.convert(getValue(), getPadding());
+    }
+
 }

--- a/quickfixj-core/src/main/java/quickfix/Field.java
+++ b/quickfixj-core/src/main/java/quickfix/Field.java
@@ -24,11 +24,9 @@ import org.quickfixj.CharsetSupport;
 import java.io.Serializable;
 
 /**
- * Base class for FIX message fields. This class should be
- * abstract but that would break compatibility with the QF JNI
- * classes.
+ * Base class for FIX message fields.
  */
-public /*abstract*/ class Field<T> implements Serializable {
+public abstract class Field<T> implements Serializable {
     static final long serialVersionUID = 7098326013456432197L;
     private int tag;
     private T object;
@@ -152,4 +150,7 @@ public /*abstract*/ class Field<T> implements Serializable {
         isCalculated = false;
         calculate();
     }
+
+    public abstract String convertToString();
+
 }

--- a/quickfixj-core/src/main/java/quickfix/FieldMap.java
+++ b/quickfixj-core/src/main/java/quickfix/FieldMap.java
@@ -86,8 +86,8 @@ public abstract class FieldMap implements Serializable {
 
     public void reset() {
         fields.clear();
-        for(List<Group> groupList : groups.values()) {
-            for(Group group : groupList)
+        for (List<Group> groupList : groups.values()) {
+            for (Group group : groupList)
                 group.reset();
         }
         groups.clear();
@@ -194,7 +194,9 @@ public abstract class FieldMap implements Serializable {
     }
 
     public void setUtcTimeStamp(int field, LocalDateTime value, boolean includeMilliseconds) {
-        setField(new StringField(field, UtcTimestampConverter.convert(value, includeMilliseconds ? UtcTimestampPrecision.MILLIS : UtcTimestampPrecision.SECONDS)));
+        setField(new StringField(field, UtcTimestampConverter.convert(value, includeMilliseconds ?
+                UtcTimestampPrecision.MILLIS :
+                UtcTimestampPrecision.SECONDS)));
     }
 
     public void setUtcTimeStamp(int field, LocalDateTime value, UtcTimestampPrecision precision) {
@@ -206,7 +208,9 @@ public abstract class FieldMap implements Serializable {
     }
 
     public void setUtcTimeOnly(int field, LocalTime value, boolean includeMilliseconds) {
-        setField(new StringField(field, UtcTimeOnlyConverter.convert(value, includeMilliseconds ? UtcTimestampPrecision.MILLIS : UtcTimestampPrecision.SECONDS)));
+        setField(new StringField(field, UtcTimeOnlyConverter.convert(value, includeMilliseconds ?
+                UtcTimestampPrecision.MILLIS :
+                UtcTimestampPrecision.SECONDS)));
     }
 
     public void setUtcTimeOnly(int field, LocalTime value, UtcTimestampPrecision precision) {
@@ -319,6 +323,10 @@ public abstract class FieldMap implements Serializable {
     }
 
     public void setField(int key, Field<?> field) {
+        setString(key, field.convertToString());
+    }
+
+    public void setField(int key, BytesField field) {
         fields.put(key, field);
     }
 
@@ -509,7 +517,8 @@ public abstract class FieldMap implements Serializable {
         }
     }
 
-    private static final boolean IS_STRING_EQUIVALENT = CharsetSupport.isStringEquivalent(CharsetSupport.getCharsetInstance());
+    private static final boolean IS_STRING_EQUIVALENT = CharsetSupport
+            .isStringEquivalent(CharsetSupport.getCharsetInstance());
 
     int calculateLength() {
         int result = 0;
@@ -524,11 +533,14 @@ public abstract class FieldMap implements Serializable {
         for (Entry<Integer, List<Group>> entry : groups.entrySet()) {
             final List<Group> groupList = entry.getValue();
             if (!groupList.isEmpty()) {
-                if(IS_STRING_EQUIVALENT) {
-                    result += getStringLength(entry.getKey()) + getStringLength(groupList.size()) + 2;
+                if (IS_STRING_EQUIVALENT) {
+                    result +=
+                            getStringLength(entry.getKey()) + getStringLength(groupList.size()) + 2;
                 } else {
-                    result += MessageUtils.length(CharsetSupport.getCharsetInstance(), NumbersCache.get(entry.getKey()));
-                    result += MessageUtils.length(CharsetSupport.getCharsetInstance(), NumbersCache.get(groupList.size()));
+                    result += MessageUtils.length(CharsetSupport.getCharsetInstance(),
+                            NumbersCache.get(entry.getKey()));
+                    result += MessageUtils.length(CharsetSupport.getCharsetInstance(),
+                            NumbersCache.get(groupList.size()));
                     result += 2;
                 }
                 for (int i = 0; i < groupList.size(); i++) {
@@ -540,9 +552,10 @@ public abstract class FieldMap implements Serializable {
     }
 
     private static int getStringLength(int num) {
-        if(num == 0)
+        if (num == 0) {
             return 1;
-        return (int)(num > 0 ? Math.log10(num) + 1 : Math.log10(-num) + 2);
+        }
+        return (int) (num > 0 ? Math.log10(num) + 1 : Math.log10(-num) + 2);
     }
 
     int calculateChecksum() {
@@ -556,12 +569,12 @@ public abstract class FieldMap implements Serializable {
         for (Entry<Integer, List<Group>> entry : groups.entrySet()) {
             final List<Group> groupList = entry.getValue();
             if (!groupList.isEmpty()) {
-                if(IS_STRING_EQUIVALENT) {
+                if (IS_STRING_EQUIVALENT) {
                     String value = NumbersCache.get(entry.getKey());
-                    for (int i = value.length(); i-- != 0;)
+                    for (int i = value.length(); i-- != 0; )
                         result += value.charAt(i);
                     value = NumbersCache.get(groupList.size());
-                    for (int i = value.length(); i-- != 0;)
+                    for (int i = value.length(); i-- != 0; )
                         result += value.charAt(i);
                     result += '=' + 1;
                 } else {
@@ -694,5 +707,4 @@ public abstract class FieldMap implements Serializable {
         return hasGroup(group.getFieldTag());
     }
 
-    
 }

--- a/quickfixj-core/src/main/java/quickfix/IntField.java
+++ b/quickfixj-core/src/main/java/quickfix/IntField.java
@@ -19,6 +19,8 @@
 
 package quickfix;
 
+import quickfix.field.converter.IntConverter;
+
 import java.lang.Integer;
 
 /**
@@ -57,4 +59,10 @@ public class IntField extends Field<Integer> {
     public boolean valueEquals(int value) {
         return getObject().equals(value);
     }
+
+    @Override
+    public String convertToString() {
+        return IntConverter.convert(getValue());
+    }
+
 }

--- a/quickfixj-core/src/main/java/quickfix/StringField.java
+++ b/quickfixj-core/src/main/java/quickfix/StringField.java
@@ -43,4 +43,10 @@ public class StringField extends Field<String> {
     public boolean valueEquals(String value) {
         return getValue().equals(value);
     }
+
+    @Override
+    public String convertToString() {
+        return getValue();
+    }
+
 }

--- a/quickfixj-core/src/main/java/quickfix/UtcDateField.java
+++ b/quickfixj-core/src/main/java/quickfix/UtcDateField.java
@@ -19,6 +19,8 @@
 
 package quickfix;
 
+import quickfix.field.converter.UtcDateOnlyConverter;
+
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 
@@ -46,5 +48,10 @@ public class UtcDateField extends Field<LocalDate> {
     public boolean valueEquals(LocalDate value) {
         return getValue().equals(value);
     }
-    
+
+    @Override
+    public String convertToString() {
+        return UtcDateOnlyConverter.convert(getValue());
+    }
+
 }

--- a/quickfixj-core/src/main/java/quickfix/UtcDateOnlyField.java
+++ b/quickfixj-core/src/main/java/quickfix/UtcDateOnlyField.java
@@ -19,6 +19,8 @@
 
 package quickfix;
 
+import quickfix.field.converter.UtcDateOnlyConverter;
+
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 
@@ -34,7 +36,7 @@ public class UtcDateOnlyField extends Field<LocalDate> {
     protected UtcDateOnlyField(int field, LocalDate data) {
         super(field, data);
     }
-        
+
     public void setValue(LocalDate value) {
         setObject(value);
     }
@@ -45,6 +47,11 @@ public class UtcDateOnlyField extends Field<LocalDate> {
 
     public boolean valueEquals(LocalDate value) {
         return getValue().equals(value);
+    }
+
+    @Override
+    public String convertToString() {
+        return UtcDateOnlyConverter.convert(getValue());
     }
 
 }

--- a/quickfixj-core/src/main/java/quickfix/UtcTimeField.java
+++ b/quickfixj-core/src/main/java/quickfix/UtcTimeField.java
@@ -19,6 +19,8 @@
 
 package quickfix;
 
+import quickfix.field.converter.UtcTimeOnlyConverter;
+
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 
@@ -53,8 +55,14 @@ public class UtcTimeField extends Field<LocalTime> {
     public boolean valueEquals(LocalTime value) {
         return getValue().equals(value);
     }
-    
+
     public UtcTimestampPrecision getPrecision() {
         return precision;
     }
+
+    @Override
+    public String convertToString() {
+        return UtcTimeOnlyConverter.convert(getValue(), getPrecision());
+    }
+
 }

--- a/quickfixj-core/src/main/java/quickfix/UtcTimeOnlyField.java
+++ b/quickfixj-core/src/main/java/quickfix/UtcTimeOnlyField.java
@@ -19,6 +19,8 @@
 
 package quickfix;
 
+import quickfix.field.converter.UtcTimeOnlyConverter;
+
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 
@@ -26,7 +28,7 @@ import java.time.ZoneOffset;
  * A time-valued message field.
  */
 public class UtcTimeOnlyField extends Field<LocalTime> {
-    
+
     private UtcTimestampPrecision precision = UtcTimestampPrecision.MILLIS;
 
     public UtcTimeOnlyField(int field) {
@@ -51,11 +53,11 @@ public class UtcTimeOnlyField extends Field<LocalTime> {
         super(field, data);
         this.precision = includeMilliseconds ? UtcTimestampPrecision.MILLIS : UtcTimestampPrecision.SECONDS;
     }
-    
+
     public UtcTimestampPrecision getPrecision() {
         return precision;
     }
-    
+
     public void setValue(LocalTime value) {
         setObject(value);
     }
@@ -66,6 +68,11 @@ public class UtcTimeOnlyField extends Field<LocalTime> {
 
     public boolean valueEquals(LocalTime value) {
         return getValue().equals(value);
+    }
+
+    @Override
+    public String convertToString() {
+        return UtcTimeOnlyConverter.convert(getValue(), getPrecision());
     }
 
 }

--- a/quickfixj-core/src/main/java/quickfix/UtcTimeStampField.java
+++ b/quickfixj-core/src/main/java/quickfix/UtcTimeStampField.java
@@ -19,6 +19,8 @@
 
 package quickfix;
 
+import quickfix.field.converter.UtcTimestampConverter;
+
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
@@ -56,11 +58,11 @@ public class UtcTimeStampField extends Field<LocalDateTime> {
         super(field, data);
         this.precision = includeMilliseconds ? UtcTimestampPrecision.MILLIS : UtcTimestampPrecision.SECONDS;
     }
-    
+
     public UtcTimestampPrecision getPrecision() {
         return precision;
     }
-    
+
     public void setValue(LocalDateTime value) {
         setObject(value);
     }
@@ -71,6 +73,11 @@ public class UtcTimeStampField extends Field<LocalDateTime> {
 
     public boolean valueEquals(LocalDateTime value) {
         return getValue().equals(value);
+    }
+
+    @Override
+    public String convertToString() {
+        return UtcTimestampConverter.convert(getValue(), getPrecision());
     }
 
 }

--- a/quickfixj-core/src/test/java/quickfix/FieldTest.java
+++ b/quickfixj-core/src/test/java/quickfix/FieldTest.java
@@ -53,7 +53,7 @@ public class FieldTest {
     }
 
     private void testFieldCalcuations(String value, int checksum, int length) {
-        Field<String> field = new Field<>(12, value);
+        Field<String> field = new StringField(12, value);
         field.setObject(value);
         assertEquals("12=" + value, field.toString());
         assertEquals(checksum, field.getChecksum());


### PR DESCRIPTION
I have some concers:

1. I wasn't really sure how to convert DateField / UtcTimeField / UtcDateField. Check how I did it.
2. Abstract method convertToString requires changes from users that made custom extensions of Field class. I don't know it is an use case, but it was possible to do. 

What I did:

* I made Field abstract
* Added abstract method convertToString
* I added method setField(int, BytesField), but I am not sure about concept with BytesField. I have seen in comments and implementation that we don't convert BytesField into StringField, but for example there is method getField(int)

```java
    StringField getField(int field) throws FieldNotFound {
        final StringField f = (StringField) fields.get(field);
        if (f == null) {
            throw new FieldNotFound(field);
        }
        return f;
    }
```

So it will fail anytime we would try to access bytes field that was set using one of methods

```java
setField(int, BytesField)
setField(BytesField)
setBytes(int, byte[])
```

Anyway I wouldn't touch in scope of this defect.


Sorry for commit name and for small formatting changes. I used formatter and I didn't see them. 