### PR TITLE
Preferred proxy authentication methods removed

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/ProtocolFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/ProtocolFactory.java
@@ -141,13 +141,6 @@ public class ProtocolFactory {
         }
 
         ProxyIoSession proxyIoSession = new ProxyIoSession(proxyAddress, req);
-
-        List<HttpAuthenticationMethods> l = new ArrayList<>();
-        l.add(HttpAuthenticationMethods.NO_AUTH);
-        l.add(HttpAuthenticationMethods.DIGEST);
-        l.add(HttpAuthenticationMethods.BASIC);
-
-        proxyIoSession.setPreferedOrder(l);
         connector.setProxyIoSession(proxyIoSession);
 
         return connector;

--- a/quickfixj-core/src/test/java/quickfix/mina/ProtocolFactoryTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/ProtocolFactoryTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) quickfixengine.org  All rights reserved.
+ *
+ * This file is part of the QuickFIX FIX Engine
+ *
+ * This file may be distributed under the terms of the quickfixengine.org
+ * license as defined by quickfixengine.org and appearing in the file
+ * LICENSE included in the packaging of this file.
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING
+ * THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * See http://www.quickfixengine.org/LICENSE for licensing information.
+ *
+ * Contact ask@quickfixengine.org if any conditions of this licensing
+ * are not clear to you.
+ ******************************************************************************/
+
+package quickfix.mina;
+
+import org.apache.mina.core.service.IoConnector;
+import org.apache.mina.proxy.ProxyConnector;
+import org.apache.mina.proxy.session.ProxyIoSession;
+import org.apache.mina.transport.socket.SocketConnector;
+import org.apache.mina.util.AvailablePortFinder;
+import org.junit.Test;
+import quickfix.ConfigError;
+
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.assertNull;
+
+public class ProtocolFactoryTest {
+
+    @Test
+    public void shouldCreateProxyConnectorWithoutPreferredAuthOrder() throws ConfigError {
+        InetSocketAddress address = new InetSocketAddress(AvailablePortFinder.getNextAvailable());
+        InetSocketAddress proxyAddress = new InetSocketAddress(AvailablePortFinder.getNextAvailable());
+
+        IoConnector connector = ProtocolFactory.createIoConnector(address);
+        ProxyConnector proxyConnector = ProtocolFactory
+                .createIoProxyConnector((SocketConnector) connector, address, proxyAddress, "socks", "5", "user",
+                                        "password", null, null);
+
+        ProxyIoSession proxySession = proxyConnector.getProxyIoSession();
+        assertNull(proxySession.getPreferedOrder());
+    }
+}

--- a/quickfixj-core/src/test/java/quickfix/mina/ProtocolFactoryTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/ProtocolFactoryTest.java
@@ -40,8 +40,8 @@ public class ProtocolFactoryTest {
 
         IoConnector connector = ProtocolFactory.createIoConnector(address);
         ProxyConnector proxyConnector = ProtocolFactory
-                .createIoProxyConnector((SocketConnector) connector, address, proxyAddress, "socks", "5", "user",
-                                        "password", null, null);
+                .createIoProxyConnector((SocketConnector) connector, address, proxyAddress, "http", "1.0", "user",
+                                        "password", "domain", "workstation");
 
         ProxyIoSession proxySession = proxyConnector.getProxyIoSession();
         assertNull(proxySession.getPreferedOrder());


### PR DESCRIPTION
Fixes https://github.com/quickfix-j/quickfixj/issues/295

Opening as a DRAFT before we gather the test evidence.

@curdreinert

Would you be able to build or test directly from branch? At the moment I'm using CCProxy for Windows, but I struggle to get either SOCKS or HTTP method to work (most likely a setup issue). Also, what OS and proxy software are you using? I will have a look again in the evening/tomorrow.
