### PR TITLE
Enhanced logic around the `ValidateFieldsOutOfOrder` setting 

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -604,7 +604,7 @@ public class Message extends FieldMap {
 
         try {
             parseHeader(sessionDataDictionary, doValidation);
-            parseBody(applicationDataDictionary, doValidation);
+            parseBody(sessionDataDictionary, applicationDataDictionary, doValidation);
             parseTrailer(sessionDataDictionary);
             if (doValidation && validateChecksum) {
                 validateCheckSum(messageData);
@@ -670,34 +670,34 @@ public class Message extends FieldMap {
         }
     }
 
-    private void parseBody(DataDictionary dd, boolean doValidation) throws InvalidMessage {
-        StringField field = extractField(dd, this);
+    private void parseBody(DataDictionary sessionDataDictionary, DataDictionary applicationDataDictionary, boolean doValidation) throws InvalidMessage {
+        StringField field = extractField(applicationDataDictionary, this);
         while (field != null) {
             if (isTrailerField(field.getField())) {
                 pushBack(field);
                 return;
             }
 
-            if (isHeaderField(field.getField())) {
+            if (isHeaderField(field, sessionDataDictionary)) {
                 // An acceptance test requires the sequence number to
                 // be available even if the related field is out of order
                 setField(header, field);
                 // Group case
-                if (dd != null && dd.isGroup(DataDictionary.HEADER_ID, field.getField())) {
-                    parseGroup(DataDictionary.HEADER_ID, field, dd, dd, header, doValidation);
+                if (sessionDataDictionary != null && sessionDataDictionary.isGroup(DataDictionary.HEADER_ID, field.getField())) {
+                    parseGroup(DataDictionary.HEADER_ID, field, sessionDataDictionary, sessionDataDictionary, header, doValidation);
                 }
-                if (doValidation && dd != null && dd.isCheckFieldsOutOfOrder())
+                if (doValidation && sessionDataDictionary != null && sessionDataDictionary.isCheckFieldsOutOfOrder())
                     throw new FieldException(SessionRejectReason.TAG_SPECIFIED_OUT_OF_REQUIRED_ORDER,
                         field.getTag());
             } else {
                 setField(this, field);
                 // Group case
-                if (dd != null && dd.isGroup(getMsgType(), field.getField())) {
-                    parseGroup(getMsgType(), field, dd, dd, this, doValidation);
+                if (applicationDataDictionary != null && applicationDataDictionary.isGroup(getMsgType(), field.getField())) {
+                    parseGroup(getMsgType(), field, applicationDataDictionary, applicationDataDictionary, this, doValidation);
                 }
             }
 
-            field = extractField(dd, this);
+            field = extractField(applicationDataDictionary, this);
         }
     }
 
@@ -770,7 +770,7 @@ public class Message extends FieldMap {
                 }
             } else {
                 // QFJ-169/QFJ-791: handle unknown repeating group fields in the body
-                if (!isTrailerField(tag) && !(DataDictionary.HEADER_ID.equals(msgType))) {
+                if (!isTrailerField(tag) && !(DataDictionary.HEADER_ID.equals(msgType) || isHeaderField(tag))) {
                     if (checkFieldValidation(parent, parentDD, field, msgType, doValidation, group)) {
                         continue;
                     }

--- a/quickfixj-core/src/main/java/quickfix/Message.java
+++ b/quickfixj-core/src/main/java/quickfix/Message.java
@@ -770,7 +770,7 @@ public class Message extends FieldMap {
                 }
             } else {
                 // QFJ-169/QFJ-791: handle unknown repeating group fields in the body
-                if (!isTrailerField(tag) && !(DataDictionary.HEADER_ID.equals(msgType) || isHeaderField(tag))) {
+                if (!isTrailerField(tag) && !(DataDictionary.HEADER_ID.equals(msgType) || isHeaderField(field, dd))) {
                     if (checkFieldValidation(parent, parentDD, field, msgType, doValidation, group)) {
                         continue;
                     }

--- a/quickfixj-core/src/test/java/quickfix/MessageTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageTest.java
@@ -2054,12 +2054,7 @@ public class MessageTest {
     @Test
     public void testValidateFieldsOutOfOrderPreFIXT11() throws Exception {
         final DataDictionary sessDictionary = DataDictionaryTest.getDictionary("FIX44.xml");
-        final DataDictionary appDictionary = sessDictionary;
         assertNotNull(sessDictionary);
-        assertEquals(sessDictionary.getVersion(), appDictionary.getVersion());
-
-        sessDictionary.setCheckFieldsOutOfOrder(true);
-        sessDictionary.setCheckUnorderedGroupFields(true);
 
         final String orderedData =
                 "8=FIX.4.4\u00019=551\u000135=AE\u0001"
@@ -2071,8 +2066,8 @@ public class MessageTest {
                         + "54=2\u000137=OrderID2\u000111=7533509260093757876\u0001453=1\u0001448=338-3\u0001447=D\u0001452=1\u00011=1040445\u0001576=1\u0001577=0\u0001"
                         + "10=191\u0001";
         final TradeCaptureReport tcrOrdered = new TradeCaptureReport();
-        tcrOrdered.fromString(orderedData, sessDictionary, appDictionary, true);
-        DataDictionary.validate(tcrOrdered, sessDictionary, appDictionary);
+        tcrOrdered.fromString(orderedData, sessDictionary, true);
+        DataDictionary.validate(tcrOrdered, sessDictionary, sessDictionary);
 
         // As this is our reference message created with all validations switched on,
         // make sure some message components
@@ -2092,8 +2087,8 @@ public class MessageTest {
                 + "34=545\u000149=SENDER\u000152=20220210-02:44:00.820\u000156=TARGET\u0001115=ON_BHEHALF\u0001"
                 + "10=191\u0001";
         TradeCaptureReport tcrUnOrdered = new TradeCaptureReport();
-        tcrUnOrdered.fromString(unorderedData, sessDictionary, appDictionary, true);
-        DataDictionary.validate(tcrUnOrdered, sessDictionary, appDictionary);
+        tcrUnOrdered.fromString(unorderedData, sessDictionary, true);
+        DataDictionary.validate(tcrUnOrdered, sessDictionary, sessDictionary);
 
         assertEquals(tcrOrdered.toString(), tcrUnOrdered.toString());
 
@@ -2108,8 +2103,8 @@ public class MessageTest {
 
                 + "10=191\u0001";
         tcrUnOrdered = new TradeCaptureReport();
-        tcrUnOrdered.fromString(unorderedData, sessDictionary, appDictionary, true);
-        DataDictionary.validate(tcrUnOrdered, sessDictionary, appDictionary);
+        tcrUnOrdered.fromString(unorderedData, sessDictionary, true);
+        DataDictionary.validate(tcrUnOrdered, sessDictionary, sessDictionary);
 
         assertEquals(tcrOrdered.toString(), tcrUnOrdered.toString());
 
@@ -2126,8 +2121,8 @@ public class MessageTest {
                 + "627=2\u0001628=HOPID1\u0001629=20220414-15:22:54\u0001628=HOPID2\u0001629=20220414-15:22:54\u0001"
                 + "10=191\u0001";
         tcrUnOrdered = new TradeCaptureReport();
-        tcrUnOrdered.fromString(unorderedData, sessDictionary, appDictionary, true);
-        DataDictionary.validate(tcrUnOrdered, sessDictionary, appDictionary);
+        tcrUnOrdered.fromString(unorderedData, sessDictionary, true);
+        DataDictionary.validate(tcrUnOrdered, sessDictionary, sessDictionary);
 
         assertEquals(tcrOrdered.toString(), tcrUnOrdered.toString());
 

--- a/quickfixj-core/src/test/java/quickfix/MessageTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageTest.java
@@ -131,6 +131,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1972,11 +1973,12 @@ public class MessageTest {
     }
 
     @Test
-    public void testValidateFieldsOutOfOrder() throws Exception {
+    public void testValidateFieldsOutOfOrderFIXT11() throws Exception {
         final DataDictionary sessDictionary = DataDictionaryTest.getDictionary("FIXT11.xml");
         final DataDictionary appDictionary = DataDictionaryTest.getDictionary("FIX50SP2.xml");
         assertNotNull(sessDictionary);
         assertNotNull(appDictionary);
+        assertNotEquals(appDictionary.getVersion(),  sessDictionary.getVersion());
 
         final String orderedData = "8=FIXT.1.1\u00019=561\u000135=AE\u0001" +
                 "34=545\u000149=SENDER\u000152=20220210-02:44:00.820\u000156=TARGET\u0001115=ON_BHEHALF\u0001" +
@@ -2041,6 +2043,88 @@ public class MessageTest {
                 // Some repeating Header tags
                 "627=2\u0001628=HOPID1\u0001629=20220414-15:22:54\u0001628=HOPID2\u0001629=20220414-15:22:54\u0001" +
                 "10=129\u0001";
+        tcrUnOrdered = new TradeCaptureReport();
+        tcrUnOrdered.fromString(unorderedData, sessDictionary, appDictionary, true);
+        DataDictionary.validate(tcrUnOrdered, sessDictionary, appDictionary);
+
+        assertEquals(tcrOrdered.toString(), tcrUnOrdered.toString());
+
+    }
+
+    @Test
+    public void testValidateFieldsOutOfOrderPreFIXT11() throws Exception {
+        final DataDictionary sessDictionary = DataDictionaryTest.getDictionary("FIX44.xml");
+        final DataDictionary appDictionary = sessDictionary;
+        assertNotNull(sessDictionary);
+        assertEquals(sessDictionary.getVersion(), appDictionary.getVersion());
+
+        sessDictionary.setCheckFieldsOutOfOrder(true);
+        sessDictionary.setCheckUnorderedGroupFields(true);
+
+        final String orderedData =
+                "8=FIX.4.4\u00019=551\u000135=AE\u0001"
+                        + "34=545\u000149=SENDER\u000152=20220210-02:44:00.820\u000156=TARGET\u0001115=ON_BHEHALF\u0001"
+                        + "627=2\u0001628=HOPID1\u0001629=20220414-15:22:54\u0001628=HOPID2\u0001629=20220414-15:22:54\u0001"
+                        + "22=4\u000131=27\u000132=5000.000000000000\u000148=AU000000ANZ3\u000155=ANZ\u000160=20220210-02:43:27.796\u000164=20220214\u000175=20220210\u0001106=4075\u0001167=CS\u0001461=Exxxxx\u0001487=0\u0001570=N\u0001571=TradeReportID\u0001762=1\u0001880=7533509260093686098:0#NORMAL#1644451200000000000\u0001"
+                        + "552=2\u0001"
+                        + "54=1\u000137=OrderID1\u000111=7533509260093758035\u0001453=1\u0001448=338-3\u0001447=D\u0001452=1\u00011=1040445\u0001576=1\u0001577=0\u0001"
+                        + "54=2\u000137=OrderID2\u000111=7533509260093757876\u0001453=1\u0001448=338-3\u0001447=D\u0001452=1\u00011=1040445\u0001576=1\u0001577=0\u0001"
+                        + "10=191\u0001";
+        final TradeCaptureReport tcrOrdered = new TradeCaptureReport();
+        tcrOrdered.fromString(orderedData, sessDictionary, appDictionary, true);
+        DataDictionary.validate(tcrOrdered, sessDictionary, appDictionary);
+
+        // As this is our reference message created with all validations switched on,
+        // make sure some message components
+        // are as expected
+        assertEquals(tcrOrdered.getHeader().getGroupCount(NoHops.FIELD), 2);
+        assertEquals(tcrOrdered.getGroupCount(NoSides.FIELD), 2);
+
+        sessDictionary.setCheckFieldsOutOfOrder(false);
+
+        String unorderedData = "8=FIX.4.4\u00019=551\u000135=AE\u0001"
+                + "22=4\u000131=27\u000132=5000.000000000000\u000148=AU000000ANZ3\u000155=ANZ\u000160=20220210-02:43:27.796\u000164=20220214\u000175=20220210\u0001106=4075\u0001167=CS\u0001461=Exxxxx\u0001487=0\u0001570=N\u0001571=TradeReportID\u0001762=1\u0001880=7533509260093686098:0#NORMAL#1644451200000000000\u0001"
+                + "552=2\u0001"
+                + "54=1\u000137=OrderID1\u000111=7533509260093758035\u0001453=1\u0001448=338-3\u0001447=D\u0001452=1\u00011=1040445\u0001576=1\u0001577=0\u0001"
+                + "54=2\u000137=OrderID2\u000111=7533509260093757876\u0001453=1\u0001448=338-3\u0001447=D\u0001452=1\u00011=1040445\u0001576=1\u0001577=0\u0001"
+                // Repeating Header Group, found just after a Repeating group within the body
+                + "627=2\u0001628=HOPID1\u0001629=20220414-15:22:54\u0001628=HOPID2\u0001629=20220414-15:22:54\u0001"
+                + "34=545\u000149=SENDER\u000152=20220210-02:44:00.820\u000156=TARGET\u0001115=ON_BHEHALF\u0001"
+                + "10=191\u0001";
+        TradeCaptureReport tcrUnOrdered = new TradeCaptureReport();
+        tcrUnOrdered.fromString(unorderedData, sessDictionary, appDictionary, true);
+        DataDictionary.validate(tcrUnOrdered, sessDictionary, appDictionary);
+
+        assertEquals(tcrOrdered.toString(), tcrUnOrdered.toString());
+
+        unorderedData = "8=FIX.4.4\u00019=551\u000135=AE\u0001"
+                + "22=4\u000131=27\u000132=5000.000000000000\u000148=AU000000ANZ3\u000155=ANZ\u000160=20220210-02:43:27.796\u000164=20220214\u000175=20220210\u0001106=4075\u0001167=CS\u0001461=Exxxxx\u0001487=0\u0001570=N\u0001571=TradeReportID\u0001762=1\u0001880=7533509260093686098:0#NORMAL#1644451200000000000\u0001"
+                + "552=2\u0001"
+                + "54=1\u000137=OrderID1\u000111=7533509260093758035\u0001453=1\u0001448=338-3\u0001447=D\u0001452=1\u00011=1040445\u0001576=1\u0001577=0\u0001"
+                + "54=2\u000137=OrderID2\u000111=7533509260093757876\u0001453=1\u0001448=338-3\u0001447=D\u0001452=1\u00011=1040445\u0001576=1\u0001577=0\u0001"
+                // Header tag found just after Repeating group within the body
+                + "34=545\u000149=SENDER\u000152=20220210-02:44:00.820\u000156=TARGET\u0001115=ON_BHEHALF\u0001"
+                + "627=2\u0001628=HOPID1\u0001629=20220414-15:22:54\u0001628=HOPID2\u0001629=20220414-15:22:54\u0001"
+
+                + "10=191\u0001";
+        tcrUnOrdered = new TradeCaptureReport();
+        tcrUnOrdered.fromString(unorderedData, sessDictionary, appDictionary, true);
+        DataDictionary.validate(tcrUnOrdered, sessDictionary, appDictionary);
+
+        assertEquals(tcrOrdered.toString(), tcrUnOrdered.toString());
+
+        unorderedData = "8=FIX.4.4\u00019=551\u000135=AE\u0001"
+                // Some body tags
+                + "22=4\u000131=27\u000132=5000.000000000000\u000148=AU000000ANZ3\u000155=ANZ\u000160=20220210-02:43:27.796\u000164=20220214\u000175=20220210\u0001106=4075\u0001167=CS\u0001461=Exxxxx\u0001487=0\u0001570=N\u0001571=TradeReportID\u0001762=1\u0001880=7533509260093686098:0#NORMAL#1644451200000000000\u0001"
+                // The some Header tags
+                + "34=545\u000149=SENDER\u000152=20220210-02:44:00.820\u000156=TARGET\u0001115=ON_BHEHALF\u0001"
+                // A Repeating body group
+                + "552=2\u0001"
+                + "54=1\u000137=OrderID1\u000111=7533509260093758035\u0001453=1\u0001448=338-3\u0001447=D\u0001452=1\u00011=1040445\u0001576=1\u0001577=0\u0001"
+                + "54=2\u000137=OrderID2\u000111=7533509260093757876\u0001453=1\u0001448=338-3\u0001447=D\u0001452=1\u00011=1040445\u0001576=1\u0001577=0\u0001"
+                // Repeating Header Group
+                + "627=2\u0001628=HOPID1\u0001629=20220414-15:22:54\u0001628=HOPID2\u0001629=20220414-15:22:54\u0001"
+                + "10=191\u0001";
         tcrUnOrdered = new TradeCaptureReport();
         tcrUnOrdered.fromString(unorderedData, sessDictionary, appDictionary, true);
         DataDictionary.validate(tcrUnOrdered, sessDictionary, appDictionary);

--- a/quickfixj-core/src/test/java/quickfix/MessageTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageTest.java
@@ -1978,7 +1978,9 @@ public class MessageTest {
         assertNotNull(sessDictionary);
         assertNotNull(appDictionary);
 
-        final String orderedData = "8=FIXT.1.1\u00019=561\u000135=AE\u000134=545\u000149=SENDER\u000152=20220210-02:44:00.820\u000156=TARGET\u0001115=ON_BHEHALF\u00011128=9\u0001" +
+        final String orderedData = "8=FIXT.1.1\u00019=561\u000135=AE\u0001" +
+                "34=545\u000149=SENDER\u000152=20220210-02:44:00.820\u000156=TARGET\u0001115=ON_BHEHALF\u0001" +
+                "1128=9\u0001" +
                 "627=2\u0001" +
                 "628=HOPID1\u0001629=20220414-15:22:54\u0001" +
                 "628=HOPID2\u0001629=20220414-15:22:54\u0001" +


### PR DESCRIPTION
Enhancements made to correctly parse Header fields found in the body of a message.

Fixes #468