### PR TITLE
extra logging first draft

### DIFF
--- a/quickfixj-base/src/main/java/quickfix/ValidationSettings.java
+++ b/quickfixj-base/src/main/java/quickfix/ValidationSettings.java
@@ -25,6 +25,7 @@ public class ValidationSettings {
     boolean checkUserDefinedFields = true;
     boolean checkUnorderedGroupFields = true;
     boolean allowUnknownMessageFields = false;
+    boolean fieldValidationLogging = false;
 
     public ValidationSettings() {}
 
@@ -34,6 +35,7 @@ public class ValidationSettings {
         this.checkUserDefinedFields = validationSettings.checkUserDefinedFields;
         this.checkUnorderedGroupFields = validationSettings.checkUnorderedGroupFields;
         this.allowUnknownMessageFields = validationSettings.allowUnknownMessageFields;
+        this.fieldValidationLogging = validationSettings.fieldValidationLogging;
     }
 
     /**
@@ -65,6 +67,10 @@ public class ValidationSettings {
         return allowUnknownMessageFields;
     }
 
+    public boolean isFieldValidationLogging() {
+        return fieldValidationLogging;
+    }
+
     /**
      * Controls whether group fields are in the same order
      *
@@ -94,5 +100,9 @@ public class ValidationSettings {
 
     public void setAllowUnknownMessageFields(boolean allowUnknownFields) {
         allowUnknownMessageFields = allowUnknownFields;
+    }
+
+    public void setFieldValidationLogging(boolean fieldValidation) {
+        fieldValidationLogging = fieldValidation;
     }
 }

--- a/quickfixj-base/src/test/java/quickfix/ValidationSettingsTest.java
+++ b/quickfixj-base/src/test/java/quickfix/ValidationSettingsTest.java
@@ -14,6 +14,7 @@ public class ValidationSettingsTest {
         validationSettings.setCheckFieldsOutOfOrder(false);
         validationSettings.setCheckUnorderedGroupFields(false);
         validationSettings.setCheckUserDefinedFields(false);
+        validationSettings.setFieldValidationLogging(true);
 
         ValidationSettings validationSettingsCopy = new ValidationSettings(validationSettings);
 
@@ -22,5 +23,6 @@ public class ValidationSettingsTest {
         assertEquals(validationSettingsCopy.isCheckFieldsOutOfOrder(), validationSettings.isCheckFieldsOutOfOrder());
         assertEquals(validationSettingsCopy.isCheckUnorderedGroupFields(), validationSettings.isCheckUnorderedGroupFields());
         assertEquals(validationSettingsCopy.isCheckUserDefinedFields(), validationSettings.isCheckUserDefinedFields());
+        assertEquals(validationSettingsCopy.isFieldValidationLogging(), validationSettings.isFieldValidationLogging());
     }
 }

--- a/quickfixj-core/src/main/java/quickfix/DefaultSessionFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/DefaultSessionFactory.java
@@ -314,6 +314,11 @@ public class DefaultSessionFactory implements SessionFactory {
                     Session.SETTING_ALLOW_UNKNOWN_MSG_FIELDS));
         }
 
+        if (settings.isSetting(sessionID, Session.SETTING_FIELD_VALIDATION_LOGGING)) {
+            validationSettings.setFieldValidationLogging(settings.getBool(sessionID,
+                    Session.SETTING_FIELD_VALIDATION_LOGGING));
+        }
+
         return validationSettings;
     }
 

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -323,6 +323,8 @@ public class Session implements Closeable {
      */
     public static final String SETTING_ALLOW_UNKNOWN_MSG_FIELDS = "AllowUnknownMsgFields";
 
+    public static final String SETTING_FIELD_VALIDATION_LOGGING = "FieldValidationLogging";
+
     public static final String SETTING_DEFAULT_APPL_VER_ID = "DefaultApplVerID";
 
     /**

--- a/quickfixj-core/src/test/java/quickfix/DefaultSessionFactoryTest.java
+++ b/quickfixj-core/src/test/java/quickfix/DefaultSessionFactoryTest.java
@@ -100,6 +100,7 @@ public class DefaultSessionFactoryTest {
         settings.setString(sessionID, Session.SETTING_APP_DATA_DICTIONARY + "." + FixVersions.BEGINSTRING_FIX40, "FIX40.xml");
         settings.setString(sessionID, Session.SETTING_ALLOW_UNKNOWN_MSG_FIELDS, "Y");
         settings.setString(sessionID, Session.SETTING_VALIDATE_UNORDERED_GROUP_FIELDS, "N");
+        settings.setString(sessionID, Session.SETTING_FIELD_VALIDATION_LOGGING, "Y");
 
         try (Session session = factory.create(sessionID, settings)) {
 
@@ -113,6 +114,7 @@ public class DefaultSessionFactoryTest {
                     is(notNullValue()));
             assertTrue(session.getValidationSettings().isAllowUnknownMessageFields());
             assertFalse(session.getValidationSettings().isCheckUnorderedGroupFields());
+            assertTrue(session.getValidationSettings().isFieldValidationLogging());
         }
     }
 
@@ -142,6 +144,7 @@ public class DefaultSessionFactoryTest {
                     is(notNullValue()));
             assertTrue(session.getValidationSettings().isAllowUnknownMessageFields());
             assertFalse(session.getValidationSettings().isCheckUnorderedGroupFields());
+            assertFalse(session.getValidationSettings().isFieldValidationLogging());
         }
     }
 


### PR DESCRIPTION
Fixes #824 
Added new configuration setting FieldValidationLogging. 
When it is Y, then prints log messages instead of failing validation for unknown user defined fields, unknown fields and unknown enum values. 