### PR TITLE
Field ordering functionality.

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/FieldMap.java
+++ b/quickfixj-core/src/main/java/quickfix/FieldMap.java
@@ -442,6 +442,7 @@ public abstract class FieldMap implements Serializable {
     }
 
     protected void initializeFrom(FieldMap source) {
+        fieldOrder = source.getFieldOrder();
         fields.clear();
         fields.putAll(source.fields);
         for (Entry<Integer, List<Group>> entry : source.groups.entrySet()) {

--- a/quickfixj-core/src/main/java/quickfix/FieldMap.java
+++ b/quickfixj-core/src/main/java/quickfix/FieldMap.java
@@ -50,7 +50,7 @@ public abstract class FieldMap implements Serializable {
 
     private final int[] fieldOrder;
 
-    private final TreeMap<Integer, Field<?>> fields;
+    private final Map<Integer, Field<?>> fields;
 
     private final TreeMap<Integer, List<Group>> groups = new TreeMap<>();
 
@@ -62,7 +62,9 @@ public abstract class FieldMap implements Serializable {
      */
     protected FieldMap(int[] fieldOrder) {
         this.fieldOrder = fieldOrder;
-        fields = new TreeMap<>(fieldOrder != null ? new FieldOrderComparator() : null);
+        fields = (fieldOrder != null) ?
+                new TreeMap<>(new FieldOrderComparator()) :
+                new LinkedHashMap<>();
     }
 
     protected FieldMap() {

--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -85,7 +85,7 @@ public class Message extends FieldMap {
         initializeHeader();
     }
 
-    protected Message(int[] fieldOrder) {
+    public Message(int[] fieldOrder) {
         super(fieldOrder);
         initializeHeader();
     }

--- a/quickfixj-core/src/test/java/quickfix/DataDictionaryTest.java
+++ b/quickfixj-core/src/test/java/quickfix/DataDictionaryTest.java
@@ -55,13 +55,11 @@ import java.io.ByteArrayInputStream;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasProperty;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class DataDictionaryTest {
 
@@ -104,6 +102,24 @@ public class DataDictionaryTest {
         assertEquals("incorrect msg type", "B", dd.getMsgType("News"));
         assertFalse(dd.isMsgField("UNKNOWN_TYPE", 1));
     }
+
+    @Test
+    public void testGetOrderedRequiredFieldsForMessage() throws Exception {
+        DataDictionary dictionary = getDictionary();
+        assertArrayEquals("incorrect field ordering", new int[]{8, 9, 35, 49, 56, 34, 52, 98, 108, 10},
+                dictionary.getOrderedRequiredFieldsForMessage("A"));
+    }
+
+    @Test
+    public void testGetOrderedFieldsForMessage() throws Exception {
+        DataDictionary dictionary = getDictionary();
+        assertArrayEquals("incorrect field ordering",
+                new int[]{8, 9, 35, 49, 56, 115, 128, 90, 91, 34, 50, 142, 57, 143, 116, 144, 129, 145,
+                        43, 97, 52, 122, 212, 213, 347, 369, 627, 98, 108, 95, 96, 141, 789, 383, 384,
+                        464, 553, 554, 93, 89, 10},
+                dictionary.getOrderedFieldsForMessage("A"));
+    }
+
 
     @Test
     public void testMissingFieldAttributeForRequired() throws Exception {

--- a/quickfixj-core/src/test/java/quickfix/FieldMapTest.java
+++ b/quickfixj-core/src/test/java/quickfix/FieldMapTest.java
@@ -30,6 +30,13 @@ public class FieldMapTest extends TestCase {
         return new TestSuite(FieldMapTest.class);
     }
 
+    public void testDefaultFieldOrderIsInsertionOrdering()  {
+        FieldMap map = new Message();
+        map.setString(2, "A");
+        map.setString(1, "B");
+        assertEquals("9=82=A1=B10=017",map.toString());
+    }
+
     public void testSetUtcTimeStampField() throws Exception {
         FieldMap map = new Message();
         LocalDateTime aDate = LocalDateTime.now();
@@ -82,7 +89,7 @@ public class FieldMapTest extends TestCase {
 
     public void testOrdering() {
         testOrdering(new int[] { 1, 2, 3 }, null, new int[] { 1, 2, 3 });
-        testOrdering(new int[] { 3, 2, 1 }, null, new int[] { 1, 2, 3 });
+        testOrdering(new int[] { 3, 2, 1 }, null, new int[] { 3, 2, 1 });
         testOrdering(new int[] { 1, 2, 3 }, new int[] { 1, 2, 3 }, new int[] { 1, 2, 3 });
         testOrdering(new int[] { 3, 2, 1 }, new int[] { 1, 2, 3 }, new int[] { 1, 2, 3 });
         testOrdering(new int[] { 1, 2, 3 }, new int[] { 1, 3, 2 }, new int[] { 1, 3, 2 });


### PR DESCRIPTION
`TreeMap` is the default ordering for fields in QFJ. This provides numerical tag based ordering.

Occasionally it is useful to be able to override it to enforce a specific ordering of fields based on a provided list. 

It's also useful to be able to get the ordered lists of fields from the Dictionary for a Message/Group.
