### PR TITLE
Add methods to `FieldMap` API to make it usable in for-each loop

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/DataDictionary.java
+++ b/quickfixj-core/src/main/java/quickfix/DataDictionary.java
@@ -43,7 +43,6 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -698,9 +697,8 @@ public class DataDictionary {
 
     private void iterate(FieldMap map, String msgType, DataDictionary dd) throws IncorrectTagValue,
             IncorrectDataFormat {
-        final Iterator<Field<?>> iterator = map.iterator();
-        while (iterator.hasNext()) {
-            final StringField field = (StringField) iterator.next();
+        for (final Field<?> f : map) {
+            final StringField field = (StringField) f;
 
             checkHasValue(field);
 

--- a/quickfixj-core/src/main/java/quickfix/FieldMap.java
+++ b/quickfixj-core/src/main/java/quickfix/FieldMap.java
@@ -45,7 +45,7 @@ import java.util.Map.Entry;
 /**
  * Field container used by messages, groups, and composites.
  */
-public abstract class FieldMap implements Serializable {
+public abstract class FieldMap implements Serializable, Iterable<Field<?>> {
 
     static final long serialVersionUID = -3193357271891865972L;
 
@@ -448,6 +448,7 @@ public abstract class FieldMap implements Serializable {
         fields.remove(field);
     }
 
+    @Override
     public Iterator<Field<?>> iterator() {
         return fields.values().iterator();
     }
@@ -602,7 +603,11 @@ public abstract class FieldMap implements Serializable {
     }
 
     public Iterator<Integer> groupKeyIterator() {
-        return groups.keySet().iterator();
+        return groupKeys().iterator();
+    }
+
+    public Iterable<Integer> groupKeys() {
+        return groups.keySet();
     }
 
     Map<Integer, List<Group>> getGroups() {

--- a/quickfixj-core/src/main/java/quickfix/FieldMap.java
+++ b/quickfixj-core/src/main/java/quickfix/FieldMap.java
@@ -602,10 +602,19 @@ public abstract class FieldMap implements Serializable, Iterable<Field<?>> {
         return getGroups(tag).size();
     }
 
+    /**
+     * @deprecated use {@linkplain #groupKeys()} instead
+     */
+    @Deprecated
     public Iterator<Integer> groupKeyIterator() {
         return groupKeys().iterator();
     }
 
+    /**
+     * Returns tags which are repeating group counters as {@code Iterable}
+     *
+     * @return tags which are repeating group counters
+     */
     public Iterable<Integer> groupKeys() {
         return groups.keySet();
     }

--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -66,7 +66,6 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.ByteArrayOutputStream;
 import java.text.DecimalFormat;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -356,9 +355,7 @@ public class Message extends FieldMap {
         final Document document = message.getOwnerDocument();
         final Element fields = document.createElement(section);
         message.appendChild(fields);
-        final Iterator<Field<?>> fieldItr = fieldMap.iterator();
-        while (fieldItr.hasNext()) {
-            final Field<?> field = fieldItr.next();
+        for (final Field<?> field : fieldMap) {
             final Element fieldElement = document.createElement("field");
             if (dataDictionary != null) {
                 final String name = dataDictionary.getFieldName(field.getTag());
@@ -376,9 +373,7 @@ public class Message extends FieldMap {
             fieldElement.appendChild(value);
             fields.appendChild(fieldElement);
         }
-        final Iterator<Integer> groupKeyItr = fieldMap.groupKeyIterator();
-        while (groupKeyItr.hasNext()) {
-            final int groupKey = groupKeyItr.next();
+        for (final int groupKey : fieldMap.groupKeys()) {
             final Element groupsElement = document.createElement("groups");
             fields.appendChild(groupsElement);
             if (dataDictionary != null) {


### PR DESCRIPTION
FieldMap already provides iterator() to inspect all fields, however does not implement Iterable - and so can't be used in for-each loop. This PR adds Iterable interface, as well as groupKeys() which exposes group keys as Iterable.
The motivation for the change is that in some cases it is useful to traverse message as a tree of key-value pairs - e.g. when visualising message structure in UI, or transforming it to another intermediate representation. Being able to iterate in a more idiomatic Collection-like way improves readability of such code.

I was thinking about marking iterator() and groupKeyIterator() as deprecated - I don't see any advantages of those methods over Iterable. In the end decided to not do this for the first cut, but they can be eventually retired.