### PR TITLE
Corrects the toAdmin description in the user manual documentation

### DIFF
--- a/quickfixj-core/src/main/doc/usermanual/usage/application.html
+++ b/quickfixj-core/src/main/doc/usermanual/usage/application.html
@@ -52,7 +52,7 @@ public interface Application {
   This could happen during a normal logout exchange or because of a forced termination
   or a loss of network connection. </dd>
   <dt>toAdmin</dt>
-  <dd> This callback provides you with a peak at the administrative messages
+  <dd> This callback provides you with a peek at the administrative messages
   that are being sent from your FIX engine to the counter party. This is normally
   not useful for an application however it is provided for any logging you may
   wish to do. Notice that the FIX::Message is not const. This allows you to add

--- a/quickfixj-core/src/main/doc/usermanual/usage/application.html
+++ b/quickfixj-core/src/main/doc/usermanual/usage/application.html
@@ -56,7 +56,7 @@ public interface Application {
   that are being sent from your FIX engine to the counter party. This is normally
   not useful for an application however it is provided for any logging you may
   wish to do. Notice that the FIX::Message is not const. This allows you to add
-  fields before an adminstrative message before it is sent out. </dd>
+  fields to an administrative message before it is sent out. </dd>
   <dt>toApp</dt>
   <dd> This is a callback for application messages that you are being
   sent to a counterparty. If you throw a <I>DoNotSend</I> exception in this function,


### PR DESCRIPTION
A small correction on the toadmin description in the user manual documentation.

This was talked on https://github.com/quickfix-j/quickfixj/issues/237

Local test:

![image](https://user-images.githubusercontent.com/47837222/104827169-d7b0cb00-5839-11eb-8aab-cacd89b53cbb.png)


### From
```
This allows you to add fields before an adminstrative message before it is sent out.
```

### To
```
This allows you to add fields to an administrative message before it is sent out.
```