### PR TITLE
Test that replicates a scenario where an initiator gets logged out by…

### DIFF
--- a/quickfixj-core/src/test/java/quickfix/test/acceptance/ATApplication.java
+++ b/quickfixj-core/src/test/java/quickfix/test/acceptance/ATApplication.java
@@ -38,6 +38,8 @@ public class ATApplication implements Application {
     private final MessageCracker outboundCracker = new MessageCracker(new Object());
     private boolean isLoggedOn;
 
+    private static int count = 0;
+
     public void onCreate(SessionID sessionID) {
         assertNoSessionLock(sessionID);
         Session.lookupSession(sessionID).reset();
@@ -81,6 +83,11 @@ public class ATApplication implements Application {
     public void fromAdmin(Message message, SessionID sessionID) throws FieldNotFound,
             IncorrectDataFormat, IncorrectTagValue, RejectLogon {
         assertNoSessionLock(sessionID);
+
+        if (count > 2) { // leave the logon and some heartbeats go through, then logout the session.
+            Session.lookupSession(sessionID).logout();
+        }
+        count++;
     }
 
     public void fromApp(Message message, SessionID sessionID) throws FieldNotFound,


### PR DESCRIPTION
… the acceptor and it can not logon again until the acceptor restarts.

The steps to replicate are:
1. The initiator connects to the acceptor
2. The acceptor accepts the connection, but after a while (it could be any reason. Here after the 4th message received fromAdmin, the acceptor logs out the initiator.) the acceptor decides to logout the initiator.
3. The initiator is logged out and can not reconnect to the acceptor because: "Logon attempt when session is disabled".
The initiator can reconnect only after the acceptor is restarted, and the enabled session variable is back to true.