### PR TITLE
Add custom tags to Logon message.

### DIFF
--- a/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
+++ b/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
@@ -1192,7 +1192,29 @@
 
     <TD COLSPAN="4" class="subsection"><A NAME="Miscellaneous">Miscellaneous</A></TD>
   </TR>
-<TR ALIGN="left" VALIGN="middle">
+  <TR ALIGN="left" VALIGN="middle">
+    <TD> <I>LogonTag</I> </TD>
+    <TD> Tag/value pair which will be set on sent or received Logon message. </TD>
+    <TD> &lt;tag&gt;=&lt;value&gt;, where "tag" has to be a positive integer and "value" a String <br>
+        Example: <br>
+                 LogonTag=553=foo
+                 </TD>
+    <TD> </TD>
+  </TR>
+  <TR ALIGN="left" VALIGN="middle">
+    <TD> <I>LogonTag&lt;n&gt;</I> </TD>
+    <TD> Additional tag/value pairs which will be set on sent or received Logon message,<br>
+         where <b>n</b> is a positive integer, i.e. LogonTag1, LogonTag2, etc.
+         Must be consecutive.
+    </TD>
+    <TD> &lt;tag&gt;=&lt;value&gt;, where "tag" has to be a positive integer and "value" a String <br>
+        Example: <br>
+                 LogonTag=553=user<br>
+                 LogonTag1=554=password
+                 </TD>
+    <TD> </TD>
+  </TR>
+  <TR ALIGN="left" VALIGN="middle">
     <TD> <I>ResetOnLogon</I> </TD>
     <TD> Determines if sequence numbers should be reset before sending/receiving a logon request. </TD>
     <TD> Y<br>N</TD>
@@ -1202,13 +1224,11 @@
     <TD> <I>ResetOnLogout</I> </TD>
     <TD> Determines if sequence numbers should be reset to 1 after a normal logout termination. </TD>
     <TD> Y<br>N</TD>
-
     <TD> N </TD>
   </TR>
   <TR ALIGN="left" VALIGN="middle">
     <TD> <I>ResetOnDisconnect</I> </TD>
     <TD> Determines if sequence numbers should be reset to 1 after an abnormal termination. </TD>
-
     <TD> Y<br>N</TD>
     <TD> N </TD>
   </TR>

--- a/quickfixj-core/src/main/java/quickfix/Field.java
+++ b/quickfixj-core/src/main/java/quickfix/Field.java
@@ -80,10 +80,11 @@ public /*abstract*/ class Field<T> implements Serializable {
     }
 
     /**
-     * Return's the formatted field (tag=value<SOH>)
+     * Returns the formatted field (tag=value<SOH>)
      *
      * @return the formatted field
      */
+    @Override
     public String toString() {
         calculate();
         return data;

--- a/quickfixj-core/src/test/java/quickfix/SessionFactoryTestSupport.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionFactoryTestSupport.java
@@ -3,6 +3,8 @@ package quickfix;
 import quickfix.field.DefaultApplVerID;
 
 import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -108,6 +110,7 @@ public class SessionFactoryTestSupport implements SessionFactory {
         private boolean enableNextExpectedMsgSeqNum = false;
         private final boolean enableLastMsgSeqNumProcessed = false;
         private final boolean validateChecksum = true;
+        private List<StringField> logonTags = new ArrayList<>();
 
         public Session build() {
             return new Session(applicationSupplier.get(), messageStoreFactorySupplier.get(), sessionIDSupplier.get(),
@@ -119,7 +122,7 @@ public class SessionFactoryTestSupport implements SessionFactory {
                     resetOnError, disconnectOnError, disableHeartBeatCheck, false, rejectInvalidMessage,
                     rejectMessageOnUnhandledException, requiresOrigSendingTime, forceResendWhenCorruptedStore,
                     allowedRemoteAddresses, validateIncomingMessage, resendRequestChunkSize, enableNextExpectedMsgSeqNum,
-                    enableLastMsgSeqNumProcessed, validateChecksum);
+                    enableLastMsgSeqNumProcessed, validateChecksum, logonTags);
         }
 
         public Builder setBeginString(final String beginString) {
@@ -166,6 +169,11 @@ public class SessionFactoryTestSupport implements SessionFactory {
 
         public Builder setLogFactory(final LogFactory logFactory) {
             this.logFactorySupplier = () -> logFactory;
+            return this;
+        }
+
+        public Builder setLogonTags(final List<StringField> logonTags) {
+            this.logonTags = logonTags;
             return this;
         }
 


### PR DESCRIPTION
Adds possibility to specify tags via setting `LogonTag` or `LogonTag<n>`.
Example:
```
LogonTag=553=user
LogonTag1=554=password 
```

It is checked whether a data dictionary is present to determine whether the specified tag is a header field. Otherwise it is put into the body of the message.