### PR TITLE
Populate Text(58) field when rejectMessageOnUnhandledException=true

### DIFF
--- a/quickfixj-core/src/test/java/quickfix/SessionTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionTest.java
@@ -1771,7 +1771,7 @@ public class SessionTest {
                     throws FieldNotFound, IncorrectDataFormat,
                     IncorrectTagValue, UnsupportedMessageType {
                 super.fromApp(message, sessionId);
-                throw new Error("TEST");
+                throw new Error("TESTApp");
             }
         };
 
@@ -1788,6 +1788,8 @@ public class SessionTest {
                         .getHeader().getString(MsgType.FIELD));
                 assertEquals(MsgType.BUSINESS_MESSAGE_REJECT, application
                         .lastToAppMessage().getHeader().getString(MsgType.FIELD));
+                assertEquals("TESTApp", application.lastToAppMessage()
+                        .getString(Text.FIELD));
                 
                 session.next(createHeartbeatMessage(3));
                 assertEquals(4, session.getExpectedTargetNum());
@@ -1796,6 +1798,8 @@ public class SessionTest {
                         .getHeader().getString(MsgType.FIELD));
                 assertEquals(MsgType.REJECT, application.lastToAdminMessage()
                         .getHeader().getString(MsgType.FIELD));
+                assertEquals("TESTAdmin", application.lastToAdminMessage()
+                        .getString(Text.FIELD));
                 
                 session.next(createAdminMessage(4));
                 assertEquals(5, session.getExpectedTargetNum());
@@ -1805,6 +1809,8 @@ public class SessionTest {
                         .getString(MsgType.FIELD));
                 assertEquals(MsgType.HEARTBEAT, application.lastToAdminMessage()
                         .getHeader().getString(MsgType.FIELD));
+                assertFalse(application.lastToAdminMessage()
+                        .isSetField(Text.FIELD));
             } catch (final Throwable t) {
                 fail("Error was thrown: " + t.getMessage());
             }


### PR DESCRIPTION
refs #639 
closes #667 

If rejectMessageOnUnhandledException=true and an unhandled exception is thrown from the fromCallback(), include the exception message in the Text(58) field of the resulting Reject or BusinessMessageReject.