### PR TITLE
QFJ-456 - NetworkingOptions should be applied before the socket is connected

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/AbstractIoHandler.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/AbstractIoHandler.java
@@ -102,13 +102,7 @@ public abstract class AbstractIoHandler extends IoHandlerAdapter {
     }
 
     @Override
-    public void sessionCreated(IoSession ioSession) throws Exception {
-        super.sessionCreated(ioSession);
-        networkingOptions.apply(ioSession);
-    }
-
-    @Override
-    public void sessionClosed(IoSession ioSession) throws Exception {
+    public void sessionClosed(IoSession ioSession) {
         try {
             Session quickFixSession = findQFSession(ioSession);
             if (quickFixSession != null) {

--- a/quickfixj-core/src/main/java/quickfix/mina/NetworkingOptions.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/NetworkingOptions.java
@@ -19,7 +19,7 @@
 
 package quickfix.mina;
 
-import org.apache.mina.core.session.IoSession;
+import org.apache.mina.core.service.IoService;
 import org.apache.mina.core.session.IoSessionConfig;
 import org.apache.mina.transport.socket.SocketSessionConfig;
 import org.slf4j.Logger;
@@ -28,7 +28,6 @@ import quickfix.FieldConvertError;
 import quickfix.field.converter.BooleanConverter;
 import quickfix.field.converter.IntConverter;
 
-import java.net.SocketException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -126,8 +125,8 @@ public class NetworkingOptions {
         return value;
     }
 
-    public void apply(IoSession session) throws SocketException {
-        IoSessionConfig sessionConfig = session.getConfig();
+    public void apply(IoService service) {
+        IoSessionConfig sessionConfig = service.getSessionConfig();
         if (sessionConfig instanceof SocketSessionConfig) {
             SocketSessionConfig socketSessionConfig = (SocketSessionConfig) sessionConfig;
             if (keepAlive != null) {

--- a/quickfixj-core/src/main/java/quickfix/mina/ProtocolFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/ProtocolFactory.java
@@ -21,8 +21,6 @@ package quickfix.mina;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.HashMap;
 
 
@@ -36,7 +34,6 @@ import org.apache.mina.transport.vmpipe.VmPipeAddress;
 import org.apache.mina.transport.vmpipe.VmPipeConnector;
 import org.apache.mina.proxy.ProxyConnector;
 import org.apache.mina.proxy.handlers.ProxyRequest;
-import org.apache.mina.proxy.handlers.http.HttpAuthenticationMethods;
 import org.apache.mina.proxy.handlers.http.HttpProxyConstants;
 import org.apache.mina.proxy.handlers.http.HttpProxyRequest;
 import org.apache.mina.proxy.handlers.socks.SocksProxyConstants;

--- a/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
@@ -158,6 +158,7 @@ public class IoSessionInitiator {
 
             IoConnector newConnector;
             newConnector = ProtocolFactory.createIoConnector(socketAddresses[nextSocketAddressIndex]);
+            networkingOptions.apply(newConnector);
             newConnector.setHandler(new InitiatorIoHandler(fixSession, networkingOptions, eventHandlingStrategy));
             newConnector.setFilterChainBuilder(ioFilterChainBuilder);
 


### PR DESCRIPTION
As mentioned in the original JIRA certain socket options set after `org.apache.mina.core.service.IoHandlerAdapter#sessionOpened` event might not be configured properly as they require to be set before call to listen() or connect() e.g. SO_REUSEADDR, SO_RCVBUF.

**Changes**

- `quickfix.mina.NetworkingOptions` will be applied before sockets around bound. 

This chagne makes "SocketReceiveBufferSize" configuration TCP handshake advertisement correct and it will allow finer tweaking based on network capacity, system requirements etc.

Increasing the "SocketReceiveBufferSize" above 64KB was working correct for **initiators** already, but was fixed as part of https://issues.apache.org/jira/projects/DIRMINA/issues/DIRMINA-1123 for **acceptors**.

Please be aware that there is still an issue for **initiators** when setting "SocketReceiveBufferSize" below 65536 which will still use default os values.

https://github.com/apache/mina/blob/faf9e5cdaf40da3a816f789bd27c95e2f3b4d354/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioSocketConnector.java#L245