### PR TITLE
update removeSection method to remove sections with the same property key and value

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/SessionSettings.java
+++ b/quickfixj-core/src/main/java/quickfix/SessionSettings.java
@@ -887,12 +887,13 @@ public class SessionSettings {
     }
 
     public void removeSection(final String propertyKey, final String propertyValue) throws ConfigError {
-        SessionID sessionIdToRemove = sections.entrySet().stream()
+        List<SessionID> sessionIDs = sections.entrySet().stream()
                 .filter(entry -> propertyValue.equals(entry.getValue().get(propertyKey)))
                 .map(Map.Entry::getKey)
-                .findFirst()
-                .orElseThrow(() -> new ConfigError("Session not found"));
+                .collect(Collectors.toList());
 
-        sections.remove(sessionIdToRemove);
+        for (SessionID sessionID : sessionIDs) {
+            this.removeSection(sessionID);
+        }
     }
 }


### PR DESCRIPTION
## Purpose

I overlooked the fact that there were several sections with the same property key and value. 

Therefore, I've updated the removeSection method to handle multiple sections.