### PR TITLE
Remove sleepycat je

### DIFF
--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -133,12 +133,6 @@
 			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.sleepycat</groupId>
-			<artifactId>je</artifactId>
-			<version>18.3.12</version>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 		  <groupId>com.zaxxer</groupId>
 		  <artifactId>HikariCP</artifactId>
 		  <version>4.0.3</version>


### PR DESCRIPTION
No release of Sleepycat JE since 2018 so probably unmaintained.

From a vulnerability management perspective I'd rather storage engines were separate plugins than part of core.