### PR TITLE
Remove tests with anonymous cipher suites

### DIFF
--- a/quickfixj-core/src/test/java/quickfix/mina/ssl/SSLCertificateTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/ssl/SSLCertificateTest.java
@@ -57,7 +57,6 @@ import org.junit.After;
 public class SSLCertificateTest {
 
     // Note: To diagnose cipher suite errors, run with -Djavax.net.debug=ssl:handshake
-    private static final String CIPHER_SUITES_ANON = "TLS_DH_anon_WITH_AES_128_CBC_SHA";
     private static final String CIPHER_SUITES_TLS = "TLS_RSA_WITH_AES_128_CBC_SHA";
 
     @After
@@ -279,98 +278,6 @@ public class SSLCertificateTest {
                 initiator1.stop();
                 initiator2.stop();
                 initiator3.stop();
-            }
-        } finally {
-            acceptor.stop();
-        }
-    }
-
-    @Test
-    public void shouldCreateFixSessionWithoutAuthenticationWhenUsingEmptyServerKeyStoreWithAnonymousCipher()
-            throws Exception {
-        int freePort = AvailablePortFinder.getNextAvailable();
-        TestAcceptor acceptor = new TestAcceptor(createAcceptorSettings("single-session/empty.keystore", false,
-                "single-session/empty.keystore", CIPHER_SUITES_ANON, null, "JKS", "JKS", freePort));
-
-        try {
-            acceptor.start();
-
-            TestInitiator initiator = new TestInitiator(
-                    createInitiatorSettings("single-session/empty.keystore", "single-session/empty.keystore",
-                            CIPHER_SUITES_ANON, null, "ZULU", "ALFA", Integer.toString(freePort), "JKS", "JKS"));
-
-            try {
-                initiator.start();
-
-                initiator.assertNoSslExceptionThrown();
-                initiator.assertLoggedOn(new SessionID(FixVersions.BEGINSTRING_FIX44, "ZULU", "ALFA"));
-                initiator.assertNotAuthenticated(new SessionID(FixVersions.BEGINSTRING_FIX44, "ZULU", "ALFA"));
-
-                acceptor.assertNoSslExceptionThrown();
-                acceptor.assertLoggedOn(new SessionID(FixVersions.BEGINSTRING_FIX44, "ALFA", "ZULU"));
-                acceptor.assertNotAuthenticated(new SessionID(FixVersions.BEGINSTRING_FIX44, "ALFA", "ZULU"));
-            } finally {
-                initiator.stop();
-            }
-        } finally {
-            acceptor.stop();
-        }
-    }
-
-    @Test
-    public void shouldCreateFixSessionWithoutAuthenticationWhenTrustStoresAreMissing() throws Exception {
-        int freePort = AvailablePortFinder.getNextAvailable();
-        TestAcceptor acceptor = new TestAcceptor(createAcceptorSettings("single-session/server.keystore", false,
-                "missing", CIPHER_SUITES_ANON, null, "JKS", "JKS", freePort));
-
-        try {
-            acceptor.start();
-
-            TestInitiator initiator = new TestInitiator(createInitiatorSettings("single-session/client.keystore",
-                    "missing", CIPHER_SUITES_ANON, null, "ZULU", "ALFA", Integer.toString(freePort), "JKS", "JKS"));
-
-            try {
-                initiator.start();
-
-                initiator.assertNoSslExceptionThrown();
-                initiator.assertLoggedOn(new SessionID(FixVersions.BEGINSTRING_FIX44, "ZULU", "ALFA"));
-                initiator.assertNotAuthenticated(new SessionID(FixVersions.BEGINSTRING_FIX44, "ZULU", "ALFA"));
-
-                acceptor.assertNoSslExceptionThrown();
-                acceptor.assertLoggedOn(new SessionID(FixVersions.BEGINSTRING_FIX44, "ALFA", "ZULU"));
-                acceptor.assertNotAuthenticated(new SessionID(FixVersions.BEGINSTRING_FIX44, "ALFA", "ZULU"));
-            } finally {
-                initiator.stop();
-            }
-        } finally {
-            acceptor.stop();
-        }
-    }
-
-    @Test
-    public void shouldCreateFixSessionWithoutAuthenticationWhenUsingDefaultKeystores() throws Exception {
-        int freePort = AvailablePortFinder.getNextAvailable();
-        TestAcceptor acceptor = new TestAcceptor(createAcceptorSettings("missing", false, "missing",
-                CIPHER_SUITES_ANON, null, "JKS", "JKS", freePort));
-
-        try {
-            acceptor.start();
-
-            TestInitiator initiator = new TestInitiator(createInitiatorSettings("missing", "missing",
-                    CIPHER_SUITES_ANON, null, "ZULU", "ALFA", Integer.toString(freePort), "JKS", "JKS"));
-
-            try {
-                initiator.start();
-
-                initiator.assertNoSslExceptionThrown();
-                initiator.assertLoggedOn(new SessionID(FixVersions.BEGINSTRING_FIX44, "ZULU", "ALFA"));
-                initiator.assertNotAuthenticated(new SessionID(FixVersions.BEGINSTRING_FIX44, "ZULU", "ALFA"));
-
-                acceptor.assertNoSslExceptionThrown();
-                acceptor.assertLoggedOn(new SessionID(FixVersions.BEGINSTRING_FIX44, "ALFA", "ZULU"));
-                acceptor.assertNotAuthenticated(new SessionID(FixVersions.BEGINSTRING_FIX44, "ALFA", "ZULU"));
-            } finally {
-                initiator.stop();
             }
         } finally {
             acceptor.stop();


### PR DESCRIPTION
... they are disabled in newer JDKs due to security concerns so we should not be suggesting that this is supported.

https://bugs.openjdk.java.net/browse/JDK-8211883