### PR TITLE
Optimise session reset to reduce Calendar creation

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/CachedFileStore.java
+++ b/quickfixj-core/src/main/java/quickfix/CachedFileStore.java
@@ -163,6 +163,14 @@ public class CachedFileStore implements MessageStore {
         return cache.getCreationTime();
     }
 
+    /*
+     * (non-Javadoc)
+     * @see quickfix.MessageStore#getCreationTimeCalendar()
+     */
+    public Calendar getCreationTimeCalendar() throws IOException {
+        return cache.getCreationTimeCalendar();
+    }
+
     private void initializeSequenceNumbers() throws IOException {
         sequenceNumberFile.seek(0);
         if (sequenceNumberFile.length() > 0) {

--- a/quickfixj-core/src/main/java/quickfix/FileStore.java
+++ b/quickfixj-core/src/main/java/quickfix/FileStore.java
@@ -153,6 +153,14 @@ public class FileStore implements MessageStore, Closeable {
         return cache.getCreationTime();
     }
 
+    /* (non-Javadoc)
+     * @see quickfix.MessageStore#getCreationTimeCalendar()
+     */
+    @Override
+    public Calendar getCreationTimeCalendar() throws IOException {
+        return cache.getCreationTimeCalendar();
+    }
+
     private void initializeSequenceNumbers() throws IOException {
         senderSequenceNumberFile.seek(0);
         if (senderSequenceNumberFile.length() > 0) {

--- a/quickfixj-core/src/main/java/quickfix/JdbcStore.java
+++ b/quickfixj-core/src/main/java/quickfix/JdbcStore.java
@@ -155,6 +155,10 @@ class JdbcStore implements MessageStore {
         return cache.getCreationTime();
     }
 
+    public Calendar getCreationTimeCalendar() throws IOException {
+        return cache.getCreationTimeCalendar();
+    }
+
     public int getNextSenderMsgSeqNum() throws IOException {
         return cache.getNextSenderMsgSeqNum();
     }

--- a/quickfixj-core/src/main/java/quickfix/MemoryStore.java
+++ b/quickfixj-core/src/main/java/quickfix/MemoryStore.java
@@ -70,6 +70,10 @@ public class MemoryStore implements MessageStore {
         return creationTime.getTime();
     }
 
+    public Calendar getCreationTimeCalendar() throws IOException {
+        return creationTime;
+    }
+
     /* package */void setCreationTime(Calendar creationTime) {
         this.creationTime = creationTime;
     }

--- a/quickfixj-core/src/main/java/quickfix/MessageStore.java
+++ b/quickfixj-core/src/main/java/quickfix/MessageStore.java
@@ -19,6 +19,7 @@
 
 package quickfix;
 
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.io.IOException;
@@ -72,6 +73,14 @@ public interface MessageStore {
      * @throws IOException IO error
      */
     Date getCreationTime() throws IOException;
+
+    /**
+     * Get the session creation time as a calendar object.
+     *
+     * @return the session creation time.
+     * @throws IOException IO error
+     */
+    Calendar getCreationTimeCalendar() throws IOException;
 
     /**
      * Reset the message store. Sequence numbers are set back to 1 and stored

--- a/quickfixj-core/src/main/java/quickfix/NoopStore.java
+++ b/quickfixj-core/src/main/java/quickfix/NoopStore.java
@@ -20,6 +20,7 @@
 
 package quickfix;
 
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 
@@ -31,6 +32,7 @@ import java.util.Date;
 public class NoopStore implements MessageStore {
 
     private Date creationTime = new Date();
+    private Calendar creationTimeCalendar = SystemTime.getUtcCalendar(creationTime);
     private int nextSenderMsgSeqNum = 1;
     private int nextTargetMsgSeqNum = 1;
 
@@ -39,6 +41,10 @@ public class NoopStore implements MessageStore {
 
     public Date getCreationTime() {
         return creationTime;
+    }
+
+    public Calendar getCreationTimeCalendar() {
+        return creationTimeCalendar;
     }
 
     public int getNextSenderMsgSeqNum() {

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -584,7 +584,7 @@ public class Session implements Closeable {
     private boolean isCurrentSession(final long time)
             throws IOException {
         return sessionSchedule == null || sessionSchedule.isSameSession(
-                SystemTime.getUtcCalendar(time), SystemTime.getUtcCalendar(state.getCreationTime()));
+                SystemTime.getUtcCalendar(time), state.getCreationTimeCalendar());
     }
 
     /**

--- a/quickfixj-core/src/main/java/quickfix/SessionState.java
+++ b/quickfixj-core/src/main/java/quickfix/SessionState.java
@@ -20,10 +20,7 @@
 package quickfix;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Date;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -500,6 +497,10 @@ public final class SessionState {
 
     public Object getLock() {
         return lock;
+    }
+
+    public Calendar getCreationTimeCalendar() throws IOException {
+        return messageStore.getCreationTimeCalendar();
     }
 
     private final static class NullLog implements Log {

--- a/quickfixj-core/src/main/java/quickfix/SessionState.java
+++ b/quickfixj-core/src/main/java/quickfix/SessionState.java
@@ -20,7 +20,11 @@
 package quickfix;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;

--- a/quickfixj-core/src/main/java/quickfix/SleepycatStore.java
+++ b/quickfixj-core/src/main/java/quickfix/SleepycatStore.java
@@ -256,8 +256,21 @@ public class SleepycatStore implements MessageStore {
         throw ioe;
     }
 
+
+    /*
+     * (non-Javadoc)
+     * @see quickfix.MessageStore#getCreationTime()
+     */
     public Date getCreationTime() throws IOException {
         return info.getCreationTime().getTime();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see quickfix.MessageStore#getCreationTimeCalendar()
+     */
+    public Calendar getCreationTimeCalendar() throws IOException {
+        return info.getCreationTime();
     }
 
     public int getNextSenderMsgSeqNum() throws IOException {

--- a/quickfixj-core/src/test/java/quickfix/DefaultSessionScheduleTest.java
+++ b/quickfixj-core/src/test/java/quickfix/DefaultSessionScheduleTest.java
@@ -1,0 +1,120 @@
+package quickfix;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.ByteArrayInputStream;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class DefaultSessionScheduleTest {
+
+    private SessionID sessionID;
+    @Mock
+    private SystemTimeSource mockTimeSource;
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+
+        sessionID = new SessionID("FIX.4.2:A->B");
+        SystemTime.setTimeSource(mockTimeSource);
+    }
+
+    @After
+    public void after() {
+        SystemTime.setTimeSource(null);
+    }
+
+    @Test
+    public void isNonStopSession_returns_true_when_SETTING_NON_STOP_SESSION_Y() throws FieldConvertError, ConfigError {
+        String sessionSettingsString = ""
+            + "[DEFAULT]\n"
+            + "NonStopSession=Y\n"
+            + "\n"
+            + "[SESSION]\n"
+            + "BeginString=FIX.4.2\n"
+            + "SenderCompID=A\n"
+            + "TargetCompID=B\n";
+        SessionSettings sessionSettings = new SessionSettings(new ByteArrayInputStream(sessionSettingsString.getBytes()));
+        DefaultSessionSchedule schedule = new DefaultSessionSchedule(sessionSettings, sessionID);
+
+        assertTrue(schedule.isNonStopSession());
+    }
+
+    @Test
+    public void isNonStopSession_returns_false_when_SETTING_NON_STOP_SESSION_N() throws FieldConvertError, ConfigError {
+        String sessionSettingsString = ""
+            + "[DEFAULT]\n"
+            + "NonStopSession=N\n"
+            + "\n"
+            + "[SESSION]\n"
+            + "BeginString=FIX.4.2\n"
+            + "SenderCompID=A\n"
+            + "TargetCompID=B\n"
+            + "StartTime=00:00:00\n"
+            + "EndTime=00:00:01\n";
+        SessionSettings sessionSettings = new SessionSettings(new ByteArrayInputStream(sessionSettingsString.getBytes()));
+        DefaultSessionSchedule schedule = new DefaultSessionSchedule(sessionSettings, sessionID);
+
+        assertFalse(schedule.isNonStopSession());
+    }
+
+    @Test
+    public void isNonStopSession_returns_false_when_SETTING_NON_STOP_SESSION_not_present() throws FieldConvertError, ConfigError {
+        String sessionSettingsString = ""
+            + "[DEFAULT]\n"
+            + "\n"
+            + "[SESSION]\n"
+            + "BeginString=FIX.4.2\n"
+            + "SenderCompID=A\n"
+            + "TargetCompID=B\n"
+            + "StartTime=00:00:00\n"
+            + "EndTime=00:00:01\n";
+        SessionSettings sessionSettings = new SessionSettings(new ByteArrayInputStream(sessionSettingsString.getBytes()));
+        DefaultSessionSchedule schedule = new DefaultSessionSchedule(sessionSettings, sessionID);
+
+        assertFalse(schedule.isNonStopSession());
+    }
+
+    @Test
+    public void isSessionTime_returns_true_for_time_within_window() throws FieldConvertError, ConfigError {
+        when(mockTimeSource.getTime()).thenReturn(1L);
+        String sessionSettingsString = ""
+            + "[DEFAULT]\n"
+            + "\n"
+            + "[SESSION]\n"
+            + "BeginString=FIX.4.2\n"
+            + "SenderCompID=A\n"
+            + "TargetCompID=B\n"
+            + "StartTime=00:00:00\n"
+            + "EndTime=00:00:01\n";
+        SessionSettings sessionSettings = new SessionSettings(new ByteArrayInputStream(sessionSettingsString.getBytes()));
+        DefaultSessionSchedule schedule = new DefaultSessionSchedule(sessionSettings, sessionID);
+
+        assertTrue(schedule.isSessionTime());
+    }
+
+    @Test
+    public void isSessionTime_returns_false_for_time_outside_window() throws FieldConvertError, ConfigError {
+        when(mockTimeSource.getTime()).thenReturn(2000L);
+        String sessionSettingsString = ""
+            + "[DEFAULT]\n"
+            + "\n"
+            + "[SESSION]\n"
+            + "BeginString=FIX.4.2\n"
+            + "SenderCompID=A\n"
+            + "TargetCompID=B\n"
+            + "StartTime=00:00:00\n"
+            + "EndTime=00:00:01\n";
+        SessionSettings sessionSettings = new SessionSettings(new ByteArrayInputStream(sessionSettingsString.getBytes()));
+        DefaultSessionSchedule schedule = new DefaultSessionSchedule(sessionSettings, sessionID);
+
+        assertFalse(schedule.isSessionTime());
+    }
+}

--- a/quickfixj-core/src/test/java/quickfix/LogUtilTest.java
+++ b/quickfixj-core/src/test/java/quickfix/LogUtilTest.java
@@ -22,6 +22,7 @@ package quickfix;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Calendar;
 import java.util.Date;
 import org.junit.After;
 import static org.junit.Assert.assertTrue;
@@ -60,7 +61,7 @@ public class LogUtilTest {
         Session session = new Session(null, sessionID1 -> {
             try {
                 return new MemoryStore() {
-                    public Date getCreationTime() throws IOException {
+                    public Calendar getCreationTimeCalendar() throws IOException {
                         throw new IOException("test");
                     }
                 };


### PR DESCRIPTION
Fixes #282

Attempts to improve Calendar-based memory churn seen in #282 by accessing original calendars and keeping a local cache of temporary ones.