### PR TITLE
Backport build changes from master to the 2.3.x branch

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,28 +1,58 @@
 name: Java CI
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
     types: [reopened, opened, synchronize]
+  schedule:
+    - cron:  '30 5 * * *'
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macOS-latest, windows-2016]
-        java: [8, 11, 15]
+        os: [ubuntu-latest, macOS-13]
+        java: [8, 11, 17]
       fail-fast: false
       max-parallel: 4
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          cache: 'maven'
       - name: Test with Maven
-        env:
-          MAVEN_OPTS: "-Xms3g -Xmx3g"
-        run: mvn test -B -V -D"java.util.logging.config.file"="logging.properties" -D"http.keepAlive"="false" -D"maven.wagon.http.pool"="false" -D"maven.wagon.httpconnectionManager.ttlSeconds"="120"
+        run: ./mvnw install -B -V -D"maven.javadoc.skip"="true" -P"skipBundlePlugin,minimal-fix-latest" -D"java.util.logging.config.file"="./quickfixj-core/src/test/resources/logging.properties" -D"http.keepAlive"="false" -D"maven.wagon.http.pool"="false" -D"maven.wagon.httpconnectionManager.ttlSeconds"="120"
+
+  test-windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+        java: [8, 11, 17]
+      fail-fast: false
+      max-parallel: 3
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure pagefile
+        uses: al-cheb/configure-pagefile-action@v1.4
+        with:
+          minimum-size: 8GB
+          maximum-size: 16GB
+          disk-root: "C:"
+      - name: Set up Windows JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+      - name: Test with Maven on Windows
+        run: ./mvnw.cmd install -B -V  -D"maven.javadoc.skip"="true" -P"skipBundlePlugin,minimal-fix-latest" -D"java.util.logging.config.file"="./quickfixj-core/src/test/resources/logging.properties"  -D"http.keepAlive"="false" -D"maven.wagon.http.pool"="false" -D"maven.wagon.httpconnectionManager.ttlSeconds"="120"

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Xms3g -Xmx6g -Djdk.xml.xpathExprGrpLimit=500 -Djdk.xml.xpathExprOpLimit=500

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# NOTE: maven version should also be changed in pom.xml
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,308 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.2.0
+#
+# Required ENV vars:
+# ------------------
+#   JAVA_HOME - location of a JDK home dir
+#
+# Optional ENV vars
+# -----------------
+#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
+#     e.g. to debug Maven itself, use
+#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+# ----------------------------------------------------------------------------
+
+if [ -z "$MAVEN_SKIP_RC" ] ; then
+
+  if [ -f /usr/local/etc/mavenrc ] ; then
+    . /usr/local/etc/mavenrc
+  fi
+
+  if [ -f /etc/mavenrc ] ; then
+    . /etc/mavenrc
+  fi
+
+  if [ -f "$HOME/.mavenrc" ] ; then
+    . "$HOME/.mavenrc"
+  fi
+
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+mingw=false
+case "$(uname)" in
+  CYGWIN*) cygwin=true ;;
+  MINGW*) mingw=true;;
+  Darwin*) darwin=true
+    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+    if [ -z "$JAVA_HOME" ]; then
+      if [ -x "/usr/libexec/java_home" ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"; export JAVA_HOME
+      else
+        JAVA_HOME="/Library/Java/Home"; export JAVA_HOME
+      fi
+    fi
+    ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=$(java-config --jre-home)
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
+fi
+
+# For Mingw, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$JAVA_HOME" ] && [ -d "$JAVA_HOME" ] &&
+    JAVA_HOME="$(cd "$JAVA_HOME" || (echo "cannot cd into $JAVA_HOME."; exit 1); pwd)"
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  javaExecutable="$(which javac)"
+  if [ -n "$javaExecutable" ] && ! [ "$(expr "\"$javaExecutable\"" : '\([^ ]*\)')" = "no" ]; then
+    # readlink(1) is not available as standard on Solaris 10.
+    readLink=$(which readlink)
+    if [ ! "$(expr "$readLink" : '\([^ ]*\)')" = "no" ]; then
+      if $darwin ; then
+        javaHome="$(dirname "\"$javaExecutable\"")"
+        javaExecutable="$(cd "\"$javaHome\"" && pwd -P)/javac"
+      else
+        javaExecutable="$(readlink -f "\"$javaExecutable\"")"
+      fi
+      javaHome="$(dirname "\"$javaExecutable\"")"
+      javaHome=$(expr "$javaHome" : '\(.*\)/bin')
+      JAVA_HOME="$javaHome"
+      export JAVA_HOME
+    fi
+  fi
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="$(\unset -f command 2>/dev/null; \command -v java)"
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute $JAVACMD" >&2
+  exit 1
+fi
+
+if [ -z "$JAVA_HOME" ] ; then
+  echo "Warning: JAVA_HOME environment variable is not set."
+fi
+
+# traverses directory structure from process work directory to filesystem root
+# first directory with .mvn subdirectory is considered project base directory
+find_maven_basedir() {
+  if [ -z "$1" ]
+  then
+    echo "Path not specified to find_maven_basedir"
+    return 1
+  fi
+
+  basedir="$1"
+  wdir="$1"
+  while [ "$wdir" != '/' ] ; do
+    if [ -d "$wdir"/.mvn ] ; then
+      basedir=$wdir
+      break
+    fi
+    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+    if [ -d "${wdir}" ]; then
+      wdir=$(cd "$wdir/.." || exit 1; pwd)
+    fi
+    # end of workaround
+  done
+  printf '%s' "$(cd "$basedir" || exit 1; pwd)"
+}
+
+# concatenates all lines of a file
+concat_lines() {
+  if [ -f "$1" ]; then
+    # Remove \r in case we run on Windows within Git Bash
+    # and check out the repository with auto CRLF management
+    # enabled. Otherwise, we may read lines that are delimited with
+    # \r\n and produce $'-Xarg\r' rather than -Xarg due to word
+    # splitting rules.
+    tr -s '\r\n' ' ' < "$1"
+  fi
+}
+
+log() {
+  if [ "$MVNW_VERBOSE" = true ]; then
+    printf '%s\n' "$1"
+  fi
+}
+
+BASE_DIR=$(find_maven_basedir "$(dirname "$0")")
+if [ -z "$BASE_DIR" ]; then
+  exit 1;
+fi
+
+MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}; export MAVEN_PROJECTBASEDIR
+log "$MAVEN_PROJECTBASEDIR"
+
+##########################################################################################
+# Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+# This allows using the maven wrapper in projects that prohibit checking in binary data.
+##########################################################################################
+wrapperJarPath="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar"
+if [ -r "$wrapperJarPath" ]; then
+    log "Found $wrapperJarPath"
+else
+    log "Couldn't find $wrapperJarPath, downloading it ..."
+
+    if [ -n "$MVNW_REPOURL" ]; then
+      wrapperUrl="$MVNW_REPOURL/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    else
+      wrapperUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    fi
+    while IFS="=" read -r key value; do
+      # Remove '\r' from value to allow usage on windows as IFS does not consider '\r' as a separator ( considers space, tab, new line ('\n'), and custom '=' )
+      safeValue=$(echo "$value" | tr -d '\r')
+      case "$key" in (wrapperUrl) wrapperUrl="$safeValue"; break ;;
+      esac
+    done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+    log "Downloading from: $wrapperUrl"
+
+    if $cygwin; then
+      wrapperJarPath=$(cygpath --path --windows "$wrapperJarPath")
+    fi
+
+    if command -v wget > /dev/null; then
+        log "Found wget ... using wget"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--quiet"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            wget $QUIET "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        else
+            wget $QUIET --http-user="$MVNW_USERNAME" --http-password="$MVNW_PASSWORD" "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        fi
+    elif command -v curl > /dev/null; then
+        log "Found curl ... using curl"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--silent"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            curl $QUIET -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        else
+            curl $QUIET --user "$MVNW_USERNAME:$MVNW_PASSWORD" -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        fi
+    else
+        log "Falling back to using Java to download"
+        javaSource="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.java"
+        javaClass="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.class"
+        # For Cygwin, switch paths to Windows format before running javac
+        if $cygwin; then
+          javaSource=$(cygpath --path --windows "$javaSource")
+          javaClass=$(cygpath --path --windows "$javaClass")
+        fi
+        if [ -e "$javaSource" ]; then
+            if [ ! -e "$javaClass" ]; then
+                log " - Compiling MavenWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/javac" "$javaSource")
+            fi
+            if [ -e "$javaClass" ]; then
+                log " - Running MavenWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$wrapperUrl" "$wrapperJarPath") || rm -f "$wrapperJarPath"
+            fi
+        fi
+    fi
+fi
+##########################################################################################
+# End of extension
+##########################################################################################
+
+# If specified, validate the SHA-256 sum of the Maven wrapper jar file
+wrapperSha256Sum=""
+while IFS="=" read -r key value; do
+  case "$key" in (wrapperSha256Sum) wrapperSha256Sum=$value; break ;;
+  esac
+done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+if [ -n "$wrapperSha256Sum" ]; then
+  wrapperSha256Result=false
+  if command -v sha256sum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  elif command -v shasum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | shasum -a 256 -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available."
+    echo "Please install either command, or disable validation by removing 'wrapperSha256Sum' from your maven-wrapper.properties."
+    exit 1
+  fi
+  if [ $wrapperSha256Result = false ]; then
+    echo "Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised." >&2
+    echo "Investigate or delete $wrapperJarPath to attempt a clean download." >&2
+    echo "If you updated your Maven version, you need to update the specified wrapperSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --path --windows "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=$(cygpath --path --windows "$CLASSPATH")
+  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
+    MAVEN_PROJECTBASEDIR=$(cygpath --path --windows "$MAVEN_PROJECTBASEDIR")
+fi
+
+# Provide a "standardized" way to retrieve the CLI args that will
+# work with both Windows and non-Windows executions.
+MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $*"
+export MAVEN_CMD_LINE_ARGS
+
+WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+# shellcheck disable=SC2086 # safe args
+exec "$JAVACMD" \
+  $MAVEN_OPTS \
+  $MAVEN_DEBUG_OPTS \
+  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,205 @@
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.2.0
+@REM
+@REM Required ENV vars:
+@REM JAVA_HOME - location of a JDK home dir
+@REM
+@REM Optional ENV vars
+@REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
+@REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
+@REM     e.g. to debug Maven itself, use
+@REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+@REM MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+@REM ----------------------------------------------------------------------------
+
+@REM Begin all REM lines with '@' in case MAVEN_BATCH_ECHO is 'on'
+@echo off
+@REM set title of command window
+title %0
+@REM enable echoing by setting MAVEN_BATCH_ECHO to 'on'
+@if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
+
+@REM set %HOME% to equivalent of $HOME
+if "%HOME%" == "" (set "HOME=%HOMEDRIVE%%HOMEPATH%")
+
+@REM Execute a user defined script before this one
+if not "%MAVEN_SKIP_RC%" == "" goto skipRcPre
+@REM check for pre script, once with legacy .bat ending and once with .cmd ending
+if exist "%USERPROFILE%\mavenrc_pre.bat" call "%USERPROFILE%\mavenrc_pre.bat" %*
+if exist "%USERPROFILE%\mavenrc_pre.cmd" call "%USERPROFILE%\mavenrc_pre.cmd" %*
+:skipRcPre
+
+@setlocal
+
+set ERROR_CODE=0
+
+@REM To isolate internal variables from possible post scripts, we use another setlocal
+@setlocal
+
+@REM ==== START VALIDATION ====
+if not "%JAVA_HOME%" == "" goto OkJHome
+
+echo.
+echo Error: JAVA_HOME not found in your environment. >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+:OkJHome
+if exist "%JAVA_HOME%\bin\java.exe" goto init
+
+echo.
+echo Error: JAVA_HOME is set to an invalid directory. >&2
+echo JAVA_HOME = "%JAVA_HOME%" >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+@REM ==== END VALIDATION ====
+
+:init
+
+@REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
+@REM Fallback to current working directory if not found.
+
+set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
+IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
+
+set EXEC_DIR=%CD%
+set WDIR=%EXEC_DIR%
+:findBaseDir
+IF EXIST "%WDIR%"\.mvn goto baseDirFound
+cd ..
+IF "%WDIR%"=="%CD%" goto baseDirNotFound
+set WDIR=%CD%
+goto findBaseDir
+
+:baseDirFound
+set MAVEN_PROJECTBASEDIR=%WDIR%
+cd "%EXEC_DIR%"
+goto endDetectBaseDir
+
+:baseDirNotFound
+set MAVEN_PROJECTBASEDIR=%EXEC_DIR%
+cd "%EXEC_DIR%"
+
+:endDetectBaseDir
+
+IF NOT EXIST "%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config" goto endReadAdditionalConfig
+
+@setlocal EnableExtensions EnableDelayedExpansion
+for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do set JVM_CONFIG_MAVEN_PROPS=!JVM_CONFIG_MAVEN_PROPS! %%a
+@endlocal & set JVM_CONFIG_MAVEN_PROPS=%JVM_CONFIG_MAVEN_PROPS%
+
+:endReadAdditionalConfig
+
+SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
+set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
+set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+set WRAPPER_URL="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperUrl" SET WRAPPER_URL=%%B
+)
+
+@REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+@REM This allows using the maven wrapper in projects that prohibit checking in binary data.
+if exist %WRAPPER_JAR% (
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Found %WRAPPER_JAR%
+    )
+) else (
+    if not "%MVNW_REPOURL%" == "" (
+        SET WRAPPER_URL="%MVNW_REPOURL%/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    )
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Couldn't find %WRAPPER_JAR%, downloading it ...
+        echo Downloading from: %WRAPPER_URL%
+    )
+
+    powershell -Command "&{"^
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+		"}"^
+		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%WRAPPER_URL%', '%WRAPPER_JAR%')"^
+		"}"
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Finished downloading %WRAPPER_JAR%
+    )
+)
+@REM End of extension
+
+@REM If specified, validate the SHA-256 sum of the Maven wrapper jar file
+SET WRAPPER_SHA_256_SUM=""
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperSha256Sum" SET WRAPPER_SHA_256_SUM=%%B
+)
+IF NOT %WRAPPER_SHA_256_SUM%=="" (
+    powershell -Command "&{"^
+       "$hash = (Get-FileHash \"%WRAPPER_JAR%\" -Algorithm SHA256).Hash.ToLower();"^
+       "If('%WRAPPER_SHA_256_SUM%' -ne $hash){"^
+       "  Write-Output 'Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised.';"^
+       "  Write-Output 'Investigate or delete %WRAPPER_JAR% to attempt a clean download.';"^
+       "  Write-Output 'If you updated your Maven version, you need to update the specified wrapperSha256Sum property.';"^
+       "  exit 1;"^
+       "}"^
+       "}"
+    if ERRORLEVEL 1 goto error
+)
+
+@REM Provide a "standardized" way to retrieve the CLI args that will
+@REM work with both Windows and non-Windows executions.
+set MAVEN_CMD_LINE_ARGS=%*
+
+%MAVEN_JAVA_EXE% ^
+  %JVM_CONFIG_MAVEN_PROPS% ^
+  %MAVEN_OPTS% ^
+  %MAVEN_DEBUG_OPTS% ^
+  -classpath %WRAPPER_JAR% ^
+  "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" ^
+  %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
+if ERRORLEVEL 1 goto error
+goto end
+
+:error
+set ERROR_CODE=1
+
+:end
+@endlocal & set ERROR_CODE=%ERROR_CODE%
+
+if not "%MAVEN_SKIP_RC%"=="" goto skipRcPost
+@REM check for post script, once with legacy .bat ending and once with .cmd ending
+if exist "%USERPROFILE%\mavenrc_post.bat" call "%USERPROFILE%\mavenrc_post.bat"
+if exist "%USERPROFILE%\mavenrc_post.cmd" call "%USERPROFILE%\mavenrc_post.cmd"
+:skipRcPost
+
+@REM pause the script if MAVEN_BATCH_PAUSE is set to 'on'
+if "%MAVEN_BATCH_PAUSE%"=="on" pause
+
+if "%MAVEN_TERMINATE_CMD%"=="on" exit %ERROR_CODE%
+
+cmd /C exit /B %ERROR_CODE%

