### PR TITLE
Use dynamic port for `LostLogoutTest`, `LostLogoutThreadedTest`, `SocketAcceptorTest`

### DIFF
--- a/quickfixj-core/src/test/java/quickfix/SocketAcceptorTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SocketAcceptorTest.java
@@ -81,9 +81,10 @@ public class SocketAcceptorTest {
         Acceptor acceptor = null;
         Initiator initiator = null;
         try {
-            acceptor = createAcceptor(testAcceptorApplication);
+            final int port = AvailablePortFinder.getNextAvailable();
+            acceptor = createAcceptor(testAcceptorApplication, port);
             acceptor.start();
-            initiator = createInitiator(testInitiatorApplication);
+            initiator = createInitiator(testInitiatorApplication, port);
 
             assertNotNull("Session should be registered", lookupSession(acceptorSessionID));
 
@@ -131,7 +132,8 @@ public class SocketAcceptorTest {
         try {
             ThreadMXBean bean = ManagementFactory.getThreadMXBean();
             TestConnectorApplication testAcceptorApplication = new TestConnectorApplication();
-            acceptor = createAcceptor(testAcceptorApplication);
+            final int port = AvailablePortFinder.getNextAvailable();
+            acceptor = createAcceptor(testAcceptorApplication, port);
             acceptor.start();
             Thread.sleep(2500L);
             acceptor.stop();
@@ -152,7 +154,8 @@ public class SocketAcceptorTest {
         try {
             ThreadMXBean bean = ManagementFactory.getThreadMXBean();
             TestConnectorApplication testAcceptorApplication = new TestConnectorApplication();
-            acceptor = createAcceptor(testAcceptorApplication);
+            final int port = AvailablePortFinder.getNextAvailable();
+            acceptor = createAcceptor(testAcceptorApplication, port);
             acceptor.start();
             // second start should be ignored
             acceptor.start();
@@ -170,7 +173,8 @@ public class SocketAcceptorTest {
         Acceptor acceptor = null;
         try {
             TestConnectorApplication testAcceptorApplication = new TestConnectorApplication();
-            acceptor = createAcceptor(testAcceptorApplication);
+            final int port = AvailablePortFinder.getNextAvailable();
+            acceptor = createAcceptor(testAcceptorApplication, port);
             acceptor.start();
             assertEquals(1, acceptor.getSessions().size() );
             assertEquals(1 + SESSION_COUNT, Session.numSessions() );
@@ -189,7 +193,8 @@ public class SocketAcceptorTest {
         Acceptor acceptor = null;
         try {
             TestConnectorApplication testAcceptorApplication = new TestConnectorApplication();
-            acceptor = createAcceptorThreaded(testAcceptorApplication);
+            final int port = AvailablePortFinder.getNextAvailable();
+            acceptor = createAcceptorThreaded(testAcceptorApplication, port);
             acceptor.start();
             assertEquals(1, acceptor.getSessions().size() );
             assertEquals(1 + SESSION_COUNT, Session.numSessions() );
@@ -345,10 +350,10 @@ public class SocketAcceptorTest {
     }
 
     
-    private Acceptor createAcceptor(TestConnectorApplication testAcceptorApplication)
+    private Acceptor createAcceptor(TestConnectorApplication testAcceptorApplication, int port)
             throws ConfigError {
 
-        SessionSettings settings = createAcceptorSettings();
+        SessionSettings settings = createAcceptorSettings(port);
 
         MessageStoreFactory factory = new MemoryStoreFactory();
         quickfix.LogFactory logFactory = new SLF4JLogFactory(new SessionSettings());
@@ -356,10 +361,10 @@ public class SocketAcceptorTest {
                 new DefaultMessageFactory());
     }
 
-    private Acceptor createAcceptorThreaded(TestConnectorApplication testAcceptorApplication)
+    private Acceptor createAcceptorThreaded(TestConnectorApplication testAcceptorApplication, int port)
             throws ConfigError {
 
-        SessionSettings settings = createAcceptorSettings();
+        SessionSettings settings = createAcceptorSettings(port);
 
         MessageStoreFactory factory = new MemoryStoreFactory();
         quickfix.LogFactory logFactory = new SLF4JLogFactory(new SessionSettings());
@@ -367,7 +372,7 @@ public class SocketAcceptorTest {
                 new DefaultMessageFactory());
     }
     
-    private SessionSettings createAcceptorSettings() {
+    private SessionSettings createAcceptorSettings(int socketAcceptPort) {
         SessionSettings settings = new SessionSettings();
         HashMap<Object, Object> defaults = new HashMap<>();
         defaults.put("ConnectionType", "acceptor");
@@ -376,12 +381,12 @@ public class SocketAcceptorTest {
         defaults.put("BeginString", "FIX.4.2");
         defaults.put("NonStopSession", "Y");
         settings.setString(acceptorSessionID, "SocketAcceptProtocol", ProtocolFactory.getTypeString(ProtocolFactory.SOCKET));
-        settings.setString(acceptorSessionID, "SocketAcceptPort", "10000");
+        settings.setString(acceptorSessionID, "SocketAcceptPort", String.valueOf(socketAcceptPort));
         settings.set(defaults);
         return settings;
     }
 
-    private Initiator createInitiator(TestConnectorApplication testInitiatorApplication) throws ConfigError {
+    private Initiator createInitiator(TestConnectorApplication testInitiatorApplication, int socketConnectPort) throws ConfigError {
         SessionSettings settings = new SessionSettings();
         HashMap<Object, Object> defaults = new HashMap<>();
         defaults.put("ConnectionType", "initiator");
@@ -395,7 +400,7 @@ public class SocketAcceptorTest {
         settings.setString("BeginString", FixVersions.BEGINSTRING_FIX42);
         settings.setString(initiatorSessionID, "SocketConnectProtocol", ProtocolFactory.getTypeString(ProtocolFactory.SOCKET));
         settings.setString(initiatorSessionID, "SocketConnectHost", "127.0.0.1");
-        settings.setString(initiatorSessionID, "SocketConnectPort", "10000");
+        settings.setString(initiatorSessionID, "SocketConnectPort", String.valueOf(socketConnectPort));
         settings.set(defaults);
 
         MessageStoreFactory factory = new MemoryStoreFactory();

--- a/quickfixj-core/src/test/java/quickfix/mina/LostLogoutTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/LostLogoutTest.java
@@ -1,5 +1,6 @@
 package quickfix.mina;
 
+import org.apache.mina.util.AvailablePortFinder;
 import org.junit.Test;
 import quickfix.Application;
 import quickfix.DefaultMessageFactory;
@@ -51,11 +52,12 @@ public class LostLogoutTest {
 
     @Test
     public void lostLogoutMessageTest() throws Exception {
+        final int port = AvailablePortFinder.getNextAvailable();
         // create server (acceptor)
-        server = new ServerApp();
+        server = new ServerApp(port);
 
         // create client (initiator) and start the FIX session (log on)
-        client = new ClientApp();
+        client = new ClientApp(port);
 
         // wait until until client is logged on
         client.waitUntilLoggedOn();
@@ -89,11 +91,11 @@ public class LostLogoutTest {
         private SocketAcceptor acceptor = null;
 
         private final SessionID sid = new SessionID("FIX.4.4", "SERVER", "CLIENT");
-        public ServerApp() throws Exception {
+        public ServerApp(int port) throws Exception {
             SessionSettings settings = new SessionSettings();
             settings.setString("ConnectionType", "acceptor");
             settings.setString("SocketAcceptAddress", "127.0.0.1");
-            settings.setLong("SocketAcceptPort", 54321);
+            settings.setLong("SocketAcceptPort", port);
             settings.setString("StartTime", "00:00:00");
             settings.setString("EndTime", "00:00:00");
             settings.setString("UseDataDictionary", "N");
@@ -164,12 +166,12 @@ public class LostLogoutTest {
         private SocketInitiator initiator = null;
         private Session session;
 
-        public ClientApp() throws Exception {
+        public ClientApp(int port) throws Exception {
             SessionID sid = new SessionID("FIX.4.4", "CLIENT", "SERVER");
             SessionSettings settings = new SessionSettings();
             settings.setString("ConnectionType", "initiator");
             settings.setString("SocketConnectHost", "127.0.0.1");
-            settings.setLong("SocketConnectPort", 54321);
+            settings.setLong("SocketConnectPort", port);
             settings.setString("StartTime", "00:00:00");
             settings.setString("EndTime", "00:00:00");
             settings.setLong("HeartBtInt", 30);

--- a/quickfixj-core/src/test/java/quickfix/mina/LostLogoutThreadedTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/LostLogoutThreadedTest.java
@@ -1,5 +1,6 @@
 package quickfix.mina;
 
+import org.apache.mina.util.AvailablePortFinder;
 import org.junit.Test;
 import quickfix.Application;
 import quickfix.DefaultMessageFactory;
@@ -51,11 +52,12 @@ public class LostLogoutThreadedTest {
 
     @Test
     public void lostLogoutMessageTest() throws Exception {
+        final int port = AvailablePortFinder.getNextAvailable();
         // create server (acceptor)
-        server = new ServerApp();
+        server = new ServerApp(port);
 
         // create client (initiator) and start the FIX session (log on)
-        client = new ClientApp();
+        client = new ClientApp(port);
 
         // wait until until client is logged on
         client.waitUntilLoggedOn();
@@ -88,12 +90,12 @@ public class LostLogoutThreadedTest {
     private class ServerApp implements Application {
         private ThreadedSocketAcceptor acceptor = null;
 
-        public ServerApp() throws Exception {
+        public ServerApp(int port) throws Exception {
             SessionID sid = new SessionID("FIX.4.4", "SERVER", "CLIENT");
             SessionSettings settings = new SessionSettings();
             settings.setString("ConnectionType", "acceptor");
             settings.setString("SocketAcceptAddress", "127.0.0.1");
-            settings.setLong("SocketAcceptPort", 54321);
+            settings.setLong("SocketAcceptPort", port);
             settings.setString("StartTime", "00:00:00");
             settings.setString("EndTime", "00:00:00");
             settings.setString("UseDataDictionary", "N");
@@ -164,12 +166,12 @@ public class LostLogoutThreadedTest {
         private ThreadedSocketInitiator initiator = null;
         private Session session;
 
-        public ClientApp() throws Exception {
+        public ClientApp(int port) throws Exception {
             SessionID sid = new SessionID("FIX.4.4", "CLIENT", "SERVER");
             SessionSettings settings = new SessionSettings();
             settings.setString("ConnectionType", "initiator");
             settings.setString("SocketConnectHost", "127.0.0.1");
-            settings.setLong("SocketConnectPort", 54321);
+            settings.setLong("SocketConnectPort", port);
             settings.setString("StartTime", "00:00:00");
             settings.setString("EndTime", "00:00:00");
             settings.setLong("HeartBtInt", 30);


### PR DESCRIPTION
Fixes #487 