### PR TITLE
SessionStateListener.onConnectException - unit test correction

### DIFF
--- a/quickfixj-core/src/test/java/quickfix/SocketInitiatorTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SocketInitiatorTest.java
@@ -239,8 +239,8 @@ public class SocketInitiatorTest {
             SessionID clientSessionID = new SessionID(FixVersions.BEGINSTRING_FIX42, "TW", "ISLD");
             SessionSettings settings = getClientSessionSettings(clientSessionID, freePort);
             settings.setString(clientSessionID, "ReconnectInterval", "1");
-            settings.setString(clientSessionID, "SocketConnectHost", "0.0.0.0");
-            settings.setString(clientSessionID, "SocketConnectProtocol", ProtocolFactory.getTypeString(ProtocolFactory.SOCKET));
+            settings.setString(clientSessionID, "SocketConnectHost", "localhost");
+            settings.setString(clientSessionID, "SocketConnectProtocol", ProtocolFactory.getTypeString(ProtocolFactory.VM_PIPE));
 
             SessionStateListener sessionStateListener = new SessionStateListener() {
                 @Override


### PR DESCRIPTION
Changed unit test to use localhost and VM_PIPE to hopefully fix flaky test behaviour in GitHub CI builds

In some builds there was no connection attempt (when it was expected each second) for the duration of the unit test (which runs about 3 seconds).