### PR TITLE
Use `ioSession.closeOnFlush()` where sensible

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/AbstractIoHandler.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/AbstractIoHandler.java
@@ -102,7 +102,7 @@ public abstract class AbstractIoHandler extends IoHandlerAdapter {
                     quickFixSession.disconnect(reason, true);
                 } else {
                     log.error(reason, cause);
-                    ioSession.closeNow();
+                    ioSession.closeOnFlush();
                 }
             } finally {
                 ioSession.setAttribute(SessionConnector.QFJ_RESET_IO_CONNECTOR, Boolean.TRUE);
@@ -127,7 +127,7 @@ public abstract class AbstractIoHandler extends IoHandlerAdapter {
             throw e;
         } finally {
             ioSession.removeAttribute(SessionConnector.QF_SESSION);
-            ioSession.closeNow();
+            ioSession.closeOnFlush();
         }
     }
 


### PR DESCRIPTION
In cases where the connection needs to be closed immediately (unknown session or invalid Logon message) we will still use `closeNow()`.
There were some SSL-related tests which failed due to messages not being flushed. See https://github.com/quickfix-j/quickfixj/pull/441/commits/4345ca0c2def0e5cc747fb9afd55bb2c5b222b37