### PR TITLE
Always re-resolve `SocketAddress` on reconnect.

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
@@ -254,7 +254,6 @@ public class IoSessionInitiator {
         private void handleConnectException(Throwable e) {
             ++connectionFailureCount;
             SocketAddress socketAddress = socketAddresses[getCurrentSocketAddressIndex()];
-            unresolveCurrentSocketAddress(socketAddress);
             while (e.getCause() != null) {
                 e = e.getCause();
             }
@@ -272,26 +271,14 @@ public class IoSessionInitiator {
         private SocketAddress getNextSocketAddress() {
             SocketAddress socketAddress = socketAddresses[nextSocketAddressIndex];
 
-            // QFJ-266 Recreate socket address for unresolved addresses
-            if (socketAddress instanceof InetSocketAddress) {
-                InetSocketAddress inetAddr = (InetSocketAddress) socketAddress;
-                if (inetAddr.isUnresolved()) {
-                    socketAddress = new InetSocketAddress(inetAddr.getHostName(), inetAddr
-                            .getPort());
-                    socketAddresses[nextSocketAddressIndex] = socketAddress;
-                }
-            }
+            // Recreate socket address to avoid cached address resolution
+			if (socketAddress instanceof InetSocketAddress) {
+				InetSocketAddress inetAddr = (InetSocketAddress) socketAddress;
+				socketAddress = new InetSocketAddress(inetAddr.getHostName(), inetAddr.getPort());
+				socketAddresses[nextSocketAddressIndex] = socketAddress;
+			}
             nextSocketAddressIndex = (nextSocketAddressIndex + 1) % socketAddresses.length;
             return socketAddress;
-        }
-
-        // QFJ-822 Reset cached DNS resolution information on connection failure.
-        private void unresolveCurrentSocketAddress(SocketAddress socketAddress) {
-            if (socketAddress instanceof InetSocketAddress) {
-                InetSocketAddress inetAddr = (InetSocketAddress) socketAddress;
-                socketAddresses[getCurrentSocketAddressIndex()] = InetSocketAddress.createUnresolved(
-                        inetAddr.getHostString(), inetAddr.getPort());
-            }
         }
 
         private int getCurrentSocketAddressIndex() {

--- a/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
@@ -274,9 +274,9 @@ public class IoSessionInitiator {
             // Recreate socket address to avoid cached address resolution
             if (socketAddress instanceof InetSocketAddress) {
                 InetSocketAddress inetAddr = (InetSocketAddress) socketAddress;
-	            socketAddress = new InetSocketAddress(inetAddr.getHostName(), inetAddr.getPort());
-	            socketAddresses[nextSocketAddressIndex] = socketAddress;
-	        }
+                socketAddress = new InetSocketAddress(inetAddr.getHostName(), inetAddr.getPort());
+                socketAddresses[nextSocketAddressIndex] = socketAddress;
+            }
             nextSocketAddressIndex = (nextSocketAddressIndex + 1) % socketAddresses.length;
             return socketAddress;
         }

--- a/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
@@ -272,11 +272,11 @@ public class IoSessionInitiator {
             SocketAddress socketAddress = socketAddresses[nextSocketAddressIndex];
 
             // Recreate socket address to avoid cached address resolution
-			if (socketAddress instanceof InetSocketAddress) {
-				InetSocketAddress inetAddr = (InetSocketAddress) socketAddress;
-				socketAddress = new InetSocketAddress(inetAddr.getHostName(), inetAddr.getPort());
-				socketAddresses[nextSocketAddressIndex] = socketAddress;
-			}
+            if (socketAddress instanceof InetSocketAddress) {
+                InetSocketAddress inetAddr = (InetSocketAddress) socketAddress;
+	            socketAddress = new InetSocketAddress(inetAddr.getHostName(), inetAddr.getPort());
+	            socketAddresses[nextSocketAddressIndex] = socketAddress;
+	        }
             nextSocketAddressIndex = (nextSocketAddressIndex + 1) % socketAddresses.length;
             return socketAddress;
         }


### PR DESCRIPTION
QFJ-266 and QFJ-822 previously made changes around the clearing of cached DNS resolution.  These resolved issues relating to a cached non-resolution, and enforcing re-resolution after a failure to connect.  However there are other cases that this does not cover such as a counter-party changing their DNS entries but leaving something listening at the old location.  In this case you can still connect successfully but not get a response to your Logon message.  As this is not a connection error, the QFJ-822 enhancement is not triggered.

All cases can be covered by following the QFJ-266 solution but ignoring whether the address was previously resolved or unresolved.  Simply clear the cached DNS info on every connect.