### PR TITLE
Improve `IntConverter` performance

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/NumbersCache.java
+++ b/quickfixj-core/src/main/java/quickfix/NumbersCache.java
@@ -32,19 +32,21 @@ public final class NumbersCache {
 
     static {
         LITTLE_NUMBERS = new ArrayList<>(LITTLE_NUMBERS_LENGTH);
-        for (int i = 0; i < LITTLE_NUMBERS_LENGTH; i++)
+        for (int i = 0; i < LITTLE_NUMBERS_LENGTH; i++) {
             LITTLE_NUMBERS.add(Integer.toString(i));
+        }
     }
 
     /**
      * Get the String representing the given number
      *
-     * @param i the long to convert
-     * @return the String representing the long
+     * @param i the int to convert
+     * @return the String representing the integer
      */
     public static String get(int i) {
-        if (i < LITTLE_NUMBERS_LENGTH)
+        if (i < LITTLE_NUMBERS_LENGTH && i >= 0) {
             return LITTLE_NUMBERS.get(i);
+        }
         return String.valueOf(i);
     }
 
@@ -56,10 +58,11 @@ public final class NumbersCache {
       * @return the String representing the double or null if the double is not an integer
       */
     public static String get(double d) {
-        long l = (long)d;
-        if (d == (double)l)
+        long l = (long) d;
+        if (d == (double) l) {
             return get(l);
+        }
         return null;
-	  }
+    }
 
 }

