### PR TITLE
Set correct value for ExecType in ExecutionReport (Executor example application)

### DIFF
--- a/quickfixj-examples/executor/src/main/java/quickfix/examples/executor/Application.java
+++ b/quickfixj-examples/executor/src/main/java/quickfix/examples/executor/Application.java
@@ -315,7 +315,7 @@ public class Application extends quickfix.MessageCracker implements quickfix.App
         Price price = getPrice(order);
 
         quickfix.fix43.ExecutionReport accept = new quickfix.fix43.ExecutionReport(
-                    genOrderID(), genExecID(), new ExecType(ExecType.FILL), new OrdStatus(
+                    genOrderID(), genExecID(), new ExecType(ExecType.NEW), new OrdStatus(
                             OrdStatus.NEW), order.getSide(), new LeavesQty(order.getOrderQty()
                             .getValue()), new CumQty(0), new AvgPx(0));
 
@@ -325,7 +325,7 @@ public class Application extends quickfix.MessageCracker implements quickfix.App
 
         if (isOrderExecutable(order, price)) {
             quickfix.fix43.ExecutionReport executionReport = new quickfix.fix43.ExecutionReport(genOrderID(),
-                    genExecID(), new ExecType(ExecType.FILL), new OrdStatus(OrdStatus.FILLED), order.getSide(),
+                    genExecID(), new ExecType(ExecType.TRADE), new OrdStatus(OrdStatus.FILLED), order.getSide(),
                     new LeavesQty(0), new CumQty(orderQty.getValue()), new AvgPx(price.getValue()));
 
             executionReport.set(order.getClOrdID());
@@ -350,7 +350,7 @@ public class Application extends quickfix.MessageCracker implements quickfix.App
         Price price = getPrice(order);
 
         quickfix.fix44.ExecutionReport accept = new quickfix.fix44.ExecutionReport(
-                    genOrderID(), genExecID(), new ExecType(ExecType.FILL), new OrdStatus(
+                    genOrderID(), genExecID(), new ExecType(ExecType.NEW), new OrdStatus(
                             OrdStatus.NEW), order.getSide(), new LeavesQty(order.getOrderQty()
                             .getValue()), new CumQty(0), new AvgPx(0));
 
@@ -360,7 +360,7 @@ public class Application extends quickfix.MessageCracker implements quickfix.App
 
         if (isOrderExecutable(order, price)) {
             quickfix.fix44.ExecutionReport executionReport = new quickfix.fix44.ExecutionReport(genOrderID(),
-                    genExecID(), new ExecType(ExecType.FILL), new OrdStatus(OrdStatus.FILLED), order.getSide(),
+                    genExecID(), new ExecType(ExecType.TRADE), new OrdStatus(OrdStatus.FILLED), order.getSide(),
                     new LeavesQty(0), new CumQty(orderQty.getValue()), new AvgPx(price.getValue()));
 
             executionReport.set(order.getClOrdID());
@@ -385,7 +385,7 @@ public class Application extends quickfix.MessageCracker implements quickfix.App
             Price price = getPrice(order);
 
             quickfix.fix50.ExecutionReport accept = new quickfix.fix50.ExecutionReport(
-                    genOrderID(), genExecID(), new ExecType(ExecType.FILL), new OrdStatus(
+                    genOrderID(), genExecID(), new ExecType(ExecType.NEW), new OrdStatus(
                             OrdStatus.NEW), order.getSide(), new LeavesQty(order.getOrderQty()
                             .getValue()), new CumQty(0));
 
@@ -395,7 +395,7 @@ public class Application extends quickfix.MessageCracker implements quickfix.App
 
             if (isOrderExecutable(order, price)) {
                 quickfix.fix50.ExecutionReport executionReport = new quickfix.fix50.ExecutionReport(
-                        genOrderID(), genExecID(), new ExecType(ExecType.FILL), new OrdStatus(
+                        genOrderID(), genExecID(), new ExecType(ExecType.TRADE), new OrdStatus(
                                 OrdStatus.FILLED), order.getSide(), new LeavesQty(0), new CumQty(
                                 orderQty.getValue()));
 


### PR DESCRIPTION
Starting from FIX.4.3, ExecType.PARTIAL_FILL and ExecType.FILL were removed
and replaced by ExecType.TRADE.