### PR TITLE
Wait for Logout response or timeout before disconnect on session reset

### DIFF
--- a/quickfixj-core/src/main/java/org/quickfixj/jmx/mbean/session/SessionAdmin.java
+++ b/quickfixj-core/src/main/java/org/quickfixj/jmx/mbean/session/SessionAdmin.java
@@ -135,7 +135,7 @@ public class SessionAdmin extends NotificationBroadcasterSupport implements Sess
     /* (non-Javadoc)
      * @see quickfix.jmx.SessionMBean#reset()
      */
-    public void reset() throws IOException {
+    public void reset() {
         logInvocation("reset");
         session.reset();
     }

--- a/quickfixj-core/src/main/java/quickfix/SessionState.java
+++ b/quickfixj-core/src/main/java/quickfix/SessionState.java
@@ -65,6 +65,12 @@ public final class SessionState {
     private boolean resetReceived;
     private String logoutReason;
 
+    /**
+     * Indicates whether resetting the internal state is still pending.
+     * Used when resetting sequence numbers after Logout.
+     */
+    private boolean resetStatePending = false;
+
     /*
      * If this is anything other than zero it's the value of the 789/NextExpectedMsgSeqNum tag in the last Logon message sent.
      * It is used to determine if the recipient has enough information (assuming they support 789) to avoid the need
@@ -432,6 +438,19 @@ public final class SessionState {
             this.resetSent = resetSent;
         }
     }
+    
+    public boolean isResetStatePending() {
+        synchronized (lock) {
+            return resetStatePending;
+        }
+    }
+
+    public void setResetStatePending(boolean resetStatePending) {
+        synchronized (lock) {
+            this.resetStatePending = resetStatePending;
+        }
+    }
+
 
     /**
      * No actual resend request has occurred but at logon we populated tag 789 so that the other side knows we

--- a/quickfixj-core/src/test/java/quickfix/SessionResetTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionResetTest.java
@@ -55,13 +55,7 @@ public class SessionResetTest {
             header.setInt(MsgSeqNum.FIELD, 1);
             header.setUtcTimeStamp(SendingTime.FIELD, SystemTime.getLocalDateTime(), true);
             
-            Thread resetThread = new Thread(() -> {
-                try {
-                    session.reset();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }, "SessionReset");
+            Thread resetThread = new Thread(session::reset, "SessionReset");
             resetThread.setDaemon(true);
             
             Thread messageSender = new Thread(() -> {

--- a/quickfixj-core/src/test/java/quickfix/test/acceptance/ATApplication.java
+++ b/quickfixj-core/src/test/java/quickfix/test/acceptance/ATApplication.java
@@ -19,8 +19,6 @@
 
 package quickfix.test.acceptance;
 
-import java.io.IOException;
-
 import org.junit.Assert;
 
 import quickfix.Application;
@@ -41,12 +39,8 @@ public class ATApplication implements Application {
     private boolean isLoggedOn;
 
     public void onCreate(SessionID sessionID) {
-        try {
-            assertNoSessionLock(sessionID);
-            Session.lookupSession(sessionID).reset();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        assertNoSessionLock(sessionID);
+        Session.lookupSession(sessionID).reset();
     }
 
     public synchronized void onLogon(SessionID sessionID) {


### PR DESCRIPTION
Fixes #244

_This is my first attempt to contribute to the core QuickFIX/J codebase. Please read the described changes bellow and review the changes thoroughly._

### Relevant changes

**quickfix.Session#reset()**
* When there is a need to logout: Instead of calling `quickfix.Session#generateLogout()` followed by `quickfix.Session#disconnect(String, boolean)`, set `quickfix.Session#isResetStatePending` flag and call `quickfix.Session#logout(String)` followed by `quickfix.Session#generateLogout(String)`. `quickfix.Session#logout(String)` will set `quickfix.Session#enabled` to `false` and `quickfix.Session#generateLogout(String)` will send a `Logout` message. The flag `quickfix.Session#isResetStatePending` is checked when `Logout` response is received or when timing out waiting for a `Logout` response.
* Only call `quickfix.Session#resetState()` if there is no need to logout.

**quickfix.Session#nextLogout(Message)**
* Reset state also if `quickfix.Session#isResetStatePending` flag is set.

**quickfix.Session#next()**
* Do not call `quickfix.Session#reset()` when outside of session time and `quickfix.Session#isResetStatePending` flag is set.
* When outside of session time and reset is not needed and reset state is pending, call `quickfix.Session#disconnect(String, boolean)`.
* Check for `Logout` timeout before `HeartBeat` timeout.

**quickfix.Session#disconnect(String, boolean)**
* Reset state also if `quickfix.Session#isResetStatePending` flag is set.

**quickfix.Session#resetState()**
* Clear `quickfix.Session#isResetStatePending` flag.

**quickfix.SessionTest#testLogonLogoutOnAcceptor()**
* Call `quickfix.SessionTest#logoutFrom(Session, int)`. This is needed because we need to receive a Logout response in order to trigger the session reset.

**quickfix.SessionTest#testStartOfInitiatorOutsideOfSessionTime()**
* Call `quickfix.SessionTest#logoutFrom(Session, int)`. This is needed because we need to receive a Logout response in order to trigger the session reset. If we would like to simulate a `Logout` timeout instead since we are outside of session time, we could replace the call to `quickfix.SessionTest#logoutFrom(Session, int)` with `systemTimeSource.increment(TimeUnit.HOURS.toMillis(state.getLogoutTimeout()) * 2); session.next();`.