### PR TITLE
Add List<String> constructor to SessionSettings

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/SessionSettings.java
+++ b/quickfixj-core/src/main/java/quickfix/SessionSettings.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import quickfix.field.converter.BooleanConverter;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,6 +48,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Settings for sessions. Settings are grouped by FIX version and target company
@@ -148,6 +150,29 @@ public class SessionSettings {
     public SessionSettings(InputStream stream, Properties variableValues) throws ConfigError {
         this(variableValues);
         load(stream);
+    }
+
+    /**
+     * Loads session settings from a list of strings.
+     *
+     * @param listValues the list of strings
+     * @throws ConfigError
+     */
+    public SessionSettings(List<String> listValues) throws ConfigError {
+        this();
+        loadFromList(listValues);
+    }
+
+    /**
+     * Loads session settings from a list of strings with custom source of variable values in the settings.
+     *
+     * @param listValues the list of strings
+     * @param variableValues custom source of variable values in the settings
+     * @throws ConfigError
+     */
+    public SessionSettings(List<String> listValues, Properties variableValues) throws ConfigError {
+        this(variableValues);
+        loadFromList(listValues);
     }
 
     /**
@@ -412,6 +437,12 @@ public class SessionSettings {
         } catch (final IOException ex) {
             throw new ConfigError(ex.getMessage());
         }
+    }
+
+    private void loadFromList(List<String> listValues) throws ConfigError {
+        byte[] bytes = listValues.stream().collect(Collectors.joining(System.lineSeparator())).getBytes();
+        InputStream in = new ByteArrayInputStream(bytes);
+        load(in);
     }
 
     private void load(InputStream inputStream) throws ConfigError {

--- a/quickfixj-core/src/test/java/quickfix/SessionSettingsTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionSettingsTest.java
@@ -27,9 +27,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.InvalidParameterException;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Properties;
 import java.util.Set;
+import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Random;
@@ -372,6 +374,55 @@ public class SessionSettingsTest {
     public void testDefaultConstructor() {
         new SessionSettings();
         // Passes if no exception is thrown
+    }
+
+    @Test
+    public void testListConstructor() throws ConfigError {
+        List<String> listValues = new ArrayList<String>();
+        listValues.add("[SESSION]");
+        listValues.add("BeginString=FIX.4.2");
+        listValues.add("SenderCompID=Company");
+        listValues.add("SenderSubID=FixedIncome");
+        listValues.add("SenderLocationID=HongKong");
+        listValues.add("TargetCompID=CLIENT1");
+        listValues.add("TargetSubID=HedgeFund");
+        listValues.add("TargetLocationID=NYC\n");
+
+        final SessionSettings settings = new SessionSettings(listValues);
+        final SessionID id = settings.sectionIterator().next();
+        assertEquals("Company", id.getSenderCompID());
+        assertEquals("FixedIncome", id.getSenderSubID());
+        assertEquals("HongKong", id.getSenderLocationID());
+        assertEquals("CLIENT1", id.getTargetCompID());
+        assertEquals("HedgeFund", id.getTargetSubID());
+        assertEquals("NYC", id.getTargetLocationID());
+    }
+
+    @Test
+    public void testListPropertiesConstructor() throws ConfigError {
+        System.setProperty("test.2", "BAR");
+        final Properties properties = new Properties(System.getProperties());
+        properties.setProperty("test.1", "FOO");
+
+        List<String> listValues = new ArrayList<String>();
+        listValues.add("[SESSION]");
+        listValues.add("BeginString=FIX.4.2");
+        listValues.add("SenderCompID=Company");
+        listValues.add("SenderSubID=FixedIncome");
+        listValues.add("SenderLocationID=HongKong");
+        listValues.add("TargetCompID=CLIENT3_${test.1}_${test.2}");
+        listValues.add("TargetSubID=HedgeFund");
+        listValues.add("TargetLocationID=NYC\n");
+
+        final SessionSettings settings = new SessionSettings(listValues, properties);
+        final SessionID id = settings.sectionIterator().next();
+        assertEquals("Company", id.getSenderCompID());
+        assertEquals("FixedIncome", id.getSenderSubID());
+        assertEquals("HongKong", id.getSenderLocationID());
+        assertEquals("CLIENT3_FOO_BAR", id.getTargetCompID());
+        assertEquals("HedgeFund", id.getTargetSubID());
+        assertEquals("NYC", id.getTargetLocationID());
+
     }
 
     @Test


### PR DESCRIPTION
Closes #367 

As stated in the #367 issue, I only created two new constructors in the SessionSettings class, one with `(List<String)` and the other with `(List<String>, Properties)`.

I tested it locally between my application and the executor and everything went fine.


### The creation of my SessionSettings object

```java
@ConfigProperty(name = "quickfix")
List<String> quickfixSessionSettings;
...
SessionSettings sessionSettings = new SessionSettings(quickfixSessionSettings);
```

### Original `List<String>`

```
[default]
# Sessions
[session]
BeginString=FIX.4.4
SenderCompID=BANZAI
TargetCompID=EXEC
ConnectionType=initiator
StartTime=00:00:00
EndTime=00:00:00
# Initiator
ReconnectInterval=5
HeartBtInt=30
SocketConnectHost=localhost
SocketConnectPort=9880
# Logging
ScreenLogShowHeartBeats=Y
```


### toString() of my SessionSettings

```
[DEFAULT]
[SESSION]
BeginString=FIX.4.4
SenderCompID=BANZAI
SocketConnectPort=9880
ConnectionType=initiator
EndTime=00:00:00
ReconnectInterval=5
TargetCompID=EXEC
ScreenLogShowHeartBeats=Y
StartTime=00:00:00
SocketConnectHost=localhost
HeartBtInt=30
```

### Executor
```
press <enter> to quit
fev 08, 2021 10:25:39 PM quickfix.mina.SingleThreadedEventHandlingStrategy lambda$blockInThread$1
INFO: Started QFJ Message Processor
fev 08, 2021 10:25:39 PM quickfix.mina.acceptor.AcceptorIoHandler sessionCreated
INFO: MINA session created: local=/127.0.0.1:9880, class org.apache.mina.transport.socket.nio.NioSocketSession, remote=/127.0.0.1:53984
<20210209-01:25:40, FIX.4.4:EXEC->BANZAI, incoming> (8=FIX.4.49=8635=A34=149=BANZAI52=20210209-01:25:40.86556=EXEC95=1196=pocPassword98=0108=3010=045)
<20210209-01:25:40, FIX.4.4:EXEC->BANZAI, event> (Accepting session FIX.4.4:EXEC->BANZAI from /127.0.0.1:53984)
<20210209-01:25:40, FIX.4.4:EXEC->BANZAI, event> (Acceptor heartbeat set to 30 seconds)
<20210209-01:25:40, FIX.4.4:EXEC->BANZAI, event> (Received logon)
<20210209-01:25:40, FIX.4.4:EXEC->BANZAI, event> (Responding to Logon request)
<20210209-01:25:40, FIX.4.4:EXEC->BANZAI, outgoing> (8=FIX.4.49=6535=A34=149=EXEC52=20210209-01:25:40.93556=BANZAI98=0108=3010=216)
```