### PR TITLE
Disallow loading of external entities in various classes

### DIFF
--- a/quickfixj-codegenerator/src/main/java/org/quickfixj/codegenerator/MessageCodeGenerator.java
+++ b/quickfixj-codegenerator/src/main/java/org/quickfixj/codegenerator/MessageCodeGenerator.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.xml.XMLConstants;
 
 /**
  * Generates Message and Field related code for the various FIX versions.
@@ -218,6 +219,8 @@ public class MessageCodeGenerator {
         Document document = specificationCache.get(task.getName());
         if (document == null) {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             DocumentBuilder builder = factory.newDocumentBuilder();
             document = builder.parse(task.getSpecification());
             specificationCache.put(task.getName(), document);

--- a/quickfixj-core/src/main/java/quickfix/DataDictionary.java
+++ b/quickfixj-core/src/main/java/quickfix/DataDictionary.java
@@ -48,6 +48,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.xml.XMLConstants;
 
 import static quickfix.FileUtil.Location.CLASSLOADER_RESOURCE;
 import static quickfix.FileUtil.Location.CONTEXT_RESOURCE;
@@ -879,6 +880,8 @@ public class DataDictionary {
 
     private void load(InputStream inputStream) throws ConfigError {
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         Document document;
         try {
             final DocumentBuilder builder = factory.newDocumentBuilder();

--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -68,6 +68,7 @@ import java.io.ByteArrayOutputStream;
 import java.text.DecimalFormat;
 import java.util.Iterator;
 import java.util.List;
+import javax.xml.XMLConstants;
 
 /**
  * Represents a FIX message.
@@ -329,7 +330,10 @@ public class Message extends FieldMap {
      */
     public String toXML(DataDictionary dataDictionary) {
         try {
-            final Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            final Document document = factory.newDocumentBuilder()
                     .newDocument();
             final Element message = document.createElement("message");
             document.appendChild(message);
@@ -340,6 +344,8 @@ public class Message extends FieldMap {
             final ByteArrayOutputStream out = new ByteArrayOutputStream();
             final StreamResult streamResult = new StreamResult(out);
             final TransformerFactory tf = TransformerFactory.newInstance();
+            tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             final Transformer serializer = tf.newTransformer();
             serializer.setOutputProperty(OutputKeys.ENCODING, "ISO-8859-1");
             serializer.setOutputProperty(OutputKeys.INDENT, "yes");

--- a/quickfixj-dictgenerator/src/main/java/org/quickfixj/dictgenerator/Repository.java
+++ b/quickfixj-dictgenerator/src/main/java/org/quickfixj/dictgenerator/Repository.java
@@ -54,7 +54,7 @@ public class Repository {
             throw new Exception("Invalid repository: Missing required files: " + requiredFiles);
         }
 
-        SAXReader reader = new SAXReader();
+        SAXReader reader = SAXReader.createDefault();
         components = reader.read(new File(repository, "Components.xml"));
         enums = reader.read(new File(repository, "Enums.xml"));
         fields = reader.read(new File(repository, "Fields.xml"));


### PR DESCRIPTION
Set following attributes where applicable:

```
XMLConstants.ACCESS_EXTERNAL_DTD
XMLConstants.ACCESS_EXTERNAL_SCHEMA
XMLConstants.ACCESS_EXTERNAL_STYLESHEET
```

Use `SAXReader.createDefault()` in `Repository` as noted in https://github.com/dom4j/dom4j/releases/tag/version-2.1.3