### PR TITLE
Provide correct end sequence number sent in request in logs

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -2411,9 +2411,10 @@ public class Session implements Closeable {
             final ResendRange range = state.getResendRange();
 
             if (!redundantResentRequestsAllowed && msgSeqNum >= range.getBeginSeqNo()) {
-
+                int endSeqNo = range.getEndSeqNo();
+                String end = endSeqNo == 0 ? "infinity" : Integer.toString(endSeqNo);
                 getLog().onEvent(
-                        "Already sent ResendRequest FROM: " + range.getBeginSeqNo() + " TO: " + range.getEndSeqNo()
+                        "Already sent ResendRequest FROM: " + range.getBeginSeqNo() + " TO: " + end
                                 + ".  Not sending another.");
                 return;
             }

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -2449,7 +2449,7 @@ public class Session implements Closeable {
         resendRequest.setInt(EndSeqNo.FIELD, endSeqNo);
         initializeHeader(resendRequest.getHeader());
         sendRaw(resendRequest, 0);
-        getLog().onEvent("Sent ResendRequest FROM: " + beginSeqNo + " TO: " + lastEndSeqNoSent);
+        getLog().onEvent("Sent ResendRequest FROM: " + beginSeqNo + " TO: " + (endSeqNo == 0 ? "infinity" : endSeqNo));
         state.setResendRange(beginSeqNo, msgSeqNum - 1, resendRequestChunkSize == 0
                 ? 0
                 : lastEndSeqNoSent);


### PR DESCRIPTION
It's misleading to suggest we're sending a closed range request when instead we're sending an open ended request.