### PR TITLE
Log remote address on multiple Logon

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/acceptor/AcceptorIoHandler.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/acceptor/AcceptorIoHandler.java
@@ -69,8 +69,8 @@ class AcceptorIoHandler extends AbstractIoHandler {
                     final Log sessionLog = qfSession.getLog();
                     if (qfSession.hasResponder()) {
                         // Session is already bound to another connection
-                        sessionLog
-                                .onErrorEvent("Multiple logons/connections for this session are not allowed");
+                        sessionLog.onErrorEvent("Multiple logons/connections for this session are not allowed. "
+                                + "Closing connection from " + protocolSession.getRemoteAddress());
                         protocolSession.closeNow();
                         return;
                     }

--- a/quickfixj-core/src/main/java/quickfix/mina/acceptor/AcceptorIoHandler.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/acceptor/AcceptorIoHandler.java
@@ -39,6 +39,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Optional;
+import quickfix.Responder;
 
 class AcceptorIoHandler extends AbstractIoHandler {
     private final EventHandlingStrategy eventHandlingStrategy;
@@ -67,10 +68,12 @@ class AcceptorIoHandler extends AbstractIoHandler {
                 qfSession = sessionProvider.getSession(sessionID, eventHandlingStrategy.getSessionConnector());
                 if (qfSession != null) {
                     final Log sessionLog = qfSession.getLog();
-                    if (qfSession.hasResponder()) {
+                    Responder responder = qfSession.getResponder();
+                    if (responder != null) {
                         // Session is already bound to another connection
-                        sessionLog.onErrorEvent("Multiple logons/connections for this session are not allowed. "
-                                + "Closing connection from " + protocolSession.getRemoteAddress());
+                        sessionLog.onErrorEvent("Multiple logons/connections for this session are not allowed."
+                                + " Closing connection from " + protocolSession.getRemoteAddress()
+                                + " since it is already established from " + responder.getRemoteAddress());
                         protocolSession.closeNow();
                         return;
                     }

--- a/quickfixj-core/src/main/java/quickfix/mina/acceptor/AcceptorIoHandler.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/acceptor/AcceptorIoHandler.java
@@ -73,7 +73,7 @@ class AcceptorIoHandler extends AbstractIoHandler {
                         // Session is already bound to another connection
                         sessionLog.onErrorEvent("Multiple logons/connections for this session are not allowed."
                                 + " Closing connection from " + protocolSession.getRemoteAddress()
-                                + " since it is already established from " + responder.getRemoteAddress());
+                                + " since session is already established from " + responder.getRemoteAddress());
                         protocolSession.closeNow();
                         return;
                     }


### PR DESCRIPTION
To be able to see the source of multiple (i.e. excess) Logon attempts at a glance.

We currently log the remote address when the TCP connection is established, but in a separate message.
```
MINA session created: local=/xxxx:1234, class org.apache.mina.transport.socket.nio.NioSocketSession, remote=/yyyy:5678
```
However, this information might be hard to find in the log file when many messages are exchanged on the already connected session. Moreover, there might be additional connection attempts by more than one counterparty.

This PR will add the remote address to the log message, for example:
```
Multiple logons/connections for this session are not allowed. Closing connection from /127.0.0.1:54082 since session is already established from /127.0.0.1:54058
```