### PR TITLE
use maven.compiler.release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		<maven-surefire-plugin-version>2.22.0</maven-surefire-plugin-version>
 		<maven-pmd-plugin-version>3.10.0</maven-pmd-plugin-version>
 		<maven-source-plugin-version>3.0.1</maven-source-plugin-version>
-		<maven-javadoc-plugin-version>2.10.4</maven-javadoc-plugin-version>
+		<maven-javadoc-plugin-version>3.3.1</maven-javadoc-plugin-version>
 		<maven-shade-plugin-version>3.1.1</maven-shade-plugin-version>
 		<maven-assembly-plugin-version>3.1.0</maven-assembly-plugin-version>
 		<maven-bundle-plugin-version>3.5.1</maven-bundle-plugin-version>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,8 @@
 		<jdkLevel>1.8</jdkLevel>
 		<slf4j.version>1.7.32</slf4j.version>
 		<junit.version>4.13.1</junit.version>
+                <maven.compiler.source>8</maven.compiler.source>
+                <maven.compiler.target>8</maven.compiler.target>
 		<mainClass/>
 
 		<maven-resources-plugin-version>3.1.0</maven-resources-plugin-version>
@@ -108,8 +110,6 @@
 					<version>${maven-compiler-plugin-version}</version>
 					<inherited>true</inherited>
 					<configuration>
-						<source>${jdkLevel}</source>
-						<target>${jdkLevel}</target>
 						<meminitial>2g</meminitial>
 						<maxmem>4g</maxmem>
 					</configuration>
@@ -291,6 +291,15 @@
 				</plugins>
 			</build>
 		</profile>
+                <profile>
+                        <id>java-8-compilation</id>
+                        <activation>
+                        <jdk>[9,)</jdk>
+                        </activation>
+                        <properties>
+                                <maven.compiler.release>8</maven.compiler.release>
+                        </properties>
+                </profile>
 	</profiles>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@
 		<jdkLevel>1.8</jdkLevel>
 		<slf4j.version>1.7.32</slf4j.version>
 		<junit.version>4.13.1</junit.version>
-                <maven.compiler.source>8</maven.compiler.source>
-                <maven.compiler.target>8</maven.compiler.target>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
 		<mainClass/>
 
 		<maven-resources-plugin-version>3.1.0</maven-resources-plugin-version>
@@ -291,15 +291,15 @@
 				</plugins>
 			</build>
 		</profile>
-                <profile>
-                        <id>java-8-compilation</id>
-                        <activation>
-                        <jdk>[9,)</jdk>
-                        </activation>
-                        <properties>
-                                <maven.compiler.release>8</maven.compiler.release>
-                        </properties>
-                </profile>
+		<profile>
+			<id>java-8-compilation</id>
+			<activation>
+			<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<maven.compiler.release>8</maven.compiler.release>
+			</properties>
+		</profile>
 	</profiles>
 
 	<distributionManagement>


### PR DESCRIPTION
... for JDK9+ to prevent build runtime errors like these:

```
Error: Exception in thread "pool-15-thread-2" java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;
	at org.apache.mina.core.buffer.AbstractIoBuffer.flip(AbstractIoBuffer.java:462)
	at org.apache.mina.core.polling.AbstractPollingIoProcessor.read(AbstractPollingIoProcessor.java:534)
	at org.apache.mina.core.polling.AbstractPollingIoProcessor.access$1200(AbstractPollingIoProcessor.java:68)
	at org.apache.mina.core.polling.AbstractPollingIoProcessor$Processor.process(AbstractPollingIoProcessor.java:1224)
	at org.apache.mina.core.polling.AbstractPollingIoProcessor$Processor.process(AbstractPollingIoProcessor.java:1213)
	at org.apache.mina.core.polling.AbstractPollingIoProcessor$Processor.run(AbstractPollingIoProcessor.java:683)
	at org.apache.mina.util.NamePreservingRunnable.run(NamePreservingRunnable.java:64)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

This happened on #441 