### PR TITLE
Calculating orderedFieldsArray eagerly to avoid concurrency problems (QFJ-971)

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/DataDictionary.java
+++ b/quickfixj-core/src/main/java/quickfix/DataDictionary.java
@@ -87,6 +87,7 @@ public class DataDictionary {
     private final IntegerStringMap<String> valueNames = new IntegerStringMap<>();
     private final StringIntegerMap<GroupInfo> groups = new StringIntegerMap<>();
     private final Map<String, Node> components = new HashMap<>();
+    private int[] orderedFieldsArray;
 
     private DataDictionary() {
     }
@@ -529,6 +530,8 @@ public class DataDictionary {
         setCheckUserDefinedFields(rhs.checkUserDefinedFields);
         setCheckUnorderedGroupFields(rhs.checkUnorderedGroupFields);
         setAllowUnknownMessageFields(rhs.allowUnknownMessageFields);
+
+        calculateOrderedFields();
     }
 
     @SuppressWarnings("unchecked")
@@ -1017,6 +1020,8 @@ public class DataDictionary {
                 load(document, msgtype, messageNode);
             }
         }
+
+        calculateOrderedFields();
     }
 
     public int getNumMessageCategories() {
@@ -1069,18 +1074,22 @@ public class DataDictionary {
         }
     }
 
