### PR TITLE
Made start/stop of SocketInitiator/SocketAcceptor thread-safe.

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/SocketInitiator.java
@@ -19,6 +19,7 @@
 
 package quickfix;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import quickfix.mina.EventHandlingStrategy;
 import quickfix.mina.SingleThreadedEventHandlingStrategy;
 import quickfix.mina.initiator.AbstractSocketInitiator;
@@ -28,7 +29,7 @@ import quickfix.mina.initiator.AbstractSocketInitiator;
  * sessions.
  */
 public class SocketInitiator extends AbstractSocketInitiator {
-    private volatile Boolean isStarted = Boolean.FALSE;
+    private final AtomicBoolean isStarted = new AtomicBoolean(false);
     private final SingleThreadedEventHandlingStrategy eventHandlingStrategy;
 
     private SocketInitiator(Builder builder) throws ConfigError {
@@ -120,7 +121,7 @@ public class SocketInitiator extends AbstractSocketInitiator {
     }
     
     private void initialize() throws ConfigError {
-        if (isStarted.equals(Boolean.FALSE)) {
+        if (isStarted.compareAndSet(false, true)) {
             eventHandlingStrategy.setExecutor(longLivedExecutor);
             createSessionInitiators();
             for (Session session : getSessionMap().values()) {
@@ -128,7 +129,6 @@ public class SocketInitiator extends AbstractSocketInitiator {
             }
             startInitiators();
             eventHandlingStrategy.blockInThread();
-            isStarted = Boolean.TRUE;
         } else {
             log.warn("Ignored attempt to start already running SocketInitiator.");
         }
@@ -136,7 +136,7 @@ public class SocketInitiator extends AbstractSocketInitiator {
 
     @Override
     public void stop(boolean forceDisconnect) {
-        if (isStarted.equals(Boolean.TRUE)) {
+        if (isStarted.get() == true) {
             try {
                 logoutAllSessions(forceDisconnect);
                 stopInitiators();
@@ -146,7 +146,7 @@ public class SocketInitiator extends AbstractSocketInitiator {
                 } finally {
                     Session.unregisterSessions(getSessions(), true);
                     clearConnectorSessions();
-                    isStarted = Boolean.FALSE;
+                    isStarted.set(false);
                 }
             }
         }

--- a/quickfixj-core/src/main/java/quickfix/mina/acceptor/AbstractSocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/acceptor/AbstractSocketAcceptor.java
@@ -56,6 +56,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Abstract base class for socket acceptors.
@@ -64,7 +66,7 @@ public abstract class AbstractSocketAcceptor extends SessionConnector implements
     private final Map<SocketAddress, AcceptorSessionProvider> sessionProviders = new HashMap<>();
     private final SessionFactory sessionFactory;
     private final Map<SocketAddress, AcceptorSocketDescriptor> socketDescriptorForAddress = new HashMap<>();
-    private final Map<AcceptorSocketDescriptor, IoAcceptor> ioAcceptors = new HashMap<>();
+    private final ConcurrentMap<AcceptorSocketDescriptor, IoAcceptor> ioAcceptors = new ConcurrentHashMap<>();
 
     protected AbstractSocketAcceptor(SessionSettings settings, SessionFactory sessionFactory)
             throws ConfigError {

--- a/quickfixj-core/src/main/java/quickfix/mina/initiator/AbstractSocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/initiator/AbstractSocketInitiator.java
@@ -47,10 +47,10 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -63,7 +63,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class AbstractSocketInitiator extends SessionConnector implements Initiator {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
-    private final Set<IoSessionInitiator> initiators = new HashSet<>();
+    private final Set<IoSessionInitiator> initiators = ConcurrentHashMap.newKeySet();
     private final ScheduledExecutorService scheduledReconnectExecutor;
     public static final String QFJ_RECONNECT_THREAD_PREFIX = "QFJ Reconnect Thread-";
 


### PR DESCRIPTION
To prevent errors like the following in CI workflow (mostly on Windows):
`Error:    SingleThreadedEventHandlingStrategyTest.shouldCleanUpInitiatorQFJMessageProcessorThreadAfterStop:294 ConcurrentModification`
But could probably also happen in the wild.