### PR TITLE
Fixed Issue QFJ-983, "SLF4JLog is suffixing category with session ID …

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/SLF4JLog.java
+++ b/quickfixj-core/src/main/java/quickfix/SLF4JLog.java
@@ -62,9 +62,9 @@ public class SLF4JLog extends AbstractLog {
     }
 
     private Logger getLogger(SessionID sessionID, String category, String defaultCategory, String logPrefix) {
-        return LoggerFactory.getLogger((category != null
+        return LoggerFactory.getLogger(logPrefix + (category != null
                 ? substituteVariables(sessionID, category)
-                : defaultCategory) + logPrefix);
+                : defaultCategory));
     }
 
     private static final String FIX_MAJOR_VERSION_VAR = "\\$\\{fixMajorVersion}";

--- a/quickfixj-core/src/test/java/quickfix/SLF4JLogTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SLF4JLogTest.java
@@ -194,13 +194,13 @@ public class SLF4JLogTest {
             // The conditional is required because of a bug in SLF4J 1.0
             // when used with JDK 1.4 logging. The wrapper does not pass
             // the logger name.
-            assertEquals(categoryName + sessionID + ": ", r.getLoggerName());
+            assertEquals(sessionID + ": " + categoryName, r.getLoggerName());
         }
         assertEquals(message, r.getMessage());
     }
 
     private TestHandler getTestHandler(String categoryName, SessionID sessionID) {
-        final Logger logger = Logger.getLogger(categoryName + sessionID + ": ");
+        final Logger logger = Logger.getLogger(sessionID + ": " + categoryName);
         TestHandler testHandler = null;
         final Handler[] handlers = logger.getHandlers();
         for (final Handler handler : handlers) {
@@ -214,7 +214,7 @@ public class SLF4JLogTest {
     }
 
     private TestHandler setUpLoggerForTest(String category, SessionID sessionID) {
-        final Logger logger = Logger.getLogger(category + sessionID + ": ");
+        final Logger logger = Logger.getLogger(sessionID + ": " + category);
         logger.setUseParentHandlers(false);
         final Handler[] handlers = logger.getHandlers();
         for (final Handler handler : handlers) {


### PR DESCRIPTION
…instead of prefixing it."

JIRA:
+ https://www.quickfixj.org/jira/browse/QFJ-983

Mailing list discussion about issue:
+ https://sourceforge.net/p/quickfixj/mailman/message/36714538/