### PR TITLE
Fix Sending Messages Example Code in User Manual

### DIFF
--- a/quickfixj-core/src/main/doc/usermanual/usage/sending_messages.html
+++ b/quickfixj-core/src/main/doc/usermanual/usage/sending_messages.html
@@ -68,7 +68,7 @@ public void sendOrderCancelRequest()
   message.setField(new StringField(55, "LNUX"));
 
   // Side, with value enumeration
-  message.setField(new CharField(54, FIX::Side_BUY));
+  message.setField(new CharField(54, Side.BUY));
 
   // Text
   message.setField(new StringField(58, "Cancel My Order!"));


### PR DESCRIPTION
There seems to have been a side effect from the QuickFix C++ Manual. I've updated the example code which was not changed to Java.