--- a/quickfixj-core/src/main/java/quickfix/field/converter/AbstractDateTimeConverter.java
+++ b/quickfixj-core/src/main/java/quickfix/field/converter/AbstractDateTimeConverter.java
@@ -47,7 +47,7 @@ abstract class AbstractDateTimeConverter {
     protected static void assertDigitSequence(String value, int i, int j, String type)
             throws FieldConvertError {
         for (int offset = i; offset < j; offset++) {
-            if (!Character.isDigit(value.charAt(offset))) {
+            if (!IntConverter.isDigit(value.charAt(offset))) {
                 throwFieldConvertError(value, type);
             }
         }

--- a/quickfixj-core/src/main/java/quickfix/field/converter/IntConverter.java
+++ b/quickfixj-core/src/main/java/quickfix/field/converter/IntConverter.java
@@ -27,6 +27,8 @@ import quickfix.NumbersCache;
  */
 public final class IntConverter {
 
+    private static final String INT_MAX_STRING = String.valueOf(Integer.MAX_VALUE);
+    
     /**
      * Convert an integer to a String
      *
@@ -44,20 +46,66 @@ public final class IntConverter {
      * @param value the String to convert
      * @return the converted integer
      * @throws FieldConvertError raised if the String does not represent a valid
-     * integer
+     * FIX integer, i.e. optional negative sign and rest are digits.
      * @see java.lang.Integer#parseInt(String)
      */
     public static int convert(String value) throws FieldConvertError {
-        try {
-            for (int i = 0; i < value.length(); i++) {
-                if (!Character.isDigit(value.charAt(i)) && !(i == 0 && value.charAt(i) == '-')) {
-                    throw new FieldConvertError("invalid integral value: " + value);
+
+        if (!value.isEmpty()) {
+            final char firstChar = value.charAt(0);
+            boolean isNegative = (firstChar == '-');
+            if (!Character.isDigit(firstChar) && !isNegative) {
+                throw new FieldConvertError("invalid integral value: " + value);
+            }
+            int minLength = (isNegative ? 2 : 1);
+            if (value.length() < minLength) {
+                throw new FieldConvertError("invalid integral value: " + value);
+            }
+
+            // Heuristic: since we have no range check in our parseInt() we only parse
+            // values which have at least one digit less than Integer.MAX_VALUE and
+            // leave longer Strings to Integer.parseInt().
+            // NB: we must not simply reject strings longer than MAX_VALUE since
+            // they could possibly include an arbitrary number of leading zeros.
+            int maxLength = (isNegative ? INT_MAX_STRING.length() : INT_MAX_STRING.length() - 1);
+            if (value.length() <= maxLength) {
+                return parseInt(value, isNegative);
+            } else {
+                try {
+                    return Integer.parseInt(value);
+                } catch (NumberFormatException e) {
+                    throw new FieldConvertError("invalid integral value: " + value + ": " + e);
                 }
             }
-            return Integer.parseInt(value);
-        } catch (NumberFormatException e) {
-            throw new FieldConvertError("invalid integral value: " + value + ": " + e);
+        } else {
+            throw new FieldConvertError("invalid integral value: empty string");
         }
+    }
+
+    /**
+     * Please note that input needs to be validated first, otherwise unexpected
+     * results may occur. Please also note that this method has no range or
+     * overflow check, so please only use it when you are sure that no overflow
+     * might occur (e.g. for parsing seconds or smaller integers).
+     *
+     * This method does however check if the contained characters are digits.
+     *
+     * @param value the String to convert
+     * @param isNegative if passed String is negative, first character will
+     * be skipped since it is assumed that it contains the negative sign
+     * @return the converted int
+     */
+    private static int parseInt(String value, boolean isNegative) throws FieldConvertError {
+        int num = 0;
+        int firstIndex = (isNegative ? 1 : 0);
+        for (int i = firstIndex; i < value.length(); i++) {
+            if (Character.isDigit(value.charAt(i))) {
+                num = (num * 10) + (value.charAt(i) - '0');
+            } else {
+                throw new FieldConvertError("invalid integral value: " + value);
+            }
+        }
+        return isNegative ? -num : num;
     }
 
     /**

--- a/quickfixj-core/src/main/java/quickfix/field/converter/IntConverter.java
+++ b/quickfixj-core/src/main/java/quickfix/field/converter/IntConverter.java
@@ -20,6 +20,7 @@
 package quickfix.field.converter;
 
 import quickfix.FieldConvertError;
+import quickfix.NumbersCache;
 
 /**
  * Convert between an integer and a String
@@ -31,10 +32,10 @@ public final class IntConverter {
      *
      * @param i the integer to convert
      * @return the String representing the integer
-     * @see java.lang.Long#toString(long)
+     * @see NumbersCache#get(int) 
      */
     public static String convert(int i) {
-        return Long.toString(i);
+        return NumbersCache.get(i);
     }
 
     /**

--- a/quickfixj-core/src/main/java/quickfix/field/converter/IntConverter.java
+++ b/quickfixj-core/src/main/java/quickfix/field/converter/IntConverter.java
@@ -54,7 +54,7 @@ public final class IntConverter {
         if (!value.isEmpty()) {
             final char firstChar = value.charAt(0);
             boolean isNegative = (firstChar == '-');
-            if (!Character.isDigit(firstChar) && !isNegative) {
+            if (!isDigit(firstChar) && !isNegative) {
                 throw new FieldConvertError("invalid integral value: " + value);
             }
             int minLength = (isNegative ? 2 : 1);
@@ -99,7 +99,7 @@ public final class IntConverter {
         int num = 0;
         int firstIndex = (isNegative ? 1 : 0);
         for (int i = firstIndex; i < value.length(); i++) {
-            if (Character.isDigit(value.charAt(i))) {
+            if (isDigit(value.charAt(i))) {
                 num = (num * 10) + (value.charAt(i) - '0');
             } else {
                 throw new FieldConvertError("invalid integral value: " + value);
@@ -155,4 +155,15 @@ public final class IntConverter {
         }
         return negative ? -num : num;
     }
+    
+    /**
+     * Check if a character is a digit, i.e. in the range between 0 and 9.
+     *
+     * @param character character to check
+     * @return true if character is a digit between 0 and 9
+     */
+    static boolean isDigit(char character) {
+        return (character >= '0' && character <= '9');
+    }
+
 }

--- a/quickfixj-core/src/test/java/quickfix/FieldConvertersTest.java
+++ b/quickfixj-core/src/test/java/quickfix/FieldConvertersTest.java
@@ -55,6 +55,12 @@ public class FieldConvertersTest {
     public void testIntegerConversion() throws Exception {
         String intMaxValuePlus3 = "2147483650";
         String intMinValueMinus3 = "-2147483651";
+        String intLargeValue  = "999999999";
+        String intLargeValue2 = "2000000000";
+        assertEquals(String.valueOf(Integer.MAX_VALUE), IntConverter.convert(Integer.MAX_VALUE));
+        assertEquals(String.valueOf(Integer.MIN_VALUE), IntConverter.convert(Integer.MIN_VALUE));
+        assertEquals(999999999, IntConverter.convert(intLargeValue));
+        assertEquals(2000000000, IntConverter.convert(intLargeValue2));
         assertEquals("123", IntConverter.convert(123));
         assertEquals(123, IntConverter.convert("123"));
         assertEquals(-1, IntConverter.convert("-1"));
@@ -87,6 +93,24 @@ public class FieldConvertersTest {
         // this should fail and not overflow
         try {
             IntConverter.convert(intMinValueMinus3);
+            fail();
+        } catch (FieldConvertError e) {
+            // expected
+        }
+        try {
+            IntConverter.convert("");
+            fail();
+        } catch (FieldConvertError e) {
+            // expected
+        }
+        try {
+            IntConverter.convert("-");
+            fail();
+        } catch (FieldConvertError e) {
+            // expected
+        }
+        try {
+            IntConverter.convert("+");
             fail();
         } catch (FieldConvertError e) {
             // expected


### PR DESCRIPTION
Replaced `Long.toString()` by call to `NumbersCache.get()` to prevent unnecessary allocation for integers ranging from 0 to 99999.

Improved performance of integer parsing for integers shorter than `Integer.MAX_VALUE`.
Heuristic: since we have no range check in our `parseInt()` we only parse values which have at least one digit less than `Integer.MAX_VALUE` and leave longer Strings to `Integer.parseInt()`.
NB: we must not simply reject strings longer than `MAX_VALUE` since they could possibly include an arbitrary number of leading zeros.
