### PR TITLE
Preventing the acceptor session from accepting Logon message when Logout was initiated locally.

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -881,8 +881,8 @@ public class Session implements Closeable {
                     ((ApplicationExtended) application).onBeforeSessionReset(sessionID);
                 }
                 state.setResetStatePending(true);
+                generateLogout("Session reset");
                 getLog().onEvent("Initiated logout request");
-                generateLogout(state.getLogoutReason());
             } else {
                 resetState();
             }

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -881,7 +881,6 @@ public class Session implements Closeable {
                     ((ApplicationExtended) application).onBeforeSessionReset(sessionID);
                 }
                 state.setResetStatePending(true);
-                logout("Session reset");
                 getLog().onEvent("Initiated logout request");
                 generateLogout(state.getLogoutReason());
             } else {

--- a/quickfixj-core/src/test/java/quickfix/SessionTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionTest.java
@@ -1876,7 +1876,7 @@ public class SessionTest {
 
     @Test
     // QFJ-457
-    public void testAcceptorAcceptsLogonWhenLogoutInitiatedExternally() throws Exception {
+    public void testAcceptorRejectsLogonWhenLogoutInitiatedLocally() throws Exception {
         final UnitTestApplication application = new UnitTestApplication();
         try (Session session = setUpSession(application, false,
                 new UnitTestResponder())) {
@@ -1896,6 +1896,7 @@ public class SessionTest {
             logout.getHeader().setInt(MsgSeqNum.FIELD, 2);
             session.next(logout);
 
+            assertFalse(session.isEnabled());
             assertFalse(session.isLoggedOn());
             logonTo(session, 3);
             Message lastToAdminMessage = application.lastToAdminMessage();
@@ -1905,7 +1906,7 @@ public class SessionTest {
     }
 
     @Test
-    public void testAcceptorRejectsLogonWhenLogoutInitiatedLocally() throws Exception {
+    public void testAcceptorAcceptsLogonWhenLogoutInitiatedExternally() throws Exception {
         final UnitTestApplication application = new UnitTestApplication();
         try (Session session = setUpSession(application, false,
                 new UnitTestResponder())) {
@@ -1913,9 +1914,6 @@ public class SessionTest {
             logonTo(session);
             assertTrue(session.isEnabled());
             assertTrue(session.isLoggedOn());
-
-            session.logout();
-            session.next();
 
             final Message logout = new Logout();
             logout.getHeader().setString(SenderCompID.FIELD, "TARGET");
@@ -1925,10 +1923,13 @@ public class SessionTest {
             logout.getHeader().setInt(MsgSeqNum.FIELD, 2);
             session.next(logout);
 
+            session.next();
+
+            assertTrue(session.isEnabled());
             assertFalse(session.isLoggedOn());
             logonTo(session, 3);
             Message lastToAdminMessage = application.lastToAdminMessage();
-            assertEquals(Logout.MSGTYPE, lastToAdminMessage.getHeader()
+            assertEquals(Logon.MSGTYPE, lastToAdminMessage.getHeader()
                     .getString(MsgType.FIELD));
         }
     }

--- a/quickfixj-core/src/test/java/quickfix/SessionTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionTest.java
@@ -1900,8 +1900,7 @@ public class SessionTest {
             assertFalse(session.isLoggedOn());
             logonTo(session, 3);
             Message lastToAdminMessage = application.lastToAdminMessage();
-            assertEquals(Logout.MSGTYPE, lastToAdminMessage.getHeader()
-                    .getString(MsgType.FIELD));
+            assertEquals(Logout.MSGTYPE, lastToAdminMessage.getHeader().getString(MsgType.FIELD));
         }
     }
 
@@ -1929,8 +1928,7 @@ public class SessionTest {
             assertFalse(session.isLoggedOn());
             logonTo(session, 3);
             Message lastToAdminMessage = application.lastToAdminMessage();
-            assertEquals(Logon.MSGTYPE, lastToAdminMessage.getHeader()
-                    .getString(MsgType.FIELD));
+            assertEquals(Logon.MSGTYPE, lastToAdminMessage.getHeader().getString(MsgType.FIELD));
         }
     }
 

--- a/quickfixj-core/src/test/java/quickfix/mina/SessionConnectorTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/SessionConnectorTest.java
@@ -99,8 +99,8 @@ public class SessionConnectorTest {
             
             assertTrue(session.isEnabled());
             connector.logoutAllSessions(true);
-            // Acceptors should get re-enabled after Logout
-            assertTrue(session.isEnabled());
+            // Acceptors should not get re-enabled after initiating Logout
+            assertFalse(session.isEnabled());
             
             assertEquals(9999, connector.getIntSetting(Acceptor.SETTING_SOCKET_ACCEPT_PORT));
             


### PR DESCRIPTION
Also see #359 

When Logon sequence was initiated externally. i.e. counterparty initiated Logout sequence, acceptor should still accept subsequent Logon attempts from that counterparty.