### PR TITLE
Add reconnectThreads functionality to ThreadedSocketInitiator.

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
@@ -31,7 +31,7 @@ public class ThreadedSocketInitiator extends AbstractSocketInitiator {
 
     private ThreadedSocketInitiator(Builder builder) throws ConfigError {
         super(builder.application, builder.messageStoreFactory, builder.settings,
-                builder.logFactory, builder.messageFactory);
+                builder.logFactory, builder.messageFactory, builder.numReconnectThreads);
 
         if (builder.queueCapacity >= 0) {
             eventHandlingStrategy
@@ -47,8 +47,16 @@ public class ThreadedSocketInitiator extends AbstractSocketInitiator {
     }
 
     public static final class Builder extends AbstractSessionConnectorBuilder<Builder, ThreadedSocketInitiator> {
+        
+        int numReconnectThreads = 3;
+        
         private Builder() {
             super(Builder.class);
+        }
+
+        public Builder withReconnectThreads(int numReconnectThreads) throws ConfigError {
+            this.numReconnectThreads = numReconnectThreads;
+            return this;
         }
 
         @Override

--- a/quickfixj-core/src/main/java/quickfix/mina/acceptor/AbstractSocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/acceptor/AbstractSocketAcceptor.java
@@ -238,7 +238,7 @@ public abstract class AbstractSocketAcceptor extends SessionConnector implements
                     }
                 } catch (Throwable t) {
                     if (continueInitOnError) {
-                        log.error("error during session initialization, continuing...", t);
+                        log.error("error during session initialization for {}, continuing...", sessionID, t);
                     } else {
                         throw t instanceof ConfigError ? (ConfigError) t : new ConfigError(
                                 "error during session initialization", t);

--- a/quickfixj-core/src/main/java/quickfix/mina/initiator/AbstractSocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/initiator/AbstractSocketInitiator.java
@@ -216,7 +216,7 @@ public abstract class AbstractSocketInitiator extends SessionConnector implement
                     }
                 } catch (final Throwable e) {
                     if (continueInitOnError) {
-                        log.error("error during session initialization, continuing...", e);
+                        log.error("error during session initialization for {}, continuing...", sessionID, e);
                     } else {
                         throw e instanceof ConfigError ? (ConfigError) e : new ConfigError(
                                 "error during session initialization", e);


### PR DESCRIPTION
 - was only possible for SocketInitiators (non-threaded) up to now
 - see #254 / #255 for original issue
 - improved error message in AbstractSocketAcceptor/Initiator