--- a/quickfixj-codegenerator/pom.xml
+++ b/quickfixj-codegenerator/pom.xml
@@ -61,6 +61,13 @@
 			<plugin>
 				<artifactId>maven-pmd-plugin</artifactId>
 			</plugin>
+                        <plugin>
+                                <artifactId>maven-plugin-plugin</artifactId>
+                                <version>3.11.0</version>
+                                <configuration>
+                                    <goalPrefix>quickfixj-codegenerator</goalPrefix>
+                                </configuration>
+                        </plugin>
 		</plugins>
 	</build>
 </project>

--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -27,8 +27,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>3.12.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -384,29 +384,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>-Xmx512m -Djava.net.preferIPv4Stack=true</argLine>
-                    <trimStackTrace>false</trimStackTrace>
-                    <includes>
-                        <include>**/*Test.java</include>
-                        <include>${acceptance.tests}</include>
-                    </includes>
-                    <excludes>
-                        <exclude>**/*ForTest.java</exclude>
-                        <exclude>**/Abstract*Test.java</exclude>
-                        <exclude>**/AcceptanceTestSuite$*</exclude>
-                    </excludes>
-                    <systemPropertyVariables>
-                        <atest.heartbeat>5</atest.heartbeat>
-                        <atest.timeout>60000</atest.timeout>
-                        <atest.reconnectDelay>5</atest.reconnectDelay>
-                        <atest.skipslow>false</atest.skipslow>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
         </plugins>
 
 	<extensions>
