### PR TITLE
QFJ-741 - missing value in AllocCancReplaceReason in FIX44.xml

### DIFF
--- a/quickfixj-messages/quickfixj-messages-fix44/src/main/resources/FIX44.xml
+++ b/quickfixj-messages/quickfixj-messages-fix44/src/main/resources/FIX44.xml
@@ -6398,6 +6398,7 @@
     <field number="796" name="AllocCancReplaceReason" type="INT">
       <value enum="1" description="ORIGINAL_DETAILS_INCOMPLETE_INCORRECT"/>
       <value enum="2" description="CHANGE_IN_UNDERLYING_ORDER_DETAILS"/>
+      <value enum="99" description="OTHER"/>
     </field>
     <field number="797" name="CopyMsgIndicator" type="BOOLEAN"/>
     <field number="798" name="AllocAccountType" type="INT">


### PR DESCRIPTION
Fixes QFJ-741

Seems like 99 - Other should be available since FIX 4.4

http://fixwiki.org/fixwiki/AllocCancReplaceReason/99_Other