### PR TITLE
Upgrade MINA to 2.1.3

### DIFF
--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
-            <version>2.0.19</version>
+            <version>2.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
We shouldn't have to do anything since we are not using `SslFilter.USE_NOTIFICATION`
https://mina.apache.org/mina-project/2.1-vs-2.0.html