### PR TITLE
Fixing test assertions for TLSv1.3

### DIFF
--- a/quickfixj-core/src/test/java/quickfix/mina/ssl/SSLCertificateTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/ssl/SSLCertificateTest.java
@@ -43,6 +43,8 @@ import quickfix.ThreadedSocketInitiator;
 import quickfix.mina.ProtocolFactory;
 import quickfix.mina.SessionConnector;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;
 import java.math.BigInteger;
@@ -757,8 +759,9 @@ public class SSLCertificateTest {
             Session session = findSession(sessionID);
             SSLSession sslSession = SSLUtil.findSSLSession(session);
 
-            if (sslSession == null)
+            if (sslSession == null) {
                 return;
+            }
 
             if (authOn) {
                 // when authentication is on, the SSL session maybe still be alive (invalid) for some time
@@ -880,9 +883,11 @@ public class SSLCertificateTest {
                 Class<?> exceptionType = exception != null ? exception.getClass() : null;
                 Certificate[] peerCertificates = SSLUtil.getPeerCertificates(sslSession);
                 Principal peerPrincipal = SSLUtil.getPeerPrincipal(sslSession);
+                SSLEngine sslEngine = SSLUtil.getSSLEngine(session);
+                SSLEngineResult.HandshakeStatus handshakeStatus = sslEngine != null ? sslEngine.getHandshakeStatus() : null;
 
-                LOGGER.info("SSL session info [sessionID={},isLoggedOn={},sslSession={},sslSession.valid={},peerCertificates={},peerPrincipal={},exceptionMessage={},exceptionType={}]",
-                    sessionID, session.isLoggedOn(), sslSession, sslSession.isValid(), peerCertificates, peerPrincipal, exceptionMessage, exceptionType);
+                LOGGER.info("SSL session info [sessionID={},isLoggedOn={},sslSession={},sslSession.valid={},peerCertificates={},peerPrincipal={},exceptionMessage={},exceptionType={},handshakeStatus={}]",
+                    sessionID, session.isLoggedOn(), sslSession, sslSession.isValid(), peerCertificates, peerPrincipal, exceptionMessage, exceptionType, handshakeStatus);
             }
         }
     }

