### PR TITLE
Change reference from ant do mvn in the user manual

### DIFF
--- a/quickfixj-core/src/main/doc/usermanual/installation.html
+++ b/quickfixj-core/src/main/doc/usermanual/installation.html
@@ -130,7 +130,7 @@ By default, the XML processing in QuickFIX/J uses the XML parser included
       running the <code>generate.code</code> target.</li>
 </ol>
 <h3>Command-line Switches</h3>
-There are various command-line switches you can pass to ant to modify the produced behavior:
+There are various command-line switches you can pass to mvn to modify the produced behavior:
 <table cellspacing="0" width="100%">
   <tr>
     <th>Switch</th>


### PR DESCRIPTION
Closes #343 

Change from:
```
There are various command-line switches you can pass to ant to modify the produced behavior:
```

To:
```
There are various command-line switches you can pass to mvn to modify the produced behavior:
```