### PR TITLE
Corrected failing `SessionTest` on Ubuntu runner

### DIFF
--- a/quickfixj-core/src/test/java/quickfix/JdbcLogTest.java
+++ b/quickfixj-core/src/test/java/quickfix/JdbcLogTest.java
@@ -133,7 +133,6 @@ public class JdbcLogTest {
         if (filterHeartbeats) {
             settings.setBool(JdbcSetting.SETTING_JDBC_LOG_HEARTBEATS, false);
         }
-        settings.setString(sessionID, JdbcSetting.SETTING_JDBC_CONNECTION_TEST_QUERY, "SELECT COUNT(1) FROM INFORMATION_SCHEMA.SYSTEM_USERS WHERE 1 = 0;");
         JdbcTestSupport.setHypersonicSettings(settings);
         initializeTableDefinitions(connection);
         logFactory = new JdbcLogFactory(settings);

--- a/quickfixj-core/src/test/java/quickfix/JdbcTestSupport.java
+++ b/quickfixj-core/src/test/java/quickfix/JdbcTestSupport.java
@@ -43,6 +43,8 @@ public class JdbcTestSupport {
         settings.setString(JdbcSetting.SETTING_JDBC_CONNECTION_URL, HSQL_CONNECTION_URL);
         settings.setString(JdbcSetting.SETTING_JDBC_USER, HSQL_USER);
         settings.setString(JdbcSetting.SETTING_JDBC_PASSWORD, "");
+        // HSQL doesn't support JDBC4 which means that test query has to be supplied to HikariCP
+        settings.setString(JdbcSetting.SETTING_JDBC_CONNECTION_TEST_QUERY, "SELECT COUNT(1) FROM INFORMATION_SCHEMA.SYSTEM_USERS WHERE 1 = 0;");
     }
 
     public static Connection getConnection() throws ClassNotFoundException, SQLException {


### PR DESCRIPTION
... due to `AbstractMethodError`

 - java.lang.AbstractMethodError: org.hsqldb.jdbc.jdbcConnection.isValid(I)Z
 - moved definition of connection test query to common method for unit tests

Don't know why this only failed on Ubuntu, though.

```
Error:    SessionTest.testSessionRegisteredCorrectly:1849 » AbstractMethod Receiver class org.hsqldb.jdbc.jdbcConnection does not define or inherit an implementation of the resolved method 'abstract boolean isValid(int)' of interface java.sql.Connection.
```