### PR TITLE
Proposal: add DoNotFulfillResendRequest exception to allow applications to prevent resend

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Application.java
+++ b/quickfixj-core/src/main/java/quickfix/Application.java
@@ -79,7 +79,7 @@ public interface Application {
      * @throws RejectLogon causes a logon reject
      */
     void fromAdmin(Message message, SessionID sessionId) throws FieldNotFound, IncorrectDataFormat,
-            IncorrectTagValue, RejectLogon;
+            IncorrectTagValue, RejectLogon, DoNotFulfillResendRequest;
 
     /**
      * This is a callback for application messages that you are sending to a

--- a/quickfixj-core/src/main/java/quickfix/DoNotFulfillResendRequest.java
+++ b/quickfixj-core/src/main/java/quickfix/DoNotFulfillResendRequest.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) quickfixengine.org  All rights reserved.
+ *
+ * This file is part of the QuickFIX FIX Engine
+ *
+ * This file may be distributed under the terms of the quickfixengine.org
+ * license as defined by quickfixengine.org and appearing in the file
+ * LICENSE included in the packaging of this file.
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING
+ * THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * See http://www.quickfixengine.org/LICENSE for licensing information.
+ *
+ * Contact ask@quickfixengine.org if any conditions of this licensing
+ * are not clear to you.
+ ******************************************************************************/
+
+package quickfix;
+
+/**
+ * Applications can throw this exception to abort the fulfillment of an
+ * incoming ResendRequest.
+ *
+ * Example use case: the counterparty sends an excessive number of
+ * ResendRequests in error, and we want to prevent quickfix from fulfilling
+ * them, spiking cpu and disk I/O, overwhelming the server.  Further action,
+ * such as sending Rejects to alert the counterparty to the problem, are left
+ * up to Applications.
+ */
+public class DoNotFulfillResendRequest extends Exception {
+    private final static String defaultMsg = "Fulfillment of ResendRequest aborted by Application";
+
+    public DoNotFulfillResendRequest() {
+        super(defaultMsg);
+    }
+
+    public DoNotFulfillResendRequest(String msg) {
+        super(defaultMsg + ": " + msg);
+    }
+}

--- a/quickfixj-core/src/test/java/quickfix/UnitTestApplication.java
+++ b/quickfixj-core/src/test/java/quickfix/UnitTestApplication.java
@@ -59,7 +59,7 @@ public class UnitTestApplication implements ApplicationExtended, SessionStateLis
 
     @Override
     public void fromAdmin(Message message, SessionID sessionId) throws FieldNotFound,
-            IncorrectDataFormat, IncorrectTagValue, RejectLogon {
+            IncorrectDataFormat, IncorrectTagValue, RejectLogon, DoNotFulfillResendRequest {
         log.info("from admin [{}] {}", sessionId, message);
         fromAdminMessages.add(message);
     }

--- a/quickfixj-core/src/test/java/quickfix/mina/ThreadPerSessionEventHandlingStrategyTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/ThreadPerSessionEventHandlingStrategyTest.java
@@ -31,6 +31,7 @@ import quickfix.IncorrectTagValue;
 import quickfix.MemoryStoreFactory;
 import quickfix.Message;
 import quickfix.RejectLogon;
+import quickfix.DoNotFulfillResendRequest;
 import quickfix.Responder;
 import quickfix.SLF4JLogFactory;
 import quickfix.Session;
@@ -116,7 +117,7 @@ public class ThreadPerSessionEventHandlingStrategyTest {
         final UnitTestApplication application = new UnitTestApplication() {
             @Override
             public void fromAdmin(Message message, SessionID sessionId) throws FieldNotFound,
-                    IncorrectDataFormat, IncorrectTagValue, RejectLogon {
+                    IncorrectDataFormat, IncorrectTagValue, RejectLogon, DoNotFulfillResendRequest {
                 super.fromAdmin(message, sessionId);
                 latch.countDown();
             }
@@ -185,7 +186,7 @@ public class ThreadPerSessionEventHandlingStrategyTest {
         final UnitTestApplication application = new UnitTestApplication() {
             @Override
             public void fromAdmin(Message message, SessionID sessionId) throws FieldNotFound,
-                    IncorrectDataFormat, IncorrectTagValue, RejectLogon {
+                    IncorrectDataFormat, IncorrectTagValue, RejectLogon, DoNotFulfillResendRequest {
                 super.fromAdmin(message, sessionId);
                 latch.countDown();
             }


### PR DESCRIPTION
Adds exception _DoNotFulfillResendRequest_ to fromAdmin, in the spirit of _RejectLogon_, to alter the behavior of the engine.
    
Applications can throw this exception to abort the fulfillment of an incoming ResendRequest.

The example use case for this comes from real life, in production at one of the largest derivatives exchanges:
- the counterparty sends an excessive number of large ResendRequests in error (multiple per second)
- this causes a massive spike in cpu, disk, and memory utilization
- there is no way to prevent quickfix from fulfilling the request, other than to log out / disconnect the counterparty
- even if logged out, they will reconnect and repeat the same behavior, causing the same problem with resources
-  blocking the counterparty from reconnecting is undersirable: it puts the operational burden on the counterparty experiencing the problem, instead of on the counterparty causing the problem
- the ability to prevent the fulfillment of the ResendRequest allows for keeping the session alive and using it to report the problem via Session-level Reject messages
- if the offending counterparty is able to correct the problem, the session can continue, including resend, without operational intervention by the counterparty on the receiving end of the problem
- this new exception can work in conjunction with existing throttling logic that is in place for other message flow

I know this is a slightly unusual use case, but it's a real one, at a very large institution.  This was the best solution we could think of -- if there's a better way to go about it, we'd love to hear your feedback.  Thanks! 