--- a/quickfixj-core/src/test/java/quickfix/mina/ssl/SSLCertificateTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/ssl/SSLCertificateTest.java
@@ -646,7 +646,7 @@ public class SSLCertificateTest {
 
                 acceptor.assertNoSslExceptionThrown();
                 acceptor.assertLoggedOn(new SessionID(FixVersions.BEGINSTRING_FIX44, "ALFA_SSL", "ZULU_SSL"));
-                acceptor.assertNotAuthenticated(new SessionID(FixVersions.BEGINSTRING_FIX44, "ALFA_SSL", "ZULU_SSL"));
+                acceptor.assertNotAuthenticated(new SessionID(FixVersions.BEGINSTRING_FIX44, "ALFA_SSL", "ZULU_SSL"), false);
 
                 nonSslInitiator.assertNoSslExceptionThrown();
                 nonSslInitiator.assertLoggedOn(new SessionID(FixVersions.BEGINSTRING_FIX44, "ZULU_NON_SSL", "ALFA_NON_SSL"));
@@ -654,7 +654,7 @@ public class SSLCertificateTest {
 
                 acceptor.assertNoSslExceptionThrown();
                 acceptor.assertLoggedOn(new SessionID(FixVersions.BEGINSTRING_FIX44, "ALFA_NON_SSL", "ZULU_NON_SSL"));
-                acceptor.assertNotAuthenticated(new SessionID(FixVersions.BEGINSTRING_FIX44, "ALFA_NON_SSL", "ZULU_NON_SSL"), false);
+                acceptor.assertNotAuthenticated(new SessionID(FixVersions.BEGINSTRING_FIX44, "ALFA_NON_SSL", "ZULU_NON_SSL"));
 
             } finally {
                 sslInitiator.stop();

--- a/quickfixj-core/src/test/java/quickfix/test/util/SSLUtil.java
+++ b/quickfixj-core/src/test/java/quickfix/test/util/SSLUtil.java
@@ -1,0 +1,110 @@
+package quickfix.test.util;
+
+import org.apache.mina.core.filterchain.IoFilterChain;
+import org.apache.mina.core.session.IoSession;
+import org.apache.mina.filter.ssl.SslFilter;
+import quickfix.Session;
+import quickfix.mina.IoSessionResponder;
+import quickfix.mina.ssl.SSLSupport;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.lang.reflect.Field;
+import java.security.Principal;
+import java.security.cert.Certificate;
+
+/**
+ * A utility class for working with SSL/TLS sessions and retrieving SSL-related information
+ * from a {@link Session}. This class provides methods to find the underlying {@link SSLSession},
+ * retrieve peer certificates, and get the peer principal.
+ */
+public final class SSLUtil {
+
+    private static final String IO_SESSION_FIELD_NAME = "ioSession";
+    private static final Field IO_SESSION_FIELD;
+
+    static {
+        try {
+            IO_SESSION_FIELD = IoSessionResponder.class.getDeclaredField(IO_SESSION_FIELD_NAME);
+            IO_SESSION_FIELD.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("Unable to get ioSession field", e);
+        }
+    }
+
+    private SSLUtil() {
+    }
+
+    /**
+     * Retrieves the {@link SSLSession} associated with the given {@link Session}.
+     *
+     * @param session the session from which to retrieve the {@link SSLSession}.
+     * @return the {@link SSLSession} if found, or {@code null} if no SSL session is available.
+     */
+    public static SSLSession findSSLSession(Session session)  {
+        IoSession ioSession = findIoSession(session);
+
+        if (ioSession == null) {
+            return null;
+        }
+
+        IoFilterChain filterChain = ioSession.getFilterChain();
+        SslFilter sslFilter = (SslFilter) filterChain.get(SSLSupport.FILTER_NAME);
+
+        if (sslFilter == null) {
+            return null;
+        }
+
+        return (SSLSession) ioSession.getAttribute(SslFilter.SSL_SECURED);
+    }
+
+
+    /**
+     * Retrieves the {@link IoSession} associated with the given {@link Session}.
+     *
+     * @param session the session from which to retrieve the {@link IoSession}.
+     * @return the {@link IoSession} if found, or {@code null} if no underlying session is available.
+     */
+    public static IoSession findIoSession(Session session) {
+        IoSessionResponder ioSessionResponder = (IoSessionResponder) session.getResponder();
+
+        if (ioSessionResponder == null) {
+            return null;
+        }
+
+        try {
+            return (IoSession) IO_SESSION_FIELD.get(ioSessionResponder);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("Failed to get IO session field",e);
+        }
+    }
+
+    /**
+     * Retrieves the peer certificates from the given {@link SSLSession}.
+     *
+     * @param sslSession the SSL session from which to retrieve the peer certificates.
+     * @return an array of {@link Certificate} objects representing the peer certificates,
+     *         or {@code null} if the peer is unverified.
+     */
+    public static Certificate[] getPeerCertificates(SSLSession sslSession) {
+        try {
+            return sslSession.getPeerCertificates();
+        } catch (SSLPeerUnverifiedException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Retrieves the peer principal from the given {@link SSLSession}.
+     *
+     * @param sslSession the SSL session from which to retrieve the peer principal.
+     * @return the {@link Principal} representing the peer, or {@code null} if the peer is unverified.
+     */
+    public static Principal getPeerPrincipal(SSLSession sslSession) {
+        try {
+            return sslSession.getPeerPrincipal();
+        } catch (SSLPeerUnverifiedException e) {
+            return null;
+        }
+    }
+}

--- a/quickfixj-core/src/test/java/quickfix/test/util/SSLUtil.java
+++ b/quickfixj-core/src/test/java/quickfix/test/util/SSLUtil.java
@@ -90,6 +90,16 @@ public final class SSLUtil {
         }
     }
 
+    /**
+     * Retrieves the {@link SslHandler} associated with the given {@link Session}.
+     * This method first finds the corresponding {@link IoSession} for the provided session,
+     * then retrieves the {@link SslFilter} from the session's filter chain.
+     * If the filter is found, it returns the {@link SslHandler} stored as an attribute in the {@link IoSession}.
+     *
+     * @param session The session for which to retrieve the {@link SslHandler}.
+     * @return The {@link SslHandler} associated with the session, or {@code null} if either
+     *         the {@link IoSession} or the {@link SslFilter} is not found.
+     */
     public static SslHandler getSSLHandler(Session session) {
         IoSession ioSession = findIoSession(session);
 
@@ -107,6 +117,16 @@ public final class SSLUtil {
         return (SslHandler) ioSession.getAttribute(SSL_HANDLER_ATTRIBUTE_KEY);
     }
 
+    /**
+     * Retrieves the {@link SSLEngine} associated with the given {@link Session}.
+     * This method first retrieves the {@link SslHandler} using {@link #getSSLHandler(Session)},
+     * and then attempts to access the {@link SSLEngine} stored within the {@link SslHandler}
+     * using reflection.
+     *
+     * @param session The session for which to retrieve the {@link SSLEngine}.
+     * @return The {@link SSLEngine} associated with the session, or {@code null} if the
+     *         {@link SslHandler} is not found.
+     */
     public static SSLEngine getSSLEngine(Session session) {
         SslHandler sslHandler = getSSLHandler(session);
 

--- a/quickfixj-core/src/test/java/quickfix/test/util/SSLUtil.java
+++ b/quickfixj-core/src/test/java/quickfix/test/util/SSLUtil.java
@@ -17,8 +17,8 @@ import java.security.Principal;
 import java.security.cert.Certificate;
 
 /**
- * A utility class for working with SSL/TLS sessions and retrieving SSL-related information from a {@link Session}. This class provides methods to find the underlying {@link SSLSession}, retrieve peer
- * certificates, and get the peer principal.
+ * A utility class for working with SSL/TLS sessions and retrieving SSL-related information from a {@link Session}.
+ * This class provides methods to find the underlying {@link SSLSession}, retrieve peer certificates, and get the peer principal etc.
  */
 public final class SSLUtil {
 


### PR DESCRIPTION
This will fix the SSL test suite for TLS v1.3.

**Changes**
 - switching cipher suite and TLS version for `SSLCertificateTest` (see https://github.com/quickfix-j/quickfixj/pull/892)
 - refactored some SSL util methods and extracted them to a separate class
 - modified `assertNotAuthenticated` method
 
The problem with  authentication and TLS v1.3 seems to be with MacOS Java version 8 and 11 as it fails continuously with this combination (works fine with MacOS Java 17). I've seen it failing occasionally on Ubuntu.

The authentication actually works fine, but the assertions were not correct. Seeing `Certificate was authenticated` was misleading since the previous checks - `assertSslExceptionThrown`  and `assertNotLoggedOn` were successful, which means that SSL session was actually NOT  established with invalid certificates as expected.

Even when authentication is enabled and SSL handshake fails, the peer certificates (and peer principal) are set for `javax.net.ssl.SSLSession#getPeerCertificates` (there is a note in later versions of Java > 8 in JavaDoc for `getPeerCertificates` saying _Note: The returned value may not be a valid certificate chain and should not be relied on for trust decisions._). This means that we can't rely on the value there. 

It seems that peer certificates and peer princpial are set for all SSL sessions that require authentication regardless if the check was successful or not. Only when auth is disabled e.g by setting `javax.net.ssl.SSLParameters#needClientAuth` to false these certificate chains and peers can be expected to be empty.

For authentication we have to rely on MINA removing the `org.apache.mina.filter.ssl.SslFilter` from `org.apache.mina.core.session.IoSession` filter chain.

Putting a few second delay after initiator start solves the problem as it is enough for MINA to tear down the SSLFilter - that's what I did, but with busy spin loop. I also kept the old validation code for peers that don't require auth.