### PR TITLE
Use MacOS 13 for now for Java CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-13]
         java: [8, 11, 17]
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
Fixes #804 