### PR TITLE
QFJ-811: Wrong field order in AllocGrp

### DIFF
--- a/quickfixj-messages/quickfixj-messages-fix50/src/main/resources/FIX50.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50/src/main/resources/FIX50.xml
@@ -3055,6 +3055,11 @@
         <field name="AllocQty" required="N"/>
         <field name="IndividualAllocID" required="N"/>
         <field name="ProcessCode" required="N"/>
+        <field name="SecondaryIndividualAllocID" required="N"/>
+        <field name="AllocMethod" required="N"/>
+        <field name="AllocCustomerCapacity" required="N"/>
+        <field name="AllocPositionEffect" required="N"/>
+        <field name="IndividualAllocType" required="N"/>
         <component name="NestedParties"/>
         <field name="NotifyBrokerOfCredit" required="N"/>
         <field name="AllocHandlInst" required="N"/>
@@ -3074,14 +3079,9 @@
         <field name="AllocInterestAtMaturity" required="N"/>
         <component name="MiscFeesGrp"/>
         <component name="ClrInstGrp"/>
+        <field name="ClearingFeeIndicator" required="N"/>
         <field name="AllocSettlInstType" required="N"/>
         <component name="SettlInstructionsData"/>
-        <field name="SecondaryIndividualAllocID" required="N"/>
-        <field name="AllocMethod" required="N"/>
-        <field name="AllocCustomerCapacity" required="N"/>
-        <field name="IndividualAllocType" required="N"/>
-        <field name="AllocPositionEffect" required="N"/>
-        <field name="ClearingFeeIndicator" required="N"/>
       </group>
     </component>
     <component name="BidCompReqGrp">


### PR DESCRIPTION
Not big deal, but I fixed it. Somehow field order in AllocGrp was wrong in FIX50.xml file. In files for SP1 & SP2 it seems to be correct. 

Verified with: 

* Compared with FIX50.xml from http://www.quickfixengine.org/
* Compared with Fiximate https://fiximate.fixtrading.org/legacy/index.html

