### PR TITLE
gitignore vim `.swp` files and `maven-wrapper jar`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # ignore maven build directories
 target/
+# ignore maven wrapper jar that gets built locally
+.mvn/wrapper/maven-wrapper.jar
 # ignore Eclipse configuration files
 .project
 .classpath
@@ -12,3 +14,5 @@ target/
 # ignore NetBeans configuration
 nb-configuration.xml
 *.bak
+# ignore vim swap files
+*.swp


### PR DESCRIPTION
I'm barely proficient with maven, but I'm pretty sure `.mvn/wrapper/maven-wrapper.jar` should be ignored.

And also vim `.swp` files.  (I can't be the only vim user in QF land, can I?)
