### PR TITLE
Integration with JaCoCo and Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ before_install:
   - echo "MAVEN_OPTS='-Xms2g -Xmx3g'" > ~/.mavenrc
 script:
   - travis_wait 30 mvn test -B -V -Djava.util.logging.config.file=logging.properties
+after_success:
+  - mvn jacoco:report coveralls:report -Droot.logging.level=INFO

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ QuickFIX/J
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.quickfixj/quickfixj-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.quickfixj/quickfixj-core)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/quickfix-j/quickfixj.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/quickfix-j/quickfixj/alerts/)
 [![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/quickfix-j/quickfixj.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/quickfix-j/quickfixj/context:java)
+[![Coverage Status](https://coveralls.io/repos/github/quickfix-j/quickfixj/badge.svg?branch=master)](https://coveralls.io/github/quickfix-j/quickfixj?branch=master)
 
 This is the official QuickFIX/J project repository.
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,8 @@
 		<maven-deploy-plugin-version>2.8.2</maven-deploy-plugin-version>
 		<nexus-staging-maven-plugin-version>1.6.8</nexus-staging-maven-plugin-version>
 		<build-helper-maven-plugin-version>3.0.0</build-helper-maven-plugin-version>
+		<coveralls-maven-plugin-version>4.3.0</coveralls-maven-plugin-version>
+		<jacoco-maven-plugin-version>0.8.2</jacoco-maven-plugin-version>
 	</properties>
 
 	<build>
@@ -222,6 +224,24 @@
 							</goals>
 						</execution>
 					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>${jacoco-maven-plugin-version}</version>
+					<executions>
+						<execution>
+							<id>prepare-agent</id>
+							<goals>
+								<goal>prepare-agent</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.eluder.coveralls</groupId>
+					<artifactId>coveralls-maven-plugin</artifactId>
+					<version>${coveralls-maven-plugin-version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -383,7 +383,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xmx512m -Djava.net.preferIPv4Stack=true</argLine>
+                    <argLine>@{argLine} -Xmx512m -Djava.net.preferIPv4Stack=true</argLine>
                     <trimStackTrace>false</trimStackTrace>
                     <includes>
                         <include>**/*Test.java</include>
@@ -401,6 +401,26 @@
                         <atest.skipslow>false</atest.skipslow>
                     </systemPropertyVariables>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>quickfix/**</include>
+                        <include>org/**</include>
+                        <include>quickfix/field/converter/*</include>
+                    </includes>
+                    <excludes>
+                        <exclude>quickfix/field/*</exclude>
+                        <exclude>quickfix/fix*/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>${coveralls-maven-plugin-version}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
I was able to integrate with JaCoCo code coverage and Coveralls plugins. The configuration excludes auto generated code so it covers only quickfixj-core logic (as it should). The build takes 30 seconds more on Travis - no impact on local builds as the goals are not executed.

Since the project is public there are no tokens required etc. The only post requisite is to login to Coveralls and add quickfix-j/quickfixj repo via QuickFIX/J organization from one of the members. Coverage status badge already points to it.

At the moment coverage is 78% which will make the badge red (> 80% orange, > 90% green), but I will be happy to improve the coverage later on.

Please have a look at my branch view in Coveralls.
https://coveralls.io/github/the-thing/quickfixj

There are also other code coverage projects such as Code Climate, but they do more than that. Coveralls seems to the most feasible for pure code coverage.