@@ -450,6 +427,79 @@
                 <acceptance.tests />
             </properties>
         </profile>
+        <!-- select different java options on JDK8 for surefire since otherwise the build will fail -->
+        <profile>
+            <id>surefire-java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>
+                                -Xmx512m -Djava.net.preferIPv4Stack=true
+                            </argLine>
+                            <trimStackTrace>false</trimStackTrace>
+                            <includes>
+                                <include>**/*Test.java</include>
+                                <include>${acceptance.tests}</include>
+                            </includes>
+                            <excludes>
+                                <exclude>**/*ForTest.java</exclude>
+                                <exclude>**/Abstract*Test.java</exclude>
+                                <exclude>**/AcceptanceTestSuite$*</exclude>
+                            </excludes>
+                            <systemPropertyVariables>
+                                <atest.heartbeat>5</atest.heartbeat>
+                                <atest.timeout>60000</atest.timeout>
+                                <atest.reconnectDelay>5</atest.reconnectDelay>
+                                <atest.skipslow>false</atest.skipslow>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile> 
+        <!-- surefire for JDK9 and upwards -->
+        <profile>
+            <id>surefire</id>
+            <activation>
+                <jdk>[1.9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>
+                                -Xmx512m -Djava.net.preferIPv4Stack=true
+                                --add-opens java.base/java.lang=ALL-UNNAMED
+                            </argLine>
+                            <trimStackTrace>false</trimStackTrace>
+                            <includes>
+                                <include>**/*Test.java</include>
+                                <include>${acceptance.tests}</include>
+                            </includes>
+                            <excludes>
+                                <exclude>**/*ForTest.java</exclude>
+                                <exclude>**/Abstract*Test.java</exclude>
+                                <exclude>**/AcceptanceTestSuite$*</exclude>
+                            </excludes>
+                            <systemPropertyVariables>
+                                <atest.heartbeat>5</atest.heartbeat>
+                                <atest.timeout>60000</atest.timeout>
+                                <atest.reconnectDelay>5</atest.reconnectDelay>
+                                <atest.skipslow>false</atest.skipslow>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile> 
     </profiles>
 </project>
 

--- a/quickfixj-core/src/test/java/quickfix/MessageCrackerTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageCrackerTest.java
@@ -22,12 +22,9 @@ package quickfix;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.stub;
 
 import java.io.InvalidObjectException;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import quickfix.MessageCracker.RedundantHandlerException;
@@ -41,14 +38,6 @@ import quickfix.field.TargetCompID;
 
 public class MessageCrackerTest {
     private int messageCracked;
-    private Session mockSession;
-
-    @Before
-    public void setUp() throws Exception {
-        mockSession = mock(Session.class);
-        stub(mockSession.getTargetDefaultApplicationVersionID()).toReturn(
-                new ApplVerID(ApplVerID.FIX50SP2));
-    }
 
     @Test(expected=UnsupportedMessageType.class)
     public void testInvokerException1() throws Exception {
@@ -241,8 +230,6 @@ public class MessageCrackerTest {
     @Test
     public void testFixtMessageCrackingWithSessionDefaultApplVerID() throws Exception {
         quickfix.fix44.Email message = createFix44Email();
-        stub(mockSession.getTargetDefaultApplicationVersionID()).toReturn(
-                new ApplVerID(ApplVerID.FIX44));
 
         MessageCracker cracker = new MessageCracker() {
             @SuppressWarnings("unused")

--- a/quickfixj-core/src/test/java/quickfix/MessageUtilsTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageUtilsTest.java
@@ -19,7 +19,6 @@
 
 package quickfix;
 
-import junit.framework.TestCase;
 import quickfix.field.ApplVerID;
 import quickfix.field.BeginString;
 import quickfix.field.DefaultApplVerID;
@@ -36,14 +35,18 @@ import quickfix.fix50.Email;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import org.junit.Test;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.stub;
 import static org.mockito.Mockito.when;
 
-public class MessageUtilsTest extends TestCase {
+public class MessageUtilsTest {
 
+    @Test
     public void testGetStringField() throws Exception {
         String messageString = "8=FIX.4.2\0019=12\00135=X\001108=30\00110=049\001";
         assertEquals("wrong value", "FIX.4.2", MessageUtils.getStringField(messageString,
@@ -52,6 +55,7 @@ public class MessageUtilsTest extends TestCase {
         assertNull(messageString, MessageUtils.getStringField(messageString, SenderCompID.FIELD));
     }
 
+    @Test
     public void testSessionIdFromMessage() throws Exception {
         Message message = new Logon();
         message.getHeader().setString(SenderCompID.FIELD, "TW");
@@ -62,6 +66,7 @@ public class MessageUtilsTest extends TestCase {
         assertEquals("ISLD", sessionID.getTargetCompID());
     }
 
+    @Test
     public void testReverseSessionIdFromMessage() throws Exception {
         Message message = new Logon();
         message.getHeader().setString(SenderCompID.FIELD, "TW");
@@ -72,6 +77,7 @@ public class MessageUtilsTest extends TestCase {
         assertEquals("TW", sessionID.getTargetCompID());
     }
 
+    @Test
     public void testReverseSessionIdFromMessageWithMissingFields() throws Exception {
         Message message = new Logon();
         SessionID sessionID = MessageUtils.getReverseSessionID(message);
@@ -80,6 +86,7 @@ public class MessageUtilsTest extends TestCase {
         assertEquals(sessionID.getTargetCompID(), SessionID.NOT_SET);
     }
 
+    @Test
     public void testSessionIdFromRawMessage() throws Exception {
         String messageString = "8=FIX.4.0\0019=56\00135=A\00134=1\00149=TW\001" +
             "52=20060118-16:34:19\00156=ISLD\00198=0\001108=2\00110=223\001";
@@ -89,6 +96,7 @@ public class MessageUtilsTest extends TestCase {
         assertEquals("ISLD", sessionID.getTargetCompID());
     }
 
+    @Test
     public void testReverseSessionIdFromRawMessage() throws Exception {
         String messageString = "8=FIX.4.0\0019=56\00135=A\00134=1\00149=TW\00150=TWS\001" +
             "142=TWL\00152=20060118-16:34:19\00156=ISLD\00198=0\001108=2\00110=223\001";
@@ -100,12 +108,14 @@ public class MessageUtilsTest extends TestCase {
         assertEquals("TWL", sessionID.getTargetLocationID());
     }
 
+    @Test
     public void testMessageType() throws Exception {
         String messageString = "8=FIX.4.0\0019=56\00135=A\00134=1\00149=TW\001" +
             "52=20060118-16:34:19\00156=ISLD\00198=0\001108=2\00110=223\001";
         assertEquals("A", MessageUtils.getMessageType(messageString));
     }
 
+    @Test
     public void testMessageTypeError() throws Exception {
         String messageString = "8=FIX.4.0\0019=56\00134=1\00149=TW\001" +
             "52=20060118-16:34:19\00156=ISLD\00198=0\001108=2\00110=223\001";
@@ -117,6 +127,7 @@ public class MessageUtilsTest extends TestCase {
         }
     }
 
+    @Test
     public void testMessageTypeError2() throws Exception {
         String messageString = "8=FIX.4.0\0019=56\00135=1";
         try {
@@ -127,23 +138,26 @@ public class MessageUtilsTest extends TestCase {
         }
     }
 
+    @Test
     public void testGetNonexistentStringField() throws Exception {
         String messageString = "8=FIX.4.0\0019=56\00134=1\00149=TW\001" +
             "52=20060118-16:34:19\00156=ISLD\00198=0\001108=2\00110=223\001";
         assertNull(MessageUtils.getStringField(messageString, 35));
     }
 
+    @Test
     public void testGetStringFieldWithBadValue() throws Exception {
         String messageString = "8=FIX.4.0\0019=56\00134=1\00149=TW\001" +
             "52=20060118-16:34:19\00156=ISLD\00198=0\001108=2\00110=223";
         assertNull(MessageUtils.getStringField(messageString, 10));
     }
 
+    @Test
     public void testParse() throws Exception {
         Session mockSession = mock(Session.class);
         DataDictionaryProvider mockDataDictionaryProvider = mock(DataDictionaryProvider.class);
-        stub(mockSession.getDataDictionaryProvider()).toReturn(mockDataDictionaryProvider);
-        stub(mockSession.getMessageFactory()).toReturn(new quickfix.fix40.MessageFactory());
+        when(mockSession.getDataDictionaryProvider()).thenReturn(mockDataDictionaryProvider);
+        when(mockSession.getMessageFactory()).thenReturn(new quickfix.fix40.MessageFactory());
         String messageString = "8=FIX.4.0\0019=56\00135=A\00134=1\00149=TW\001" +
             "52=20060118-16:34:19\00156=ISLD\00198=0\001108=2\00110=223\001";
 
@@ -152,6 +166,7 @@ public class MessageUtilsTest extends TestCase {
         assertThat(message, is(notNullValue()));
     }
 
+    @Test
     public void testLegacyParse() throws Exception {
         String data = "8=FIX.4.4\0019=309\00135=8\00149=ASX\00156=CL1_FIX44\00134=4\001" +
             "52=20060324-01:05:58\00117=X-B-WOW-1494E9A0:58BD3F9D-1109\001150=D\001" +
@@ -164,11 +179,12 @@ public class MessageUtilsTest extends TestCase {
         assertThat(message, is(notNullValue()));
     }
 
+    @Test
     public void testParseFixt() throws Exception {
         Session mockSession = mock(Session.class);
         DataDictionaryProvider mockDataDictionaryProvider = mock(DataDictionaryProvider.class);
-        stub(mockSession.getDataDictionaryProvider()).toReturn(mockDataDictionaryProvider);
-        stub(mockSession.getMessageFactory()).toReturn(new quickfix.fix40.MessageFactory());
+        when(mockSession.getDataDictionaryProvider()).thenReturn(mockDataDictionaryProvider);
+        when(mockSession.getMessageFactory()).thenReturn(new quickfix.fix40.MessageFactory());
 
         Email email = new Email(new EmailThreadID("THREAD_ID"), new EmailType(EmailType.NEW), new Subject("SUBJECT"));
         email.getHeader().setField(new ApplVerID(ApplVerID.FIX42));
@@ -181,11 +197,12 @@ public class MessageUtilsTest extends TestCase {
         assertThat(message, is(quickfix.fix40.Email.class));
     }
 
+    @Test
     public void testParseFixtLogon() throws Exception {
         Session mockSession = mock(Session.class);
         DataDictionaryProvider mockDataDictionaryProvider = mock(DataDictionaryProvider.class);
-        stub(mockSession.getDataDictionaryProvider()).toReturn(mockDataDictionaryProvider);
-        stub(mockSession.getMessageFactory()).toReturn(new DefaultMessageFactory());
+        when(mockSession.getDataDictionaryProvider()).thenReturn(mockDataDictionaryProvider);
+        when(mockSession.getMessageFactory()).thenReturn(new DefaultMessageFactory());
 
         quickfix.fixt11.Logon logon = new quickfix.fixt11.Logon(new EncryptMethod(EncryptMethod.NONE_OTHER), new HeartBtInt(30),
                 new DefaultApplVerID(ApplVerID.FIX42));
@@ -196,11 +213,12 @@ public class MessageUtilsTest extends TestCase {
         assertThat(message, is(quickfix.fixt11.Logon.class));
     }
 
+    @Test
     public void testParseFixtLogout() throws Exception {
         Session mockSession = mock(Session.class);
         DataDictionaryProvider mockDataDictionaryProvider = mock(DataDictionaryProvider.class);
-        stub(mockSession.getDataDictionaryProvider()).toReturn(mockDataDictionaryProvider);
-        stub(mockSession.getMessageFactory()).toReturn(new DefaultMessageFactory());
+        when(mockSession.getDataDictionaryProvider()).thenReturn(mockDataDictionaryProvider);
+        when(mockSession.getMessageFactory()).thenReturn(new DefaultMessageFactory());
 
         quickfix.fixt11.Logout logout = new quickfix.fixt11.Logout();
 
@@ -210,11 +228,12 @@ public class MessageUtilsTest extends TestCase {
         assertThat(message, is(quickfix.fixt11.Logout.class));
     }
 
+    @Test
     public void testParseFix50() throws Exception {
         Session mockSession = mock(Session.class);
         DataDictionaryProvider mockDataDictionaryProvider = mock(DataDictionaryProvider.class);
-        stub(mockSession.getDataDictionaryProvider()).toReturn(mockDataDictionaryProvider);
-        stub(mockSession.getMessageFactory()).toReturn(new DefaultMessageFactory());
+        when(mockSession.getDataDictionaryProvider()).thenReturn(mockDataDictionaryProvider);
+        when(mockSession.getMessageFactory()).thenReturn(new DefaultMessageFactory());
 
         Email email = new Email(new EmailThreadID("THREAD_ID"), new EmailType(EmailType.NEW), new Subject("SUBJECT"));
         email.getHeader().setField(new ApplVerID(ApplVerID.FIX50));
@@ -228,6 +247,7 @@ public class MessageUtilsTest extends TestCase {
     }
 
     // QFJ-973
+    @Test
     public void testParseMessageWithoutChecksumValidation() throws InvalidMessage {
         Session mockSession = mock(Session.class);
         when(mockSession.isValidateChecksum()).thenReturn(Boolean.FALSE);
@@ -235,8 +255,8 @@ public class MessageUtilsTest extends TestCase {
         DataDictionary dataDictionary = mock(DataDictionary.class);
         DataDictionaryProvider mockDataDictionaryProvider = mock(DataDictionaryProvider.class);
         when(mockDataDictionaryProvider.getSessionDataDictionary(any(String.class))).thenReturn(dataDictionary);
-        stub(mockSession.getDataDictionaryProvider()).toReturn(mockDataDictionaryProvider);
-        stub(mockSession.getMessageFactory()).toReturn(new quickfix.fix40.MessageFactory());
+        when(mockSession.getDataDictionaryProvider()).thenReturn(mockDataDictionaryProvider);
+        when(mockSession.getMessageFactory()).thenReturn(new quickfix.fix40.MessageFactory());
 
         String messageString = "8=FIX.4.0\0019=56\00135=A\00134=1\00149=TW\001" +
                 "52=20060118-16:34:19\00156=ISLD\00198=0\001108=2\00110=283\001";

--- a/quickfixj-core/src/test/java/quickfix/SessionTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionTest.java
@@ -64,7 +64,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.stub;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -91,12 +90,11 @@ public class SessionTest {
 
         final MessageStoreFactory mockMessageStoreFactory = mock(MessageStoreFactory.class);
         final CloseableMessageStore mockMessageStore = mock(CloseableMessageStore.class);
-        stub(mockMessageStoreFactory.create(sessionID)).toReturn(
-                mockMessageStore);
+        when(mockMessageStoreFactory.create(sessionID)).thenReturn(mockMessageStore);
 
         final LogFactory mockLogFactory = mock(LogFactory.class);
         final CloseableLog mockLog = mock(CloseableLog.class);
-        stub(mockLogFactory.create(sessionID)).toReturn(mockLog);
+        when(mockLogFactory.create(sessionID)).thenReturn(mockLog);
 
         try (Session session = new Session(application,
                 mockMessageStoreFactory, sessionID, null, null, mockLogFactory,
@@ -132,12 +130,11 @@ public class SessionTest {
 
         final MessageStoreFactory mockMessageStoreFactory = mock(MessageStoreFactory.class);
         final MessageStore mockMessageStore = mock(MessageStore.class);
-        stub(mockMessageStoreFactory.create(sessionID)).toReturn(
-                mockMessageStore);
+        when(mockMessageStoreFactory.create(sessionID)).thenReturn(mockMessageStore);
 
         final LogFactory mockLogFactory = mock(LogFactory.class);
         final Log mockLog = mock(Log.class);
-        stub(mockLogFactory.create(sessionID)).toReturn(mockLog);
+        when(mockLogFactory.create(sessionID)).thenReturn(mockLog);
 
         try (Session session = new Session(application,
                 mockMessageStoreFactory, sessionID, null, null, mockLogFactory,

--- a/quickfixj-core/src/test/java/quickfix/mina/IoSessionResponderTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/IoSessionResponderTest.java
@@ -19,20 +19,30 @@
 
 package quickfix.mina;
 
-import junit.framework.TestCase;
+import java.net.InetSocketAddress;
 import org.apache.mina.core.future.WriteFuture;
 import org.apache.mina.core.session.IoSession;
 
-import java.net.InetSocketAddress;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
-public class IoSessionResponderTest extends TestCase {
+
+public class IoSessionResponderTest {
+    
+    @Test
     public void testAsynchronousSend() throws Exception {
         IoSession mockIoSession = mock(IoSession.class);
         WriteFuture mockWriteFuture = mock(WriteFuture.class);
-        stub(mockWriteFuture.isWritten()).toReturn(true);
-        stub(mockIoSession.write("abcd")).toReturn(mockWriteFuture);
+        when(mockWriteFuture.isWritten()).thenReturn(true);
+        when(mockIoSession.write("abcd")).thenReturn(mockWriteFuture);
         IoSessionResponder responder = new IoSessionResponder(mockIoSession, false, 0, 0);
 
         boolean result = responder.send("abcd");
@@ -43,12 +53,13 @@ public class IoSessionResponderTest extends TestCase {
         verifyNoMoreInteractions(mockIoSession);
     }
 
+    @Test
     public void testSynchronousSend() throws Exception {
         int timeout = 123;
         IoSession mockIoSession = mock(IoSession.class);
         WriteFuture mockWriteFuture = mock(WriteFuture.class);
-        stub(mockIoSession.write("abcd")).toReturn(mockWriteFuture);
-        stub(mockWriteFuture.awaitUninterruptibly(timeout)).toReturn(true);
+        when(mockIoSession.write("abcd")).thenReturn(mockWriteFuture);
+        when(mockWriteFuture.awaitUninterruptibly(timeout)).thenReturn(true);
         IoSessionResponder responder = new IoSessionResponder(mockIoSession, true, timeout, 0);
 
         boolean result = responder.send("abcd");
@@ -60,12 +71,13 @@ public class IoSessionResponderTest extends TestCase {
         verifyNoMoreInteractions(mockIoSession);
     }
 
+    @Test
     public void testSynchronousSendWithJoinException() throws Exception {
         int timeout = 123;
         IoSession mockIoSession = mock(IoSession.class);
 
         WriteFuture mockWriteFuture = mock(WriteFuture.class);
-        stub(mockIoSession.write("abcd")).toReturn(mockWriteFuture);
+        when(mockIoSession.write("abcd")).thenReturn(mockWriteFuture);
         doThrow(new RuntimeException("TEST")).when(mockWriteFuture).awaitUninterruptibly(timeout);
         IoSessionResponder responder = new IoSessionResponder(mockIoSession, true, timeout, 0);
 
@@ -78,13 +90,14 @@ public class IoSessionResponderTest extends TestCase {
         verifyNoMoreInteractions(mockIoSession);
     }
 
+    @Test
     public void testSynchronousSendWithJoinTimeout() throws Exception {
         int timeout = 123;
         IoSession mockIoSession = mock(IoSession.class);
 
         WriteFuture mockWriteFuture = mock(WriteFuture.class);
-        stub(mockIoSession.write("abcd")).toReturn(mockWriteFuture);
-        stub(mockWriteFuture.awaitUninterruptibly(timeout)).toReturn(false);
+        when(mockIoSession.write("abcd")).thenReturn(mockWriteFuture);
+        when(mockWriteFuture.awaitUninterruptibly(timeout)).thenReturn(false);
         IoSessionResponder responder = new IoSessionResponder(mockIoSession, true, timeout, 0);
 
         boolean result = responder.send("abcd");
@@ -96,10 +109,12 @@ public class IoSessionResponderTest extends TestCase {
         verifyNoMoreInteractions(mockIoSession);
     }
 
+    @Test
     public void testDisconnect() throws Exception {
         IoSession mockProtocolSession = mock(IoSession.class);
-        stub(mockProtocolSession.getScheduledWriteMessages()).toReturn(0);
-        stub(mockProtocolSession.closeNow()).toReturn(null);
+        
+        when(mockProtocolSession.getScheduledWriteMessages()).thenReturn(0);
+        when(mockProtocolSession.closeNow()).thenReturn(null);
 
         IoSessionResponder responder = new IoSessionResponder(mockProtocolSession, false, 0, 0);
         responder.disconnect();
@@ -110,10 +125,10 @@ public class IoSessionResponderTest extends TestCase {
         verifyNoMoreInteractions(mockProtocolSession);
     }
 
+    @Test
     public void testGetRemoteSocketAddress() throws Exception {
         IoSession mockProtocolSession = mock(IoSession.class);
-        stub(mockProtocolSession.getRemoteAddress()).toReturn(
-                new InetSocketAddress("1.2.3.4", 5432));
+        when(mockProtocolSession.getRemoteAddress()).thenReturn(new InetSocketAddress("1.2.3.4", 5432));
 
         IoSessionResponder responder = new IoSessionResponder(mockProtocolSession, false, 0, 0);
 

--- a/quickfixj-core/src/test/java/quickfix/mina/acceptor/AcceptorIoHandlerTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/acceptor/AcceptorIoHandlerTest.java
@@ -57,9 +57,9 @@ import java.util.Properties;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.stub;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class AcceptorIoHandlerTest {
 
@@ -77,7 +77,7 @@ public class AcceptorIoHandlerTest {
                 "TARGET");
         try (Session session = SessionFactoryTestSupport.createSession(sessionID,
                 new UnitTestApplication(), false)) {
-            stub(mockIoSession.getAttribute("QF_SESSION")).toReturn(null); // to create a new Session
+            when(mockIoSession.getAttribute("QF_SESSION")).thenReturn(null);    // to create a new Session
 
             final HashMap<SessionID, Session> acceptorSessions = new HashMap<>();
             acceptorSessions.put(sessionID, session);
@@ -103,7 +103,7 @@ public class AcceptorIoHandlerTest {
     @Test
     public void testMessageBeforeLogon() throws Exception {
         IoSession mockIoSession = mock(IoSession.class);
-        stub(mockIoSession.getAttribute("QF_SESSION")).toReturn(null);
+        when(mockIoSession.getAttribute("QF_SESSION")).thenReturn(null);
 
         EventHandlingStrategy mockEventHandlingStrategy = mock(EventHandlingStrategy.class);
 
@@ -127,7 +127,7 @@ public class AcceptorIoHandlerTest {
         IoSession mockIoSession = mock(IoSession.class);
 
         try (Session qfSession = SessionFactoryTestSupport.createSession()) {
-            stub(mockIoSession.getAttribute("QF_SESSION")).toReturn(qfSession);
+            when(mockIoSession.getAttribute("QF_SESSION")).thenReturn(qfSession);
 
             EventHandlingStrategy mockEventHandlingStrategy = mock(EventHandlingStrategy.class);
 
@@ -153,7 +153,7 @@ public class AcceptorIoHandlerTest {
     public void testMessageBeforeLogonWithKnownButUnboundSession() throws Exception {
         IoSession mockIoSession = mock(IoSession.class);
 
-        stub(mockIoSession.getAttribute("QF_SESSION")).toReturn(null);
+        when(mockIoSession.getAttribute("QF_SESSION")).thenReturn(null);
 
         EventHandlingStrategy mockEventHandlingStrategy = mock(EventHandlingStrategy.class);
 
@@ -190,7 +190,7 @@ public class AcceptorIoHandlerTest {
                 "TARGET");
         try (Session session = SessionFactoryTestSupport.createSession(sessionID,
                 new UnitTestApplication(), false)) {
-            stub(mockIoSession.getAttribute("QF_SESSION")).toReturn(null); // to create a new Session
+            when(mockIoSession.getAttribute("QF_SESSION")).thenReturn(null);    // to create a new Session
 
             final HashMap<SessionID, Session> acceptorSessions = new HashMap<>();
             acceptorSessions.put(sessionID, session);
@@ -228,7 +228,7 @@ public class AcceptorIoHandlerTest {
             session.setRejectGarbledMessage(true);
             eventHandlingStrategy.blockInThread();
             Responder responder = new UnitTestResponder();
-            stub(mockIoSession.getAttribute("QF_SESSION")).toReturn(null); // to create a new Session
+            when(mockIoSession.getAttribute("QF_SESSION")).thenReturn(null);    // to create a new Session
 
             final HashMap<SessionID, Session> acceptorSessions = new HashMap<>();
             acceptorSessions.put(sessionID, session);
@@ -252,7 +252,7 @@ public class AcceptorIoHandlerTest {
 
             assertEquals(2, session.getStore().getNextTargetMsgSeqNum());
             assertEquals(2, session.getStore().getNextSenderMsgSeqNum());
-            stub(mockIoSession.getAttribute("QF_SESSION")).toReturn(session);
+            when(mockIoSession.getAttribute("QF_SESSION")).thenReturn(session);
 
             // garbled: character as group count
             String fixString = "8=FIXT.1.19=6835=B34=249=TARGET52=20180623-22:06:28.97756=SENDER148=foo33=a10=248";
@@ -331,7 +331,7 @@ public class AcceptorIoHandlerTest {
             session.setRejectGarbledMessage(true);
             eventHandlingStrategy.blockInThread();
             Responder responder = new UnitTestResponder();
-            stub(mockIoSession.getAttribute("QF_SESSION")).toReturn(null); // to create a new Session
+            when(mockIoSession.getAttribute("QF_SESSION")).thenReturn(null);    // to create a new Session
 
             final HashMap<SessionID, Session> acceptorSessions = new HashMap<>();
             acceptorSessions.put(sessionID, session);

--- a/quickfixj-core/src/test/java/quickfix/mina/initiator/InitiatorIoHandlerTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/initiator/InitiatorIoHandlerTest.java
@@ -34,7 +34,7 @@ import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.stub;
+import static org.mockito.Mockito.when;
 
 public class InitiatorIoHandlerTest {
 
@@ -57,7 +57,7 @@ public class InitiatorIoHandlerTest {
                         ApplVerID.FIX50SP2))) {
             session.setRejectGarbledMessage(true);
             eventHandlingStrategy.blockInThread();
-            stub(mockIoSession.getAttribute("QF_SESSION")).toReturn(null); // to create a new Session
+            when(mockIoSession.getAttribute("QF_SESSION")).thenReturn(null);    // to create a new Session
 
             final InitiatorIoHandler handler = new InitiatorIoHandler(session,
                     new NetworkingOptions(new Properties()), eventHandlingStrategy);
@@ -77,7 +77,7 @@ public class InitiatorIoHandlerTest {
 
             assertEquals(2, session.getStore().getNextTargetMsgSeqNum());
             assertEquals(2, session.getStore().getNextSenderMsgSeqNum());
-            stub(mockIoSession.getAttribute("QF_SESSION")).toReturn(session);
+            when(mockIoSession.getAttribute("QF_SESSION")).thenReturn(session);
 
             // garbled: character as group count
             String fixString = "8=FIXT.1.19=6835=B34=249=TARGET52=20180623-22:06:28.97756=SENDER148=foo33=a10=248";

--- a/quickfixj-core/src/test/java/quickfix/mina/ssl/X509TrustManagerWrapperTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/ssl/X509TrustManagerWrapperTest.java
@@ -11,6 +11,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
 public class X509TrustManagerWrapperTest {
 
     private X509TrustManagerWrapper underTest;
@@ -18,14 +21,14 @@ public class X509TrustManagerWrapperTest {
 
     @Before
     public void setUp() throws Exception {
-        trustManager = Mockito.mock(X509TrustManager.class);
+        trustManager = mock(X509TrustManager.class);
         underTest = new X509TrustManagerWrapper(trustManager);
     }
 
     @Test
     public void shouldWrapX509TrustManagers() {
-        TrustManager[] managers = new TrustManager[] { Mockito.mock(TrustManager.class),
-                Mockito.mock(X509TrustManager.class) };
+        TrustManager[] managers = new TrustManager[]{mock(TrustManager.class),
+            mock(X509TrustManager.class)};
 
         TrustManager[] wrapped = X509TrustManagerWrapper.wrap(managers);
 
@@ -38,8 +41,8 @@ public class X509TrustManagerWrapperTest {
     @Test(expected = CertificateException.class)
     public void shouldRethrowCertificateExceptionOnCheckClientTrusted() throws Exception {
         // underlying trust manager should throw runtime exception
-        Mockito.doThrow(new RuntimeException()).when(trustManager)
-                .checkClientTrusted(Mockito.any(X509Certificate[].class), Mockito.anyString());
+        doThrow(new RuntimeException()).when(trustManager)
+                .checkClientTrusted(Mockito.<X509Certificate[]>any(), Mockito.<String>any());
 
         underTest.checkClientTrusted(null, null);
     }
@@ -47,8 +50,8 @@ public class X509TrustManagerWrapperTest {
     @Test(expected = CertificateException.class)
     public void shouldRethrowCertificateExceptionOnCheckServerTrusted() throws Exception {
         // underlying trust manager should throw runtime exception
-        Mockito.doThrow(new RuntimeException()).when(trustManager)
-                .checkServerTrusted(Mockito.any(X509Certificate[].class), Mockito.anyString());
+        doThrow(new RuntimeException()).when(trustManager)
+                .checkServerTrusted(Mockito.<X509Certificate[]>any(), Mockito.<String>any());
 
         underTest.checkServerTrusted(null, null);
     }


### PR DESCRIPTION
Hello @chrjohn, thank you for starting the release of 2.3.2!
I've noticed that the build failed because branch 2.3.x is not up to date with the recent changes, in particular upgrading from Java 15 to Java 17 and from Windows-2016 to Windows latest.

I've backported the latest build from master to the 2.3.x to restore the build, so it also needs the Maven wrapper.
This also entails upgrading Mockito to a version compatible with Java 17.

