### PR TITLE
add oracle ddl tables event_log and messages_log (QFJ-979)

### DIFF
--- a/quickfixj-core/src/main/resources/config/sql/oracle/event_log_table.sql
+++ b/quickfixj-core/src/main/resources/config/sql/oracle/event_log_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE event_log (
+  id INTEGER GENERATED ALWAYS AS IDENTITY INCREMENT BY 1 START WITH 1 CACHE 1000,
+  time TIMESTAMP NOT NULL,
+  beginstring VARCHAR2(8) NOT NULL,
+  sendercompid VARCHAR2(64) NOT NULL,
+  sendersubid VARCHAR2(64) NOT NULL,
+  senderlocid VARCHAR2(64) NOT NULL,
+  targetcompid VARCHAR2(64) NOT NULL,
+  targetsubid VARCHAR2(64) NOT NULL,
+  targetlocid VARCHAR2(64) NOT NULL,
+  session_qualifier VARCHAR2(64) NOT NULL,
+  text VARCHAR2(4000) NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/quickfixj-core/src/main/resources/config/sql/oracle/messages_log_table.sql
+++ b/quickfixj-core/src/main/resources/config/sql/oracle/messages_log_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE messages_log (
+  id INTEGER GENERATED ALWAYS AS IDENTITY INCREMENT BY 1 START WITH 1 CACHE 1000,
+  time TIMESTAMP NOT NULL,
+  beginstring VARCHAR2(8) NOT NULL,
+  sendercompid VARCHAR2(64) NOT NULL,
+  sendersubid VARCHAR2(64) NOT NULL,
+  senderlocid VARCHAR2(64) NOT NULL,
+  targetcompid VARCHAR2(64) NOT NULL,
+  targetsubid VARCHAR2(64) NOT NULL,
+  targetlocid VARCHAR2(64) NOT NULL,
+  session_qualifier VARCHAR2(64) NOT NULL,
+  text VARCHAR2(4000) NOT NULL,
+  PRIMARY KEY (id)
+);


### PR DESCRIPTION
Closes #348 

Add Oracle DDLs to create `event_log` and `messages_log` tables.

This is possible to test running one [Oracle 12c R2](https://hub.docker.com/_/oracle-database-enterprise-edition) container and following these steps:

## Login on dockerhub and accept the terms to use Oracle Database
https://hub.docker.com/_/oracle-database-enterprise-edition

## Make a docker login and run the database container

```
docker login
docker run -d -it -p 1521:1521 --name oracle-db store/oracle/database-enterprise:12.2.0.1-slim
```
## Login as a sysdba in the database
Example with DBeaver:
- Host: localhost
- Port: 1521
- Database: ORCLCDB
- Type: SID
- Username: sys
- Password: Oradoc_db1
- Role: sysdba

### Allow the creation of a user
```sql
alter session set "_ORACLE_SCRIPT"=true;
```

### Create QUICKFIX user
```sql
create user QUICKFIX identified by QUICKFIX;
```

### Grant all privileges to the user
```sql
GRANT ALL PRIVILEGES TO QUICKFIX;
```
## Login again with the QUICKFIX user
Example with DBeaver:
- Host: localhost
- Port: 1521
- Database: ORCLCDB
- Type: SID
- Username: QUICKFIX
- Password: QUICKFIX
- Role: normal

### Execute the Oracle DDLs
Now you only have to execute the Oracle DDLs that are at `quickfixj/quickfixj-core/src/main/resources/config/sql/oracle`

## Test it with Banzai

### Configuration
JdbcURL=jdbc:oracle:thin:@localhost:1521/ORCLCDB.localdomain
JdbcUser=QUICKFIX
JdbcPassword=QUICKFIX
JdbcDriver=oracle.jdbc.driver.OracleDriver

### Import the Oracle driver
```xml
    <dependency>
      <groupId>com.oracle.ojdbc</groupId>
      <artifactId>ojdbc10</artifactId>
      <version>19.3.0.0</version>
    </dependency>
```

### Obtaining the DataSource
```java
import javax.sql.DataSource;
import oracle.jdbc.pool.OracleDataSource;

    private DataSource getOracleDataSource(SessionSettings settings) throws SQLException, ConfigError {

        OracleDataSource ds = new OracleDataSource();

        ds.setURL(settings.getString("JdbcURL"));

        ds.setUser(settings.getString("JdbcUser"));

        ds.setPassword(settings.getString("JdbcPassword"));

        return ds;
    }
```

### Creating the factories
```java
        DataSource ds = getOracleDataSource(settings);

        JdbcStoreFactory jdbcStoreFactory = new JdbcStoreFactory(settings);

        jdbcStoreFactory.setDataSource(ds);

        MessageStoreFactory messageStoreFactory = jdbcStoreFactory;

        JdbcLogFactory jdbcLogFactory = new JdbcLogFactory(settings);

        jdbcLogFactory.setDataSource(ds);

        LogFactory logFactory = jdbcLogFactory;

        MessageFactory messageFactory = new DefaultMessageFactory();

        initiator = new SocketInitiator(application, messageStoreFactory, settings, logFactory, messageFactory);
```