### PR TITLE
Correct `Resource not found` in `FileUtilTest` (#654) on QFJ 2.3.x

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/FileUtil.java
+++ b/quickfixj-core/src/main/java/quickfix/FileUtil.java
@@ -24,7 +24,10 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLConnection;
+
 
 public class FileUtil {
     public static String fileAppendPath(String pathPrefix, String pathSuffix) {
@@ -141,7 +144,18 @@ public class FileUtil {
                 break;
             case URL:
                 try {
-                    in = new URL(name).openStream();
+                    URL url = new URL(name);
+                    URLConnection urlConnection = url.openConnection();
+                    if (urlConnection instanceof HttpURLConnection) {
+                        HttpURLConnection httpURLConnection = (HttpURLConnection)urlConnection;
+                        httpURLConnection.setRequestProperty("User-Agent", "Java-QuickFIXJ-FileUtil");
+                        httpURLConnection.connect();
+                        in = httpURLConnection.getInputStream();
+                    } else {
+                        if (urlConnection != null) {
+                            in = urlConnection.getInputStream();
+                        }
+                    }
                 } catch (IOException e) {
                     // ignore
                 }

--- a/quickfixj-core/src/test/java/quickfix/FileUtilTest.java
+++ b/quickfixj-core/src/test/java/quickfix/FileUtilTest.java
@@ -68,6 +68,15 @@ public class FileUtilTest {
     }
 
     @Test
+    public void testJARURLLocation() throws Exception {
+        // just test that we don't run into a ClassCastException
+        InputStream in = FileUtil.open(Message.class, "jar:file:/foo.bar!/");
+        if (in != null) {
+            in.close();
+        }
+    }
+
+    @Test
     // QFJ-775
     public void testSessionIDFileName() {
         SessionID sessionID = new SessionID(FixVersions.BEGINSTRING_FIX44, "SENDER???",


### PR DESCRIPTION
Same PR as #654 on master

* update FileUtil to resolve new 403 error for requests with User-Agent header
* Updated User-Agent value for FileUtil
* Added check for HttpUrlConnection to changes done in #460
