### PR TITLE
QFJ-636 - custom fields in component blocks are not added to parent

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/FieldMap.java
+++ b/quickfixj-core/src/main/java/quickfix/FieldMap.java
@@ -50,9 +50,9 @@ public abstract class FieldMap implements Serializable {
 
     private final int[] fieldOrder;
 
-    private final TreeMap<Integer, Field<?>> fields;
+    protected final TreeMap<Integer, Field<?>> fields;
 
-    private final TreeMap<Integer, List<Group>> groups = new TreeMap<>();
+    protected final TreeMap<Integer, List<Group>> groups = new TreeMap<>();
 
     /**
      * Constructs a FieldMap with the given field order.
@@ -694,5 +694,5 @@ public abstract class FieldMap implements Serializable {
         return hasGroup(group.getFieldTag());
     }
 
-    
+
 }

--- a/quickfixj-core/src/main/java/quickfix/MessageComponent.java
+++ b/quickfixj-core/src/main/java/quickfix/MessageComponent.java
@@ -17,6 +17,12 @@ public abstract class MessageComponent extends FieldMap {
         super(fieldOrder);
     }
 
+    /**
+     * Copies fields defined in the data dictionary inside this message component from specified source fields. This
+     * method is not symmetric with {@link MessageComponent#copyTo(FieldMap)} method.
+     *
+     * @param fields source fields
+     */
     public void copyFrom(FieldMap fields) {
         try {
             for (int componentField : getFields()) {
@@ -35,22 +41,23 @@ public abstract class MessageComponent extends FieldMap {
         }
     }
 
+    /**
+     * Copies all fields inside this message component to specified destination fields. This method is not symmetric
+     * with {@link MessageComponent#copyFrom(FieldMap)} method.
+     *
+     * @param fields destination fields
+     */
     public void copyTo(FieldMap fields) {
         try {
-            for (int componentField : getFields()) {
-                if (isSetField(componentField)) {
-                    fields.setField(componentField, getField(componentField));
-                }
+            for (int componentField : this.fields.keySet()) {
+                fields.setField(componentField, getField(componentField));
             }
-            for (int groupField : getGroupFields()) {
-                if (isSetField(groupField)) {
-                    fields.setField(groupField, getField(groupField));
-                    fields.setGroups(groupField, getGroups(groupField));
-                }
+            for (int groupField : this.groups.keySet()) {
+                fields.setField(groupField, getField(groupField));
+                fields.setGroups(groupField, getGroups(groupField));
             }
         } catch (FieldNotFound e) {
             // should not happen
         }
     }
-
 }

--- a/quickfixj-core/src/test/java/quickfix/MessageComponentTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageComponentTest.java
@@ -1,0 +1,162 @@
+package quickfix;
+
+import org.junit.Test;
+import quickfix.field.AgreementCurrency;
+import quickfix.field.Product;
+import quickfix.field.SecurityType;
+import quickfix.field.Symbol;
+import quickfix.fix44.QuoteRequest;
+import quickfix.fix44.component.FinancingDetails;
+import quickfix.fix44.component.Instrument;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class MessageComponentTest {
+
+    @Test
+    public void shouldCopyCustomTagsToComponent() throws FieldNotFound {
+        Instrument instrument1 = new Instrument();
+        instrument1.set(new Symbol("EURUSD"));
+        instrument1.set(new Product(Product.CURRENCY));
+        instrument1.set(new SecurityType(SecurityType.FOREIGN_EXCHANGE_CONTRACT));
+        instrument1.setString(12345, "ABC");
+        instrument1.setInt(54321, 0xCAFE);
+
+        assertEquals("EURUSD", instrument1.getSymbol().getValue());
+        assertEquals(Product.CURRENCY, instrument1.getProduct().getValue());
+        assertEquals(SecurityType.FOREIGN_EXCHANGE_CONTRACT, instrument1.getSecurityType().getValue());
+        assertEquals("ABC", instrument1.getString(12345));
+        assertEquals(0xCAFE, instrument1.getInt(54321));
+
+        Instrument instrument2 = new Instrument();
+        instrument1.copyTo(instrument2);
+
+        assertEquals("EURUSD", instrument2.getSymbol().getValue());
+        assertEquals(Product.CURRENCY, instrument2.getProduct().getValue());
+        assertEquals(SecurityType.FOREIGN_EXCHANGE_CONTRACT, instrument2.getSecurityType().getValue());
+
+        assertEquals("ABC", instrument2.getString(12345));
+        assertEquals(0xCAFE, instrument2.getInt(54321));
+    }
+
+    @Test
+    public void shouldNotCopyCustomTagsFromComponent() throws FieldNotFound {
+        Instrument instrument1 = new Instrument();
+        instrument1.set(new Symbol("EURUSD"));
+        instrument1.set(new Product(Product.CURRENCY));
+        instrument1.set(new SecurityType(SecurityType.FOREIGN_EXCHANGE_CONTRACT));
+        instrument1.setString(12345, "ABC");
+        instrument1.setInt(54321, 0xCAFE);
+
+        assertEquals("EURUSD", instrument1.getSymbol().getValue());
+        assertEquals(Product.CURRENCY, instrument1.getProduct().getValue());
+        assertEquals(SecurityType.FOREIGN_EXCHANGE_CONTRACT, instrument1.getSecurityType().getValue());
+        assertEquals("ABC", instrument1.getString(12345));
+        assertEquals(0xCAFE, instrument1.getInt(54321));
+
+        Instrument instrument2 = new Instrument();
+        instrument2.copyFrom(instrument1);
+
+        assertEquals("EURUSD", instrument2.getSymbol().getValue());
+        assertEquals(Product.CURRENCY, instrument2.getProduct().getValue());
+        assertEquals(SecurityType.FOREIGN_EXCHANGE_CONTRACT, instrument2.getSecurityType().getValue());
+
+        assertFalse(instrument2.isSetField(12345));
+        assertFalse(instrument2.isSetField(54321));
+    }
+
+    @Test
+    public void shouldSetComponentWithCustomTags() throws FieldNotFound {
+        Instrument instrument = new Instrument();
+        instrument.set(new Symbol("EURUSD"));
+        instrument.set(new Product(Product.CURRENCY));
+        instrument.set(new SecurityType(SecurityType.FOREIGN_EXCHANGE_CONTRACT));
+        instrument.setString(12345, "ABC");
+        instrument.setInt(54321, 0xCAFE);
+
+        FinancingDetails financingDetails = new FinancingDetails();
+        financingDetails.set(new AgreementCurrency("USD"));
+        financingDetails.setString(111222, "DEF");
+
+        QuoteRequest.NoRelatedSym noRelatedSym = new QuoteRequest.NoRelatedSym();
+        noRelatedSym.set(instrument);
+        noRelatedSym.set(financingDetails);
+
+        assertEquals("EURUSD", noRelatedSym.getSymbol().getValue());
+        assertEquals(Product.CURRENCY, noRelatedSym.getProduct().getValue());
+        assertEquals(SecurityType.FOREIGN_EXCHANGE_CONTRACT, noRelatedSym.getSecurityType().getValue());
+        assertEquals("ABC", noRelatedSym.getString(12345));
+        assertEquals(0xCAFE, noRelatedSym.getInt(54321));
+
+        assertEquals("USD", noRelatedSym.getFinancingDetails().getAgreementCurrency().getValue());
+        assertEquals("DEF", noRelatedSym.getString(111222));
+    }
+
+    @Test
+    public void shouldOverrideCustomComponentTags() throws FieldNotFound {
+        Instrument instrument = new Instrument();
+        instrument.set(new Symbol("EURUSD"));
+        instrument.set(new Product(Product.CURRENCY));
+        instrument.set(new SecurityType(SecurityType.FOREIGN_EXCHANGE_CONTRACT));
+        instrument.setString(12345, "ABC");
+        instrument.setInt(54321, 0xCAFE);
+
+        FinancingDetails financingDetails = new FinancingDetails();
+        financingDetails.set(new AgreementCurrency("USD"));
+        financingDetails.setString(111222, "DEF");
+
+        QuoteRequest.NoRelatedSym noRelatedSym = new QuoteRequest.NoRelatedSym();
+        noRelatedSym.set(instrument);
+        noRelatedSym.set(financingDetails);
+
+        instrument.set(new Symbol("USDCAD"));
+        instrument.setString(12345, "XYZ");
+        noRelatedSym.set(instrument);
+
+        financingDetails.set(new AgreementCurrency("CAD"));
+        financingDetails.setString(111222, "GHI");
+        financingDetails.setInt(54321, 0xBABE);
+        noRelatedSym.set(financingDetails);
+
+        assertEquals("USDCAD", noRelatedSym.getSymbol().getValue());
+        assertEquals(Product.CURRENCY, noRelatedSym.getProduct().getValue());
+        assertEquals(SecurityType.FOREIGN_EXCHANGE_CONTRACT, noRelatedSym.getSecurityType().getValue());
+        assertEquals("XYZ", noRelatedSym.getString(12345));
+        assertEquals(0xBABE, noRelatedSym.getInt(54321));
+
+        assertEquals("CAD", noRelatedSym.getFinancingDetails().getAgreementCurrency().getValue());
+        assertEquals("GHI", noRelatedSym.getString(111222));
+    }
+
+    @Test
+    public void shouldNotGetComponentWithCustomTags() throws FieldNotFound {
+        Instrument instrument = new Instrument();
+        instrument.set(new Symbol("EURUSD"));
+        instrument.set(new Product(Product.CURRENCY));
+        instrument.set(new SecurityType(SecurityType.FOREIGN_EXCHANGE_CONTRACT));
+        instrument.setString(12345, "ABC");
+        instrument.setInt(54321, 0xCAFE);
+
+        FinancingDetails financingDetails = new FinancingDetails();
+        financingDetails.set(new AgreementCurrency("USD"));
+        financingDetails.setString(111222, "DEF");
+
+        QuoteRequest.NoRelatedSym noRelatedSym = new QuoteRequest.NoRelatedSym();
+        noRelatedSym.set(instrument);
+        noRelatedSym.set(financingDetails);
+
+        instrument = noRelatedSym.getInstrument();
+
+        assertEquals("EURUSD", instrument.getSymbol().getValue());
+        assertEquals(Product.CURRENCY, instrument.getProduct().getValue());
+        assertEquals(SecurityType.FOREIGN_EXCHANGE_CONTRACT, instrument.getSecurityType().getValue());
+        assertFalse(instrument.isSetField(12345));
+        assertFalse(instrument.isSetField(54321));
+
+        financingDetails = noRelatedSym.getFinancingDetails();
+
+        assertEquals("USD", financingDetails.getAgreementCurrency().getValue());
+        assertFalse(instrument.isSetField(111222));
+    }
+}


### PR DESCRIPTION
**Changes**

- Custom FIX tags are copied to "parent" components.

Unfortunately it is not possible to do a reverse operation as the custom fields copied to "parent" would pollute every child component when retrieving it via "get*" methods. This is something that we don't want, especially when is an existing test case `quickfix.MessageTest#testComponent`.

Arguably we could change the class generation and add extra "get*" methods with additional arguments indicating that all (or selected ones) fields from "parent" components should be copied, but I think it might be a little overhead. The first attempt was done in https://github.com/quickfix-j/quickfixj/pull/210, but I think this is unnecessary clutter.

I updated the javadoc for `quickfix.MessageComponent#copyFrom` and `quickfix.MessageComponent#copyTo` to point out the difference in behaviour.