### PR TITLE
Fixes for the branch 2.3.x build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macOS-latest, windows-2016]
+        os: [ubuntu-18.04, macOS-latest, windows-latest]
         java: [8, 11, 15]
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         java: [8, 11, 15]
       fail-fast: false
       max-parallel: 4

--- a/quickfixj-codegenerator/pom.xml
+++ b/quickfixj-codegenerator/pom.xml
@@ -61,6 +61,14 @@
 			<plugin>
 				<artifactId>maven-pmd-plugin</artifactId>
 			</plugin>
+
+                        <plugin>
+                                <artifactId>maven-plugin-plugin</artifactId>
+                                <version>3.11.0</version>
+                                <configuration>
+                                    <goalPrefix>quickfixj-codegenerator</goalPrefix>
+                                </configuration>
+                        </plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
- Replaced windows 2016 by windows latest (since 2016 was removed from the GHA runners)
- Replaced Ubuntu 18 by Ubuntu latest (since 18 was removed from the GHA runners)
- cherry picked commit 2e1a73fc06b88a7a16cb9b3a38651b2c75c2e752 to add the missing goal prefix