### PR TITLE
Set UtcTimestampPrecision in codegenerator

### DIFF
--- a/quickfixj-codegenerator/src/main/java/org/quickfixj/codegenerator/GenerateMojo.java
+++ b/quickfixj-codegenerator/src/main/java/org/quickfixj/codegenerator/GenerateMojo.java
@@ -87,6 +87,13 @@ public class GenerateMojo extends AbstractMojo {
     private String fieldPackage = "quickfix.field";
 
     /**
+     * The default UtcTimestampPrecision to be used during field code generation.
+     *
+     * @parameter
+     */
+    private String utcTimestampPrecision;
+
+    /**
      * The Maven project to act upon.
      *
      * @parameter expression="${project}"
@@ -135,6 +142,7 @@ public class GenerateMojo extends AbstractMojo {
             task.setMessagePackage(packaging);
             task.setOutputBaseDirectory(outputDirectory);
             task.setFieldPackage(fieldPackage);
+            task.setUtcTimestampPrecision(utcTimestampPrecision);
             task.setOverwrite(true);
             task.setOrderedFields(orderedFields);
             task.setDecimalGenerated(decimal);
@@ -299,5 +307,23 @@ public class GenerateMojo extends AbstractMojo {
      */
     public void setFieldPackage(String fieldPackage) {
         this.fieldPackage = fieldPackage;
+    }
+
+    /**
+     * Returns the default UtcTimestampPrecision to be used during field code generation.
+     *
+     * @return the default UtcTimestampPrecision to be used during field code generation.
+     */
+    public String getUtcTimestampPrecision() {
+        return utcTimestampPrecision;
+    }
+    
+    /**
+     * Sets the default UtcTimestampPrecision to be used during field code generation.
+     *
+     * @param utcTimestampPrecision the default UtcTimestampPrecision to be used during field code generation.
+     */
+    public void setUtcTimestampPrecision(String utcTimestampPrecision) {
+        this.utcTimestampPrecision = utcTimestampPrecision;
     }
 }