-    private int[] orderedFieldsArray;
-
     public int[] getOrderedFields() {
-        if (orderedFieldsArray == null) {
-            orderedFieldsArray = new int[fields.size()];
-            int i = 0;
-            for (Integer field : fields) {
-                orderedFieldsArray[i++] = field;
-            }
+        return orderedFieldsArray;
+    }
+
+    private void calculateOrderedFields() {
+        orderedFieldsArray = new int[fields.size()];
+        int i = 0;
+        for (Integer field : fields) {
+            orderedFieldsArray[i++] = field;
         }
 
-        return orderedFieldsArray;
+        for (Map<Integer, GroupInfo> gm : groups.values()) {
+            for (GroupInfo gi : gm.values()) {
+                gi.dataDictionary.calculateOrderedFields();
+            }
+        }
     }
 
     private int lookupXMLFieldNumber(Document document, Node node) throws ConfigError {

--- a/quickfixj-core/src/test/java/quickfix/DataDictionaryTest.java
+++ b/quickfixj-core/src/test/java/quickfix/DataDictionaryTest.java
@@ -34,9 +34,15 @@ import quickfix.field.MsgSeqNum;
 import quickfix.field.MsgType;
 import quickfix.field.NoHops;
 import quickfix.field.NoPartyIDs;
+import quickfix.field.NoPartySubIDs;
 import quickfix.field.NoRelatedSym;
 import quickfix.field.OrdType;
 import quickfix.field.OrderQty;
+import quickfix.field.PartyID;
+import quickfix.field.PartyIDSource;
+import quickfix.field.PartyRole;
+import quickfix.field.PartySubID;
+import quickfix.field.PartySubIDType;
 import quickfix.field.Price;
 import quickfix.field.QuoteReqID;
 import quickfix.field.SenderCompID;
@@ -58,6 +64,7 @@ import java.net.URLClassLoader;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -973,6 +980,8 @@ public class DataDictionaryTest {
         assertEquals(ddCopy.isCheckFieldsOutOfOrder(),dataDictionary.isCheckFieldsOutOfOrder());
         assertEquals(ddCopy.isCheckUnorderedGroupFields(),dataDictionary.isCheckUnorderedGroupFields());
         assertEquals(ddCopy.isCheckUserDefinedFields(),dataDictionary.isCheckUserDefinedFields());
+        assertArrayEquals(getDictionary().getOrderedFields(),ddCopy.getOrderedFields());
+        assertArrayEquals(getDictionary().getOrderedFields(),dataDictionary.getOrderedFields());
 
         DataDictionary.GroupInfo groupFromDDCopy = ddCopy.getGroup(NewOrderSingle.MSGTYPE, NoPartyIDs.FIELD);
         assertTrue(groupFromDDCopy.getDataDictionary().isAllowUnknownMessageFields());
@@ -984,6 +993,31 @@ public class DataDictionaryTest {
         assertTrue(ddCopy.isAllowUnknownMessageFields());
         groupFromDDCopy = ddCopy.getGroup(NewOrderSingle.MSGTYPE, NoPartyIDs.FIELD);
         assertTrue(groupFromDDCopy.getDataDictionary().isAllowUnknownMessageFields());
+
+        DataDictionary originalGroupDictionary = getDictionary().getGroup(NewOrderSingle.MSGTYPE, NoPartyIDs.FIELD).getDataDictionary();
+        DataDictionary groupDictionary = dataDictionary.getGroup(NewOrderSingle.MSGTYPE, NoPartyIDs.FIELD).getDataDictionary();
+        DataDictionary copyGroupDictionary = ddCopy.getGroup(NewOrderSingle.MSGTYPE, NoPartyIDs.FIELD).getDataDictionary();
+        assertArrayEquals(originalGroupDictionary.getOrderedFields(), groupDictionary.getOrderedFields());
+        assertArrayEquals(originalGroupDictionary.getOrderedFields(), copyGroupDictionary.getOrderedFields());
+
+        DataDictionary originalNestedGroupDictionary = originalGroupDictionary.getGroup(NewOrderSingle.MSGTYPE, NoPartySubIDs.FIELD).getDataDictionary();
+        DataDictionary nestedGroupDictionary = groupDictionary.getGroup(NewOrderSingle.MSGTYPE, NoPartySubIDs.FIELD).getDataDictionary();
+        DataDictionary copyNestedGroupDictionary = copyGroupDictionary.getGroup(NewOrderSingle.MSGTYPE, NoPartySubIDs.FIELD).getDataDictionary();
+        assertArrayEquals(originalNestedGroupDictionary.getOrderedFields(), nestedGroupDictionary.getOrderedFields());
+        assertArrayEquals(originalNestedGroupDictionary.getOrderedFields(), copyNestedGroupDictionary.getOrderedFields());
+    }
+
+    @Test
+    public void testOrderedFields() throws Exception {
+        final DataDictionary dataDictionary = getDictionary();
+
+        final DataDictionary partyIDsDictionary = dataDictionary.getGroup(NewOrderSingle.MSGTYPE, NoPartyIDs.FIELD).getDataDictionary();
+        int[] expectedPartyIDsFieldOrder = new int[] {PartyID.FIELD, PartyIDSource.FIELD, PartyRole.FIELD, NoPartySubIDs.FIELD};
+        assertArrayEquals(expectedPartyIDsFieldOrder, partyIDsDictionary.getOrderedFields());
+
+        final DataDictionary partySubIDsDictionary = partyIDsDictionary.getGroup(NewOrderSingle.MSGTYPE, NoPartySubIDs.FIELD).getDataDictionary();
+        int[] expectedPartySubIDsFieldOrder = new int[] {PartySubID.FIELD, PartySubIDType.FIELD};
+        assertArrayEquals(expectedPartySubIDsFieldOrder, partySubIDsDictionary.getOrderedFields());
     }
 
     /**

--- a/quickfixj-core/src/test/java/quickfix/PausableThreadPoolExecutor.java
+++ b/quickfixj-core/src/test/java/quickfix/PausableThreadPoolExecutor.java
@@ -15,6 +15,11 @@ class PausableThreadPoolExecutor extends ThreadPoolExecutor {
         super(2, 2, 20, TimeUnit.SECONDS, new ArrayBlockingQueue<>(10000));
     }
 
+    public PausableThreadPoolExecutor(int noOfThreads) {
+        super(noOfThreads, noOfThreads, 20, TimeUnit.SECONDS, new ArrayBlockingQueue<>(10000));
+    }
+
+    @Override
     protected void beforeExecute(Thread t, Runnable r) {
         super.beforeExecute(t, r);
         pauseLock.lock();


### PR DESCRIPTION
Fixes #240 

I've added unit tests for DataDictionary to verify this refactor doesn't change it's public API. Unfortunately this is as far as I was able to take this - not quite sure how to construct testcase for the actual race.