### PR TITLE
Remove `slf4j-jdk14` from `examples` and `distribution` module

### DIFF
--- a/quickfixj-distribution/src/main/assembly/distribution.xml
+++ b/quickfixj-distribution/src/main/assembly/distribution.xml
@@ -26,18 +26,6 @@
 							<exclude>classworlds:*</exclude>
 						</excludes>
 					</dependencySet>
-					<!--
-						Due to an assembly bug, a dependency that appears both in test scope
-						and another scope (compile/runtime) in two different modules will be
-						excluded. We re-include these here manually for now.
-					-->
-					<dependencySet>
-						<outputDirectory>lib</outputDirectory>
-						<scope>test</scope>
-						<includes>
-							<include>org.slf4j:slf4j-jdk14</include>
-						</includes>
-					</dependencySet>
 				</dependencySets>
 			</binaries>
 		</moduleSet>

--- a/quickfixj-examples/pom.xml
+++ b/quickfixj-examples/pom.xml
@@ -36,12 +36,6 @@
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-jdk14</artifactId>
-			<version>${slf4j.version}</version>
-			<scope>runtime</scope>
-		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
See https://github.com/quickfix-j/quickfixj/discussions/566#discussioncomment-5113958 and following comments.

This should correct the `NullPointerException` during builds with the `-PskipBundlePlugin` profile.