### PR TITLE
`DataDictionary`: removed check for empty message body

### DIFF
--- a/quickfixj-base/src/main/java/quickfix/DataDictionary.java
+++ b/quickfixj-base/src/main/java/quickfix/DataDictionary.java
@@ -1155,8 +1155,7 @@ public class DataDictionary {
     private int getIntegerAttributeIfDefined(final Element documentElement, final String attribute) throws ConfigError {
         try {
             return documentElement.hasAttribute(attribute)
-                    // TODO
-                    ? Integer.valueOf(documentElement.getAttribute(attribute)) : 0;
+                    ? Integer.parseInt(documentElement.getAttribute(attribute)) : 0;
         } catch (NumberFormatException e) {
             throw new ConfigError("Attribute " + attribute + " could not be parsed as Integer.", e);
         }
@@ -1171,7 +1170,7 @@ public class DataDictionary {
         final NodeList fieldNodes = node.getChildNodes();
 
         if (countElementNodes(fieldNodes) == 0 && (msgtype == HEADER_ID || msgtype == TRAILER_ID)) {
-            throw new ConfigError("No fields found: msgType=" + msgtype);
+            throw new ConfigError("No fields found in " + msgtype);
         }
 
         for (int j = 0; j < fieldNodes.getLength(); j++) {

--- a/quickfixj-base/src/main/java/quickfix/DataDictionary.java
+++ b/quickfixj-base/src/main/java/quickfix/DataDictionary.java
@@ -1155,6 +1155,7 @@ public class DataDictionary {
     private int getIntegerAttributeIfDefined(final Element documentElement, final String attribute) throws ConfigError {
         try {
             return documentElement.hasAttribute(attribute)
+                    // TODO
                     ? Integer.valueOf(documentElement.getAttribute(attribute)) : 0;
         } catch (NumberFormatException e) {
             throw new ConfigError("Attribute " + attribute + " could not be parsed as Integer.", e);
@@ -1168,6 +1169,11 @@ public class DataDictionary {
     private void load(Document document, String msgtype, Node node) throws ConfigError {
         String name;
         final NodeList fieldNodes = node.getChildNodes();
+
+        if (countElementNodes(fieldNodes) == 0 && (msgtype == HEADER_ID || msgtype == TRAILER_ID)) {
+            throw new ConfigError("No fields found: msgType=" + msgtype);
+        }
+
         for (int j = 0; j < fieldNodes.getLength(); j++) {
             final Node fieldNode = fieldNodes.item(j);
 

--- a/quickfixj-base/src/main/java/quickfix/DataDictionary.java
+++ b/quickfixj-base/src/main/java/quickfix/DataDictionary.java
@@ -1168,10 +1168,6 @@ public class DataDictionary {
     private void load(Document document, String msgtype, Node node) throws ConfigError {
         String name;
         final NodeList fieldNodes = node.getChildNodes();
-        if (countElementNodes(fieldNodes) == 0) {
-            throw new ConfigError("No fields found: msgType=" + msgtype);
-        }
-
         for (int j = 0; j < fieldNodes.getLength(); j++) {
             final Node fieldNode = fieldNodes.item(j);
 

--- a/quickfixj-base/src/test/java/quickfix/DataDictionaryTest.java
+++ b/quickfixj-base/src/test/java/quickfix/DataDictionaryTest.java
@@ -206,59 +206,6 @@ public class DataDictionaryTest {
     }
 
     @Test
-    public void testMessageWithNoChildren40() throws Exception {
-        String data = "";
-        data += "<fix major=\"4\" minor=\"0\">";
-        data += "  <header>";
-        data += "    <field name=\"BeginString\" required=\"Y\"/>";
-        data += "  </header>";
-        data += "  <trailer>";
-        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
-        data += "  </trailer>";
-        data += "  <fields>";
-        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
-        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
-        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
-        data += "  </fields>";
-        data += "  <messages>";
-        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\"/>";
-        data += "  </messages>";
-        data += "</fix>";
-
-        expectedException.expect(ConfigError.class);
-        expectedException.expectMessage("No fields found: msgType=msg");
-
-        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
-    }
-
-    @Test
-    public void testMessageWithTextElement40() throws Exception {
-        String data = "";
-        data += "<fix major=\"4\" minor=\"0\">";
-        data += "  <header>";
-        data += "    <field name=\"BeginString\" required=\"Y\"/>";
-        data += "  </header>";
-        data += "  <trailer>";
-        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
-        data += "  </trailer>";
-        data += "  <fields>";
-        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
-        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
-        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
-        data += "  </fields>";
-        data += "  <messages>";
-        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
-        data += "    </message>";
-        data += "  </messages>";
-        data += "</fix>";
-
-        expectedException.expect(ConfigError.class);
-        expectedException.expectMessage("No fields found: msgType=msg");
-
-        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
-    }
-
-    @Test
     public void testMessagesWithNoChildren40() throws Exception {
         String data = "";
         data += "<fix major=\"4\" minor=\"0\">";
@@ -458,59 +405,6 @@ public class DataDictionaryTest {
 
         expectedException.expect(ConfigError.class);
         expectedException.expectMessage("No fields defined");
-
-        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
-    }
-
-    @Test
-    public void testMessageWithNoChildren50() throws Exception {
-        String data = "";
-        data += "<fix major=\"5\" minor=\"0\">";
-        data += "  <header>";
-        data += "    <field name=\"BeginString\" required=\"Y\"/>";
-        data += "  </header>";
-        data += "  <trailer>";
-        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
-        data += "  </trailer>";
-        data += "  <fields>";
-        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
-        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
-        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
-        data += "  </fields>";
-        data += "  <messages>";
-        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\"/>";
-        data += "  </messages>";
-        data += "</fix>";
-
-        expectedException.expect(ConfigError.class);
-        expectedException.expectMessage("No fields found: msgType=msg");
-
-        new DataDictionary(new ByteArrayInputStream(data.getBytes()));
-    }
-
-    @Test
-    public void testMessageWithTextElement50() throws Exception {
-        String data = "";
-        data += "<fix major=\"5\" minor=\"0\">";
-        data += "  <header>";
-        data += "    <field name=\"BeginString\" required=\"Y\"/>";
-        data += "  </header>";
-        data += "  <trailer>";
-        data += "    <field name=\"CheckSum\" required=\"Y\"/>";
-        data += "  </trailer>";
-        data += "  <fields>";
-        data += "    <field number=\"1\" name=\"Account\" type=\"STRING\"/>";
-        data += "    <field number=\"8\" name=\"BeginString\" type=\"STRING\"/>";
-        data += "    <field number=\"10\" name=\"CheckSum\" type=\"STRING\"/>";
-        data += "  </fields>";
-        data += "  <messages>";
-        data += "    <message name=\"MessageWithNoChildren\" msgtype=\"msg\" msgcat=\"custom\">";
-        data += "    </message>";
-        data += "  </messages>";
-        data += "</fix>";
-
-        expectedException.expect(ConfigError.class);
-        expectedException.expectMessage("No fields found: msgType=msg");
 
         new DataDictionary(new ByteArrayInputStream(data.getBytes()));
     }

--- a/quickfixj-base/src/test/java/quickfix/DataDictionaryTest.java
+++ b/quickfixj-base/src/test/java/quickfix/DataDictionaryTest.java
@@ -275,7 +275,7 @@ public class DataDictionaryTest {
         data += "</fix>";
 
         expectedException.expect(ConfigError.class);
-        expectedException.expectMessage("No fields found: msgType=HEADER");
+        expectedException.expectMessage("No fields found in HEADER");
 
         new DataDictionary(new ByteArrayInputStream(data.getBytes()));
     }
@@ -302,7 +302,7 @@ public class DataDictionaryTest {
         data += "</fix>";
 
         expectedException.expect(ConfigError.class);
-        expectedException.expectMessage("No fields found: msgType=HEADER");
+        expectedException.expectMessage("No fields found in HEADER");
 
         new DataDictionary(new ByteArrayInputStream(data.getBytes()));
     }
@@ -328,7 +328,7 @@ public class DataDictionaryTest {
         data += "</fix>";
 
         expectedException.expect(ConfigError.class);
-        expectedException.expectMessage("No fields found: msgType=TRAILER");
+        expectedException.expectMessage("No fields found in TRAILER");
 
         new DataDictionary(new ByteArrayInputStream(data.getBytes()));
     }
@@ -355,7 +355,7 @@ public class DataDictionaryTest {
         data += "</fix>";
 
         expectedException.expect(ConfigError.class);
-        expectedException.expectMessage("No fields found: msgType=TRAILER");
+        expectedException.expectMessage("No fields found in TRAILER");
 
         new DataDictionary(new ByteArrayInputStream(data.getBytes()));
     }


### PR DESCRIPTION
Fixes #636 

There is no reason why a message shouldn't have only header and trailer, see message type `n`.

![image](https://github.com/quickfix-j/quickfixj/assets/6644028/3bbb3987-dca0-4fa9-8ca6-1434fdd8c463)

https://fiximate.fixtrading.org/legacy/en/FIX.4.4/body_5255110.html


Header and trailer should not allowed to be empty. Unit tests need to be updated.