### PR TITLE
QFJ-684 - added charset support to `BytesField`

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/BytesField.java
+++ b/quickfixj-core/src/main/java/quickfix/BytesField.java
@@ -19,9 +19,7 @@
 
 package quickfix;
 
-import java.io.UnsupportedEncodingException;
-
-import org.quickfixj.QFJException;
+import org.quickfixj.CharsetSupport;
 
 /**
  * BytesField enables better handling of binary data. With BytesFields binary data can
@@ -47,11 +45,6 @@ public class BytesField extends Field<byte[]> {
 
     @Override
     protected String objectAsString() {
-        try {
-            return new String(getObject(), "UTF8");
-        } catch (UnsupportedEncodingException e) {
-            throw new QFJException(e);
-        }
+        return new String(getObject(), CharsetSupport.getCharsetInstance());
     }
-
 }

--- a/quickfixj-core/src/test/java/quickfix/FieldTest.java
+++ b/quickfixj-core/src/test/java/quickfix/FieldTest.java
@@ -251,6 +251,25 @@ public class FieldTest {
     }
 
     @Test
+    public void testBytesFieldFullRange() {
+        byte[] data = new byte[256];
+
+        for (int i = 0; i < 256; i++) {
+            data[i] = (byte) i;
+        }
+
+        BytesField field = new BytesField(RawData.FIELD);
+        field.setValue(data);
+
+        byte[] tagPrefixedData = field.toString().getBytes(CharsetSupport.getCharsetInstance());
+        assertEquals(256 + 3, tagPrefixedData.length);
+
+        for (int i = 0; i < data.length; ++i) {
+            assertEquals(data[i], tagPrefixedData[i + 3]);
+        }
+    }
+
+    @Test
     public void testFieldhashCode() throws Exception {
         assertEqualsAndHash(new IntField(11, 100), new IntField(11, 100));
         assertEqualsAndHash(new DoubleField(11, 100.0), new DoubleField(11, 100.0));


### PR DESCRIPTION
**Changes**
- `quickfix.BytesField` uses `org.quickfixj.CharsetSupport`

This is the last remaining item from QFJ-789, so possibly this could be closed as well.