### PR TITLE
Correct NullPointerException on `UseDataDictionary=N` and FIXT session

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -2163,7 +2163,6 @@ public class Session implements Closeable {
             throw new RejectLogon("Logon attempt not within session time");
         }
 
-        // UseDataDictionary=N   dataDictionaryProvider is null
         if (sessionID.isFIXT() && dataDictionaryProvider != null) {
             final DataDictionary dictionary = dataDictionaryProvider
                     .getSessionDataDictionary(sessionID.getBeginString());

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -2163,7 +2163,8 @@ public class Session implements Closeable {
             throw new RejectLogon("Logon attempt not within session time");
         }
 
-        if (sessionID.isFIXT()) {
+        // UseDataDictionary=N   dataDictionaryProvider is null
+        if (sessionID.isFIXT() && dataDictionaryProvider != null) {
             final DataDictionary dictionary = dataDictionaryProvider
                     .getSessionDataDictionary(sessionID.getBeginString());
             if (dictionary != null) {


### PR DESCRIPTION
UseDataDictionary=N , dataDictionaryProvider is null
Fixes #776 