### PR TITLE
Add extra options to session class

### DIFF
--- a/quickfixj-core/src/test/java/quickfix/SessionTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionTest.java
@@ -2512,5 +2512,39 @@ public class SessionTest {
             disconnectCalled = true;
         }
     }
+    
+    @Test
+    public void testSendWithoutAllowPosDupDropsFlagAndOrigSendingTime() throws Exception {
+        final UnitTestApplication application = new UnitTestApplication();
+        final SessionID sessionID = new SessionID(FixVersions.BEGINSTRING_FIX44, "SENDER", "TARGET");
+        final Session session = SessionFactoryTestSupport.createSession(sessionID, application, false, false, true, true, null);
+        UnitTestResponder responder = new UnitTestResponder();
+        session.setResponder(responder);
+        logonTo(session);
+        
+        session.send(createPossDupAppMessage(1));
+        
+        final Message sentMessage = new Message(responder.sentMessageData);
+        
+        assertFalse(sentMessage.getHeader().isSetField(PossDupFlag.FIELD));
+        assertFalse(sentMessage.getHeader().isSetField(OrigSendingTime.FIELD));
+    }
+    
+    @Test
+    public void testSendWithAllowPosDupKeepsFlagAndOrigSendingTime() throws Exception {
+        final UnitTestApplication application = new UnitTestApplication();
+        final SessionID sessionID = new SessionID(FixVersions.BEGINSTRING_FIX44, "SENDER", "TARGET");
+        final Session session = SessionFactoryTestSupport.createSession(sessionID, application, false, false, true, true, null);
+        UnitTestResponder responder = new UnitTestResponder();
+        session.setResponder(responder);
+        session.setAllowPosDup(true);
+        logonTo(session);
+        session.send(createPossDupAppMessage(1));
+        
+        final Message sentMessage = new Message(responder.sentMessageData);
+        
+        assertFalse(sentMessage.getHeader().isSetField(PossDupFlag.FIELD));
+        assertFalse(sentMessage.getHeader().isSetField(OrigSendingTime.FIELD));
+    }
 
 }


### PR DESCRIPTION
We have long had some internal setting that I feel like upstream will benefit from (also it makes my life easier).

**AllowPosDup**

`PossDupFlag` is set when resending messages. Currently it's automatically removed by QFJ. 
This PR makes two changes:

* It exposes a method 'sendNoChange' which never removes these settings. This is useful when resending messages from a cache or from an application store behind QFJ.
* It exposes a session setting 'AllowPosDup' that means we never remove the flag. This has been useful on occasion - primarily when a QFJ application is acting as purely a pass-through/monitoring hop.

**Fix41ResendRequestAsFix42**

* Some sessions claim to be FIX.4.1 but actually send FIX.4.2 format ResendRequests. This is useful for that. Quite common in less formalised trading networks where quite frankly the begin string is often just misleading.