--- a/quickfixj-codegenerator/src/main/java/org/quickfixj/codegenerator/MessageCodeGenerator.java
+++ b/quickfixj-codegenerator/src/main/java/org/quickfixj/codegenerator/MessageCodeGenerator.java
@@ -61,6 +61,7 @@ public class MessageCodeGenerator {
     private static final String BIGDECIMAL_TYPE_OPTION = "generator.decimal";
     private static final String ORDERED_FIELDS_OPTION = "generator.orderedFields";
     private static final String OVERWRITE_OPTION = "generator.overwrite";
+    private static final String UTC_TIMESTAMP_PRECISION_OPTION = "generator.utcTimestampPrecision";
 
     // An arbitrary serial UID which will have to be changed when messages and fields won't be compatible with next versions in terms
     // of java serialization.
@@ -461,6 +462,7 @@ public class MessageCodeGenerator {
                 return;
             }
 
+            String utcTimestampPrecision = getOption(UTC_TIMESTAMP_PRECISION_OPTION, null);
             boolean overwrite = getOption(OVERWRITE_OPTION, true);
             boolean orderedFields = getOption(ORDERED_FIELDS_OPTION, false);
             boolean useDecimal = getOption(BIGDECIMAL_TYPE_OPTION, false);
@@ -477,7 +479,7 @@ public class MessageCodeGenerator {
                 task.setMessagePackage("quickfix." + version.toLowerCase());
                 task.setOutputBaseDirectory(new File(args[2]));
                 task.setFieldPackage("quickfix.field");
-                task.setUtcTimestampPrecision(task.utcTimestampPrecision);
+                task.setUtcTimestampPrecision(utcTimestampPrecision);
                 task.setOverwrite(overwrite);
                 task.setOrderedFields(orderedFields);
                 task.setDecimalGenerated(useDecimal);
@@ -491,6 +493,11 @@ public class MessageCodeGenerator {
             codeGenerator.logError("error during code generation", e);
             System.exit(1);
         }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static String getOption(String key, String defaultValue) {
+        return System.getProperties().getProperty(key, defaultValue);
     }
 
     private static boolean getOption(String key, boolean defaultValue) {

--- a/quickfixj-codegenerator/src/main/java/org/quickfixj/codegenerator/MessageCodeGenerator.java
+++ b/quickfixj-codegenerator/src/main/java/org/quickfixj/codegenerator/MessageCodeGenerator.java
@@ -147,7 +147,7 @@ public class MessageCodeGenerator {
                         String utcTimestampPrecisionParameterName = "utcTimestampPrecision";
                         if (!UTC_TIMESTAMP_PRECISION_ALLOWED_VALUES.contains(utcTimestampPrecision)) {
                             throw new CodeGenerationException(new IllegalArgumentException(String.format(
-                                "Allowed values for parameter %s is %s. Supplied value: \"%s\".",
+                                "Allowed values for parameter %s are %s. Supplied value: \"%s\".",
                                 utcTimestampPrecisionParameterName,
                                 String.join(", ", UTC_TIMESTAMP_PRECISION_ALLOWED_VALUES),
                                 utcTimestampPrecision

--- a/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/Fields.xsl
+++ b/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/Fields.xsl
@@ -61,20 +61,18 @@
 package <xsl:value-of select="$fieldPackage"/>;
 
 import quickfix.<xsl:call-template name="get-field-type"/>Field;
-<xsl:choose>
-    <xsl:when test="$utcTimestampPrecision">
-        <xsl:if test="@type='UTCTIMESTAMP' or @type='UTCTIME' or @type='UTCTIMEONLY'">
-import quickfix.UtcTimestampPrecision;
-        </xsl:if>
-    </xsl:when>
-</xsl:choose>
+<xsl:if test="@type='UTCTIMESTAMP' or @type='UTCTIME' or @type='UTCTIMEONLY'">
+<xsl:choose><xsl:when test="$utcTimestampPrecision">import quickfix.UtcTimestampPrecision;
+</xsl:when></xsl:choose></xsl:if>
 <xsl:if test="@type='UTCTIMESTAMP'">
-import java.time.LocalDateTime;</xsl:if>
+import java.time.LocalDateTime;
+</xsl:if>
 <xsl:if test="@type='UTCDATE' or @type='UTCDATEONLY'">
-import java.time.LocalDate;</xsl:if>
+import java.time.LocalDate;
+</xsl:if>
 <xsl:if test="@type='UTCTIME' or @type='UTCTIMEONLY'">
-import java.time.LocalTime;</xsl:if>
-
+import java.time.LocalTime;
+</xsl:if>
 public class <xsl:value-of select="@name"/> extends <xsl:call-template name="get-field-type"/>Field {
 
 	static final long serialVersionUID = <xsl:value-of select="$serialVersionUID"/>;
@@ -87,27 +85,18 @@ public class <xsl:value-of select="@name"/> extends <xsl:call-template name="get
 
 	public <xsl:value-of select="@name"/>(<xsl:call-template name="get-type"/> data) {
 		super(<xsl:value-of select="@number"/>, data<xsl:if test="@type='UTCTIMESTAMP' or @type='UTCTIMEONLY'"><xsl:choose><xsl:when test="$utcTimestampPrecision">, UtcTimestampPrecision.<xsl:value-of select="$utcTimestampPrecision"/></xsl:when><xsl:otherwise>, true</xsl:otherwise></xsl:choose></xsl:if><xsl:if test="@type='UTCTIME'"><xsl:choose><xsl:when test="$utcTimestampPrecision">, UtcTimestampPrecision.<xsl:value-of select="$utcTimestampPrecision"/></xsl:when></xsl:choose></xsl:if>);
-	}
-	<xsl:variable name="dataType"><xsl:call-template name="get-type"/></xsl:variable>
+	}<xsl:variable name="dataType"><xsl:call-template name="get-type"/></xsl:variable><xsl:if test="$dataType = 'java.math.BigDecimal'">
 
-	<xsl:if test="$dataType = 'java.math.BigDecimal'">
-	public <xsl:value-of select="@name"/>(double data) {
+    public <xsl:value-of select="@name"/>(double data) {
 		super(<xsl:value-of select="@number"/>, new <xsl:value-of select="$dataType"/>(data));
-	}
-	</xsl:if>
+	}</xsl:if><xsl:if test="@type='UTCTIMESTAMP' or @type='UTCTIME' or @type='UTCTIMEONLY'">
+    <xsl:choose><xsl:when test="$utcTimestampPrecision">
 
-    <xsl:choose>
-        <xsl:when test="$utcTimestampPrecision">
-            <xsl:if test="@type='UTCTIMESTAMP' or @type='UTCTIME' or @type='UTCTIMEONLY'">
     @Override
     protected UtcTimestampPrecision getDefaultUtcTimestampPrecision() {
         return UtcTimestampPrecision.<xsl:value-of select="$utcTimestampPrecision"/>;
-    }
-            </xsl:if>
-        </xsl:when>
-    </xsl:choose>
-}
-</xsl:template>
+    }</xsl:when></xsl:choose></xsl:if>
+}</xsl:template>
 
 <xsl:template name="get-type">
    <xsl:choose>

--- a/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/Fields.xsl
+++ b/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/Fields.xsl
@@ -22,6 +22,7 @@
  <xsl:output method="text" encoding="UTF-8"/>
  <xsl:param name="fieldName"/>
  <xsl:param name="fieldPackage"/>
+ <xsl:param name="utcTimestampPrecision"/>
  <xsl:param name="decimalType">double</xsl:param>
  <xsl:param name="decimalConverter">Double</xsl:param>
  <xsl:param name="serialVersionUID"/>
@@ -60,11 +61,18 @@
 package <xsl:value-of select="$fieldPackage"/>;
 
 import quickfix.<xsl:call-template name="get-field-type"/>Field;
+<xsl:choose>
+    <xsl:when test="$utcTimestampPrecision">
+        <xsl:if test="@type='UTCTIMESTAMP' or @type='UTCTIME' or @type='UTCTIMEONLY'">
+import quickfix.UtcTimestampPrecision;
+        </xsl:if>
+    </xsl:when>
+</xsl:choose>
 <xsl:if test="@type='UTCTIMESTAMP'">
 import java.time.LocalDateTime;</xsl:if>
 <xsl:if test="@type='UTCDATE' or @type='UTCDATEONLY'">
 import java.time.LocalDate;</xsl:if>
-<xsl:if test="@type='UTCTIMEONLY'">
+<xsl:if test="@type='UTCTIME' or @type='UTCTIMEONLY'">
 import java.time.LocalTime;</xsl:if>
 
 public class <xsl:value-of select="@name"/> extends <xsl:call-template name="get-field-type"/>Field {
@@ -78,7 +86,7 @@ public class <xsl:value-of select="@name"/> extends <xsl:call-template name="get
 	}
 
 	public <xsl:value-of select="@name"/>(<xsl:call-template name="get-type"/> data) {
-		super(<xsl:value-of select="@number"/>, data<xsl:if test="@type='UTCTIMESTAMP' or @type='UTCTIMEONLY'">, true</xsl:if>);
+		super(<xsl:value-of select="@number"/>, data<xsl:if test="@type='UTCTIMESTAMP' or @type='UTCTIMEONLY'"><xsl:choose><xsl:when test="$utcTimestampPrecision">, UtcTimestampPrecision.<xsl:value-of select="$utcTimestampPrecision"/></xsl:when><xsl:otherwise>, true</xsl:otherwise></xsl:choose></xsl:if><xsl:if test="@type='UTCTIME'"><xsl:choose><xsl:when test="$utcTimestampPrecision">, UtcTimestampPrecision.<xsl:value-of select="$utcTimestampPrecision"/></xsl:when></xsl:choose></xsl:if>);
 	}
 	<xsl:variable name="dataType"><xsl:call-template name="get-type"/></xsl:variable>
 
@@ -87,6 +95,17 @@ public class <xsl:value-of select="@name"/> extends <xsl:call-template name="get
 		super(<xsl:value-of select="@number"/>, new <xsl:value-of select="$dataType"/>(data));
 	}
 	</xsl:if>
+
+    <xsl:choose>
+        <xsl:when test="$utcTimestampPrecision">
+            <xsl:if test="@type='UTCTIMESTAMP' or @type='UTCTIME' or @type='UTCTIMEONLY'">
+    @Override
+    protected UtcTimestampPrecision getDefaultUtcTimestampPrecision() {
+        return UtcTimestampPrecision.<xsl:value-of select="$utcTimestampPrecision"/>;
+    }
+            </xsl:if>
+        </xsl:when>
+    </xsl:choose>
 }
 </xsl:template>
 
@@ -100,6 +119,7 @@ public class <xsl:value-of select="@name"/> extends <xsl:call-template name="get
      <xsl:when test="@type='QTY'"><xsl:value-of select="$decimalType"/></xsl:when>
      <xsl:when test="@type='CURRENCY'">String</xsl:when>
      <xsl:when test="@type='UTCTIMESTAMP'">LocalDateTime</xsl:when>
+     <xsl:when test="@type='UTCTIME'">LocalTime</xsl:when>
      <xsl:when test="@type='UTCTIMEONLY'">LocalTime</xsl:when>
      <xsl:when test="@type='UTCDATE'">LocalDate</xsl:when>
      <xsl:when test="@type='UTCDATEONLY'">LocalDate</xsl:when>
@@ -127,6 +147,7 @@ public class <xsl:value-of select="@name"/> extends <xsl:call-template name="get
      <xsl:when test="@type='QTY'"><xsl:value-of select="$decimalConverter"/></xsl:when>
      <xsl:when test="@type='CURRENCY'">String</xsl:when>
      <xsl:when test="@type='UTCTIMESTAMP'">UtcTimeStamp</xsl:when>
+     <xsl:when test="@type='UTCTIME'">UtcTime</xsl:when>
      <xsl:when test="@type='UTCTIMEONLY'">UtcTimeOnly</xsl:when>
      <xsl:when test="@type='UTCDATE'">UtcDateOnly</xsl:when>
      <xsl:when test="@type='UTCDATEONLY'">UtcDateOnly</xsl:when>

--- a/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/Fields.xsl
+++ b/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/Fields.xsl
@@ -84,7 +84,7 @@ public class <xsl:value-of select="@name"/> extends <xsl:call-template name="get
 	}
 
 	public <xsl:value-of select="@name"/>(<xsl:call-template name="get-type"/> data) {
-		super(<xsl:value-of select="@number"/>, data<xsl:if test="@type='UTCTIMESTAMP' or @type='UTCTIMEONLY'"><xsl:choose><xsl:when test="$utcTimestampPrecision">, UtcTimestampPrecision.<xsl:value-of select="$utcTimestampPrecision"/></xsl:when><xsl:otherwise>, true</xsl:otherwise></xsl:choose></xsl:if><xsl:if test="@type='UTCTIME'"><xsl:choose><xsl:when test="$utcTimestampPrecision">, UtcTimestampPrecision.<xsl:value-of select="$utcTimestampPrecision"/></xsl:when></xsl:choose></xsl:if>);
+		super(<xsl:value-of select="@number"/>, data<xsl:if test="@type='UTCTIMESTAMP' or @type='UTCTIMEONLY'"><xsl:choose><xsl:when test="$utcTimestampPrecision"/><xsl:otherwise>, true</xsl:otherwise></xsl:choose></xsl:if>);
 	}<xsl:variable name="dataType"><xsl:call-template name="get-type"/></xsl:variable><xsl:if test="$dataType = 'java.math.BigDecimal'">
 
     public <xsl:value-of select="@name"/>(double data) {

--- a/quickfixj-core/src/main/doc/usermanual/usage/codegen.html
+++ b/quickfixj-core/src/main/doc/usermanual/usage/codegen.html
@@ -44,11 +44,11 @@ process. The types of customizations currently supported include:
 <tr>
 	<td>outputBaseDirectory</td>
 	<td>The base directory where generated source code will be placed.</td>
-</td>
+</tr>
 <tr>
 	<td>overwrite</td>
 	<td>Controls whether existings files are overwritten. Usually this would be true.</td>
-</td>
+</tr>
 <tr>
 	<td>messagePackage</td>
 	<td>The Java package for the generated messages. This would be something like "my.message.fix42".
@@ -67,12 +67,16 @@ process. The types of customizations currently supported include:
 	the meta. Although the FIX specification does not require this ordering, some exchanges do
 	require it. There may be a slight (probably very slight) performance degradation when
 	using this option.</td>
-</td>
+</tr>
 <tr>
 	<td>decimalGenerated</td>
 	<td>Generates BigDecimals for price, quantity, and similar fields. The default code
 	generation generated doubles to be compatible with the QuickFIX C++ implementation.</td>
-</td>
+</tr>
+<tr>
+	<td>utcTimestampPrecision</td>
+	<td>The default UtcTimestampPrecision to be used during field code generation.</td>
+</tr>
 </table>
 <p>
 To generate you own message library, you can create a program that uses the <code>MessageCodeGenerator</code>

--- a/quickfixj-core/src/main/java/quickfix/UtcTimeField.java
+++ b/quickfixj-core/src/main/java/quickfix/UtcTimeField.java
@@ -27,7 +27,7 @@ import java.time.ZoneOffset;
  */
 public class UtcTimeField extends Field<LocalTime> {
 
-    protected UtcTimestampPrecision precision = UtcTimestampPrecision.MILLIS;
+    protected UtcTimestampPrecision precision = getDefaultUtcTimestampPrecision();
 
     protected UtcTimeField(int field) {
         super(field, LocalTime.now(ZoneOffset.UTC));
@@ -56,5 +56,9 @@ public class UtcTimeField extends Field<LocalTime> {
     
     public UtcTimestampPrecision getPrecision() {
         return precision;
+    }
+
+    protected UtcTimestampPrecision getDefaultUtcTimestampPrecision() {
+        return UtcTimestampPrecision.MILLIS;
     }
 }

--- a/quickfixj-core/src/main/java/quickfix/UtcTimeOnlyField.java
+++ b/quickfixj-core/src/main/java/quickfix/UtcTimeOnlyField.java
@@ -27,7 +27,7 @@ import java.time.ZoneOffset;
  */
 public class UtcTimeOnlyField extends Field<LocalTime> {
     
-    private UtcTimestampPrecision precision = UtcTimestampPrecision.MILLIS;
+    private UtcTimestampPrecision precision = getDefaultUtcTimestampPrecision();
 
     public UtcTimeOnlyField(int field) {
         super(field, LocalTime.now(ZoneOffset.UTC));
@@ -68,4 +68,7 @@ public class UtcTimeOnlyField extends Field<LocalTime> {
         return getValue().equals(value);
     }
 
+    protected UtcTimestampPrecision getDefaultUtcTimestampPrecision() {
+        return UtcTimestampPrecision.MILLIS;
+    }
 }

--- a/quickfixj-core/src/main/java/quickfix/UtcTimeStampField.java
+++ b/quickfixj-core/src/main/java/quickfix/UtcTimeStampField.java
@@ -27,7 +27,7 @@ import java.time.ZoneOffset;
  */
 public class UtcTimeStampField extends Field<LocalDateTime> {
 
-    private UtcTimestampPrecision precision = UtcTimestampPrecision.MILLIS;
+    private UtcTimestampPrecision precision = getDefaultUtcTimestampPrecision();
 
     public UtcTimeStampField(int field) {
         super(field, LocalDateTime.now(ZoneOffset.UTC));
@@ -73,4 +73,7 @@ public class UtcTimeStampField extends Field<LocalDateTime> {
         return getValue().equals(value);
     }
 
+    protected UtcTimestampPrecision getDefaultUtcTimestampPrecision() {
+        return UtcTimestampPrecision.MILLIS;
+    }
 }


### PR DESCRIPTION
Fixes #310

Added support for setting a default UtcTimestampPrecision in the
quickfixj-codegenerator Maven plugin. The default applies to the
following classes and their generated sub classes.
- UtcTimeField
- UtcTimeOnlyField
- UtcTimeStampField