### PR TITLE
Add Character.class java type for FieldType.CHAR

### DIFF
--- a/quickfixj-base/src/main/java/quickfix/FieldType.java
+++ b/quickfixj-base/src/main/java/quickfix/FieldType.java
@@ -30,7 +30,7 @@ public enum FieldType {
 
     UNKNOWN,
     STRING,
-    CHAR,
+    CHAR(Character.class),
     PRICE(Double.class),
     INT(Integer.class),
     AMT(Double.class),


### PR DESCRIPTION
While parsing a rawstring back to a quickfix.Message object, CHAR fields are created as StringField because it String.java is the default javaType.

All other primitive types have their wrapper classes defined except CHAR.