### PR TITLE
Improve handling of Weekday schedules when EndTime < StartTime

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/DefaultSessionSchedule.java
+++ b/quickfixj-core/src/main/java/quickfix/DefaultSessionSchedule.java
@@ -210,6 +210,24 @@ public class DefaultSessionSchedule implements SessionSchedule {
 
             if (intervalEnd.getTimeInMillis() <= intervalStart.getTimeInMillis()) {
                 intervalEnd.add(Calendar.DAY_OF_WEEK, 1);
+
+                // go back even further so both start and end time are weekdays
+                // this allows handling schedules like "Sun 17:05 - Mon 16:55,  ..., Thu 17:05 - Fri 16:55"
+                // in case of a really screwed up configuration we may not find a suitable interval,
+                // so limit this loop to a week and undo the change afterwards if we failed
+                int undoOffset = 0;
+                for (int i = 0; i < 7; i++) {
+                    if (validDayOfWeek(intervalStart) && validDayOfWeek(intervalEnd)) {
+                        undoOffset = 0;
+                        break;
+                    }
+
+                    undoOffset++;
+                    intervalStart.add(Calendar.DAY_OF_WEEK, -1);
+                    intervalEnd.add(Calendar.DAY_OF_WEEK, -1);
+                }
+                intervalStart.add(Calendar.DAY_OF_WEEK, undoOffset);
+                intervalEnd.add(Calendar.DAY_OF_WEEK, undoOffset);
             }
 
         } else {

--- a/quickfixj-core/src/test/java/quickfix/SessionScheduleTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionScheduleTest.java
@@ -1076,9 +1076,9 @@ public class SessionScheduleTest {
         doIsSessionTimeTest(schedule, true, 2017, Calendar.JANUARY, 6, 3, 0, 0);
         doIsSessionTimeTest(schedule, false, 2017, Calendar.JANUARY, 6, 3, 0, 1);
         doIsSessionTimeTest(schedule, false, 2017, Calendar.JANUARY, 6, 17, 59, 59);
-        doIsSessionTimeTest(schedule, true, 2017, Calendar.JANUARY, 6, 18, 0, 0);
+        doIsSessionTimeTest(schedule, false, 2017, Calendar.JANUARY, 6, 18, 0, 0);
         // Saturday
-        doIsSessionTimeTest(schedule, true, 2017, Calendar.JANUARY, 7, 3, 0, 0);
+        doIsSessionTimeTest(schedule, false, 2017, Calendar.JANUARY, 7, 3, 0, 0);
         doIsSessionTimeTest(schedule, false, 2017, Calendar.JANUARY, 7, 3, 0, 1);
         doIsSessionTimeTest(schedule, false, 2017, Calendar.JANUARY, 7, 17, 59, 59);
         doIsSessionTimeTest(schedule, false, 2017, Calendar.JANUARY, 7, 18, 0, 0);
@@ -1402,6 +1402,215 @@ public class SessionScheduleTest {
         // November,7 -> Friday
         doIsSessionTimeTest(schedule, true, 2008, Calendar.NOVEMBER, 7, 17, 0, 0,
                 TimeZone.getTimeZone("America/New_York"));
+    }
+
+    @Test
+    public void testIsSessionTimeWithStartTimeAfterEndAndWeekdays() throws Exception {
+        SessionSettings settings = new SessionSettings();
+        settings.setString(Session.SETTING_TIMEZONE, "America/New_York");
+        settings.setString(Session.SETTING_START_TIME, "17:05:00");
+        settings.setString(Session.SETTING_END_TIME, "16:55:00");
+        settings.setString(Session.SETTING_WEEKDAYS, "Sun,Mon,Tue,Wed,Thu,Fri");
+
+        mockSystemTimeSource.setTime(getTimeStamp(2008, Calendar.NOVEMBER, 2, 18, 0, 0, TimeZone.getTimeZone("America/New_York")));
+
+        SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
+
+
+        // Sun 17:05 - Monday 16:55
+        //  not in session Sun [00:00:00, 17:04:59]
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 13, 0, 0, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 13, 16, 55, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 13, 17, 4, 59,
+                TimeZone.getTimeZone("America/New_York"));
+        // in session Sun [17:05, 23:59:59]
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 13, 17, 5, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 13, 23, 59, 59,
+                TimeZone.getTimeZone("America/New_York"));
+        // in session Mon [00:00:00, 16:55:00]
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 14, 0, 0, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 14, 16, 55, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        // not in session Mon [16:55:01, 17:04:59]
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 14, 16, 55, 1,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 14, 17, 4, 59,
+                TimeZone.getTimeZone("America/New_York"));
+
+        // Mon 17:05 - Tue 16:55
+        // in session Mon [17:55:00, 23:59:59]
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 14, 17, 5, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 14, 23, 59, 59,
+                TimeZone.getTimeZone("America/New_York"));
+        // in session Tue [00:00:00, 16:55:00]
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 15, 0, 0, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 15, 16, 55, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        // not in session Tue [16:55:01, 17:04:59]
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 15, 16, 55, 1,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 15, 17, 4, 59,
+                TimeZone.getTimeZone("America/New_York"));
+
+        // Tue 17:05 - Wed 16:55
+        // in session Tue [17:55:00, 23:59:59]
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 15, 17, 5, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 15, 23, 59, 59,
+                TimeZone.getTimeZone("America/New_York"));
+        // in session Wed [00:00:00, 16:55:00]
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 16, 0, 0, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 16, 16, 55, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        // not in session Wed [16:55:01, 17:04:59]
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 16, 16, 55, 1,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 16, 17, 4, 59,
+                TimeZone.getTimeZone("America/New_York"));
+
+        // Wed 17:05 - Thu 16:55
+        // in session Wed [17:55:00, 23:59:59]
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 16, 17, 5, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 16, 23, 59, 59,
+                TimeZone.getTimeZone("America/New_York"));
+        // in session Thu [00:00:00, 16:55:00]
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 17, 0, 0, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 17, 16, 55, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        // not in session Thu [16:55:01, 17:04:59]
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 17, 16, 55, 1,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 17, 17, 4, 59,
+                TimeZone.getTimeZone("America/New_York"));
+
+        // Thu 17:05 - Fri 16:55
+        // in session Thu [17:55:00, 23:59:59]
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 17, 17, 5, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 17, 23, 59, 59,
+                TimeZone.getTimeZone("America/New_York"));
+        // in session Fri [00:00:00, 16:55:00]
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 18, 0, 0, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, true, 2022, Calendar.NOVEMBER, 18, 16, 55, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        // not in session Fri [16:55:01, 00:00:00]
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 18, 16, 55, 1,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 18, 17, 4, 59,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 18, 17, 5, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 18, 17, 5, 1,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 18, 23, 59, 59,
+                TimeZone.getTimeZone("America/New_York"));
+        // Sat - not in schedule
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 19, 0, 0, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 19, 16, 54, 59,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 19, 16, 55, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 19, 16, 55, 1,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 19, 17, 4, 59,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 19, 17, 5, 0,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 19, 17, 5, 1,
+                TimeZone.getTimeZone("America/New_York"));
+        doIsSessionTimeTest(schedule, false, 2022, Calendar.NOVEMBER, 19, 23, 59, 59,
+                TimeZone.getTimeZone("America/New_York"));
+    }
+
+    @Test
+    public void testIsSameSessionWithStartTimeAfterEndAndWeekdays() throws Exception {
+        SessionSettings settings = new SessionSettings();
+        settings.setString(Session.SETTING_TIMEZONE, "America/New_York");
+        settings.setString(Session.SETTING_START_TIME, "17:05:00");
+        settings.setString(Session.SETTING_END_TIME, "16:55:00");
+        settings.setString(Session.SETTING_WEEKDAYS, "Sun,Mon,Tue,Wed,Thu,Fri");
+
+        TimeZone tz = TimeZone.getTimeZone("America/New_York");
+        mockSystemTimeSource.setTime(getTimeStamp(2008, Calendar.NOVEMBER, 2, 18, 0, 0, tz));
+
+        SessionID sessionID = new SessionID("FIX.4.2", "SENDER", "TARGET");
+        SessionSchedule schedule = new DefaultSessionSchedule(settings, sessionID);
+
+        // Sun 17:05 - Mon 16:55
+        // t1 is before start time, t2 is in session
+        Calendar t1 = getTimeStamp(2022, Calendar.NOVEMBER, 13, 14, 0, 0, tz);
+        Calendar t2 = getTimeStamp(2022, Calendar.NOVEMBER, 13, 17, 5, 0, tz);
+        doIsSameSessionTest(schedule, t1, t2, false);
+
+        // t1 and t2 are in session
+        t1 = getTimeStamp(2022, Calendar.NOVEMBER, 13, 17, 5, 0, tz);
+
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 13, 23, 59, 59, tz);
+        doIsSameSessionTest(schedule, t1, t2, true);
+
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 14, 0, 0, 0, tz);
+        doIsSameSessionTest(schedule, t1, t2, true);
+
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 14, 16, 55, 0, tz);
+        doIsSameSessionTest(schedule, t1, t2, true);
+
+        // t1 is in session, t2 is after end time (Mon)
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 14, 16, 55, 1, tz);
+        doIsSameSessionTest(schedule, t1, t2, false);
+
+        // Mon 17:05 - Tue 16:55
+
+        // t1 and t2 are in session
+        t1 = getTimeStamp(2022, Calendar.NOVEMBER, 14, 17, 5, 0, tz);
+
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 14, 23, 59, 59, tz);
+        doIsSameSessionTest(schedule, t1, t2, true);
+
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 15, 0, 0, 0, tz);
+        doIsSameSessionTest(schedule, t1, t2, true);
+
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 15, 16, 55, 0, tz);
+        doIsSameSessionTest(schedule, t1, t2, true);
+
+        // t1 is in session, t2 is after end time
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 15, 16, 55, 1, tz);
+        doIsSameSessionTest(schedule, t1, t2, false);
+
+        // Thu 17:05 - Fri 16:55
+
+        // t1 and t2 are in session
+        t1 = getTimeStamp(2022, Calendar.NOVEMBER, 17, 17, 5, 0, tz);
+
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 17, 23, 59, 59, tz);
+        doIsSameSessionTest(schedule, t1, t2, true);
+
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 18, 0, 0, 0, tz);
+        doIsSameSessionTest(schedule, t1, t2, true);
+
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 18, 16, 55, 0, tz);
+        doIsSameSessionTest(schedule, t1, t2, true);
+
+        // t1 is in session, t2 is after end time (Tue)
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 18, 16, 55, 1, tz);
+        doIsSameSessionTest(schedule, t1, t2, false);
+
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 18, 17, 5, 0, tz);
+        doIsSameSessionTest(schedule, t1, t2, false);
+
+        t2 = getTimeStamp(2022, Calendar.NOVEMBER, 18, 17, 23, 59, tz);
+        doIsSameSessionTest(schedule, t1, t2, false);
     }
 
 }


### PR DESCRIPTION
In FX session typically starts on Sun evening and is reset around 5PM NewYork time. So daily schedule may look like this
 Sun 17:05 - Mon 16:55
 Mon 17:05 - Tue 16:55
 Tue 17:05 - Wed 16:55
 Wed 17:05 - Thu 16:55
 Thu 17:05 - Fri 16:55

I was expecting that below settings would achieve this:
```
  Weekdays = SUNDAY,MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY
  StartTime = 17:05:00
  EndTime = 16:55:00
```
But they don't, because DefaultSessionSchedule considers the interval [Fri 17:05 - Sat 16:55] to be in session - even if Sat is not a weekday.

This change improves weekday behaviour by going backwards until both start and end days are weekdays. It does not have any impact in cases when EndTime > StartTime.

As a precaution, if suitable interval could not be found we revert to original behaviour. This should be configuration error, but even then returning something which is not quite right is better than getting stuck in infinite loop.