### PR TITLE
Move `unbind` into `closeManagedSessionsAndDispose`

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/SessionConnector.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/SessionConnector.java
@@ -52,6 +52,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.mina.core.future.CloseFuture;
+import org.apache.mina.core.service.IoAcceptor;
 import org.apache.mina.core.service.IoService;
 
 /**

--- a/quickfixj-core/src/main/java/quickfix/mina/SessionConnector.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/SessionConnector.java
@@ -454,9 +454,10 @@ public abstract class SessionConnector implements Connector {
                     completed = closeFuture.await(1000, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException ex) {
                     Thread.currentThread().interrupt();
-                }
-                if (!completed) {
-                    logger.warn("Could not close IoSession {}", ioSession);
+                } finally {
+                    if (!completed) {
+                        logger.warn("Could not close IoSession {}", ioSession);
+                    }
                 }
             }
         }

--- a/quickfixj-core/src/main/java/quickfix/mina/acceptor/AbstractSocketAcceptor.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/acceptor/AbstractSocketAcceptor.java
@@ -265,7 +265,6 @@ public abstract class AbstractSocketAcceptor extends SessionConnector implements
         while (ioIt.hasNext()) {
             IoAcceptor ioAcceptor = ioIt.next();
             SocketAddress localAddress = ioAcceptor.getLocalAddress();
-            ioAcceptor.unbind();
             closeManagedSessionsAndDispose(ioAcceptor, true, log);
             log.info("No longer accepting connections on {}", localAddress);
             ioIt.remove();


### PR DESCRIPTION
Sometimes the unit test `SocketAcceptorTest` is failing because it cannot bind on an address that was used before. More often than not this seems to happen on MacOS.
In this PR we try a little harder to get rid of all sessions but it also may be a race condition somewhere in MINA...