### PR TITLE
Fixing Xerces dtd/schema backward compatibility

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -68,7 +68,6 @@ import java.io.ByteArrayOutputStream;
 import java.text.DecimalFormat;
 import java.util.Iterator;
 import java.util.List;
-import javax.xml.XMLConstants;
 
 /**
  * Represents a FIX message.
@@ -331,8 +330,6 @@ public class Message extends FieldMap {
     public String toXML(DataDictionary dataDictionary) {
         try {
             final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             final Document document = factory.newDocumentBuilder()
                     .newDocument();
             final Element message = document.createElement("message");
@@ -344,8 +341,6 @@ public class Message extends FieldMap {
             final ByteArrayOutputStream out = new ByteArrayOutputStream();
             final StreamResult streamResult = new StreamResult(out);
             final TransformerFactory tf = TransformerFactory.newInstance();
-            tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             final Transformer serializer = tf.newTransformer();
             serializer.setOutputProperty(OutputKeys.ENCODING, "ISO-8859-1");
             serializer.setOutputProperty(OutputKeys.INDENT, "yes");
@@ -357,7 +352,7 @@ public class Message extends FieldMap {
     }
 
     private void toXMLFields(Element message, String section, FieldMap fieldMap,
-            DataDictionary dataDictionary) throws FieldNotFound {
+            DataDictionary dataDictionary) {
         final Document document = message.getOwnerDocument();
         final Element fields = document.createElement(section);
         message.appendChild(fields);

--- a/quickfixj-core/src/test/java/quickfix/DataDictionaryTest.java
+++ b/quickfixj-core/src/test/java/quickfix/DataDictionaryTest.java
@@ -59,6 +59,7 @@ import quickfix.fix44.Quote;
 import quickfix.fix44.QuoteRequest;
 import quickfix.test.util.ExpectedTestFailure;
 
+import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
 import java.math.BigDecimal;
 import java.net.URL;
@@ -76,6 +77,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class DataDictionaryTest {
 
@@ -1396,7 +1398,20 @@ public class DataDictionaryTest {
         }
     }
 
+    @Test
+    public void shouldLoadDictionaryWhenExternalDTDisEnabled() throws ConfigError {
+        new DataDictionary("FIX_External_DTD.xml", DocumentBuilderFactory::newInstance);
+    }
 
+    @Test
+    public void shouldFailToLoadDictionaryWhenExternalDTDisDisabled() {
+        try {
+            new DataDictionary("FIX_External_DTD.xml");
+            fail("should fail to load dictionary with external DTD");
+        } catch (ConfigError e) {
+            assertEquals("External DTD: Failed to read external DTD 'mathml.dtd', because 'http' access is not allowed due to restriction set by the accessExternalDTD property.", e.getCause().getCause().getMessage());
+        }
+    }
 
     //
     // Group Validation Tests in RepeatingGroupTest

--- a/quickfixj-core/src/test/java/quickfix/MessageTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageTest.java
@@ -117,6 +117,7 @@ import quickfix.fix44.component.Instrument;
 import quickfix.fix44.component.Parties;
 import quickfix.fix50.MarketDataSnapshotFullRefresh;
 
+import javax.xml.parsers.DocumentBuilderFactory;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -1929,6 +1930,18 @@ public class MessageTest {
 
         final Message seventhConstructor = new Message(rawMessage, dataDictionary, dataDictionary, false);
         assertNotNull(seventhConstructor.getHeader());
+    }
+
+    @Test
+    public void shouldConvertToXmlWhenDataDictionaryLoadedWithExternalDTD() throws ConfigError {
+        DataDictionary dataDictionary = new DataDictionary("FIX_External_DTD.xml", DocumentBuilderFactory::newInstance);
+
+        Message message = new Message();
+        message.setString(Account.FIELD, "test-account");
+
+        String xml = message.toXML(dataDictionary);
+        xml = xml.replace("\r", "").replace("\n", " ");
+        assertEquals("<?xml version=\"1.0\" encoding=\"ISO-8859-1\" standalone=\"no\"?> <message> <header/> <body> <field name=\"Account\" tag=\"1\"><![CDATA[test-account]]></field> </body> <trailer/> </message> ", xml);
     }
 
     private void assertHeaderField(Message message, String expectedValue, int field)

--- a/quickfixj-core/src/test/resources/FIX_External_DTD.xml
+++ b/quickfixj-core/src/test/resources/FIX_External_DTD.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE note SYSTEM "http://www.w3.org/Math/DTD/mathml1/mathml.dtd">
+<fix major="4" minor="4">
+    <header>
+        <field name="BeginString" required="Y"/>
+        <field name="MsgType" required="Y"/>
+    </header>
+    <trailer>
+        <field name="SignatureLength" required="N"/>
+        <field name="Signature" required="N"/>
+        <field name="CheckSum" required="Y"/>
+    </trailer>
+    <messages>
+        <message name="TestMessage" msgtype="A" msgcat="app">
+            <field name="Account" required="Y"/>
+        </message>
+    </messages>
+    <components/>
+    <fields>
+        <field number="1" name="Account" type="STRING"/>
+        <field number="8" name="BeginString" type="STRING"/>
+        <field number="10" name="CheckSum" type="STRING"/>
+        <field number="35" name="MsgType" type="STRING"/>
+        <field number="89" name="Signature" type="DATA"/>
+        <field number="93" name="SignatureLength" type="LENGTH"/>
+    </fields>
+</fix>


### PR DESCRIPTION
Fixes https://github.com/quickfix-j/quickfixj/issues/306

**Changes**

- data dictionary blocks external dtd/schema properties only when using JDK Xerces implementation
- removed dtd/schema properties from `quickfix.Message#toXML(quickfix.DataDictionary)` - it is not required as we are neither loading, nor validation against schemas
- unit tests

**Comments**

- dtd/schema properties probably are not required in `org.quickfixj.codegenerator.MessageCodeGenerator` as it uses files that belong to the codebase, so changes pointing to external dtd/schema would be visible in PRs (the only reason I can think to keep it there is if somebody is dependent on `org.quickfixj:quickfixj-codegenerator` directly in their project to customise message generation)
- this change fixes Xerces compatiblity problem, but if external Xerces dependency is being used, there is not easy way to supply `javax.xml.parsers.DocumentBuilderFactory` with custom properties or features  (https://xerces.apache.org/xerces2-j/features.html, https://xerces.apache.org/xerces2-j/properties.html). Additional changes have to be made to propagate `javax.xml.parsers.DocumentBuilderFactory` across the board.

