### PR TITLE
Add method to DataDictionary to get the value for a given enum value name

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/DataDictionary.java
+++ b/quickfixj-core/src/main/java/quickfix/DataDictionary.java
@@ -173,6 +173,17 @@ public class DataDictionary {
     }
 
     /**
+     * Get the value, if any, for an enumerated value name.
+     *
+     * @param field the tag
+     * @param name the value name
+     * @return the value assigned to passed name
+     */
+    public String getValue(int field, String name) {
+        return valueNames.getValue(field, name);
+    }
+
+    /**
      * Predicate for determining if a tag is a defined field.
      *
      * @param field the tag
@@ -1253,6 +1264,18 @@ public class DataDictionary {
         public V get(int field, String group) {
             Map<String, V> map = get(field);
             return map == null ? null : map.get(group);
+        }
+
+        public String getValue(int field, String name) {
+            Map<String, V> map = get(field);
+            if (map != null) {
+                for (Entry<String, V> entry : map.entrySet()) {
+                    if (entry.getValue().equals(name)) {
+                        return entry.getKey();
+                    }
+                }
+            }
+            return null;
         }
 
         public void put(int field, String group, V value) {

--- a/quickfixj-core/src/test/java/quickfix/DataDictionaryTest.java
+++ b/quickfixj-core/src/test/java/quickfix/DataDictionaryTest.java
@@ -88,6 +88,7 @@ public class DataDictionaryTest {
 
         assertEquals("wrong field name", "Currency", dd.getFieldName(15));
         assertEquals("wrong value description", "BUY", dd.getValueName(4, "B"));
+        assertEquals("wrong value for given value name", "2", dd.getValue(54, "SELL"));
         assertEquals("wrong value type", FieldType.STRING, dd.getFieldType(1));
         assertEquals("wrong version", FixVersions.BEGINSTRING_FIX44, dd.getVersion());
         assertFalse("unexpected field values existence", dd.hasFieldValue(1));


### PR DESCRIPTION
 - this is useful for mapping from/to the XML representation obtained
from `Message.toXML()`
 - since the DataDictionary is kind of a memory hog we do not store the
values in yet another HashMap (which would cause Node objects to be created) but iterate over the entries on each call to `getValue(int, String)`
  -- it is up to the user's application to cache the returned values if desired