### PR TITLE
Add nightly SNAPSHOT release to GitHub Packages

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
           cache: 'maven'
 
       - name: Build and Publish SNAPSHOT

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -21,6 +21,7 @@ jobs:
           cache: 'maven'
 
       - name: Build and Publish SNAPSHOT
-        run: ./mvnw deploy -B -V -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}
+        run: ./mvnw deploy -B -V -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }} -D"maven.javadoc.skip"="true" -D"java.util.logging.config.file"="${{github.workspace}}/quickfixj-core/src/test/resources/logging.properties" -D"http.keepAlive"="false" -D"maven.wagon.http.pool"="false" -D"maven.wagon.httpconnectionManager.ttlSeconds"="120"
+
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,5 +1,8 @@
 name: Java SNAPSHOT Release
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:
@@ -13,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: 21
-          cache: 'maven'
+          cache: maven
 
       - name: Build and Publish SNAPSHOT
-        run: ./mvnw deploy -B -V -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }} -D"maven.javadoc.skip"="true" -D"java.util.logging.config.file"="${{github.workspace}}/quickfixj-core/src/test/resources/logging.properties" -D"http.keepAlive"="false" -D"maven.wagon.http.pool"="false" -D"maven.wagon.httpconnectionManager.ttlSeconds"="120"
-
+        run: ./mvnw deploy -B -V -D"maven.javadoc.skip"="true" -D"java.util.logging.config.file"="${{github.workspace}}/quickfixj-core/src/test/resources/logging.properties" -D"http.keepAlive"="false" -D"maven.wagon.http.pool"="false" -D"maven.wagon.httpconnectionManager.ttlSeconds"="120"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,26 @@
+name: Java SNAPSHOT Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  release-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'maven'
+
+      - name: Build and Publish SNAPSHOT
+        run: ./mvnw deploy -B -V -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -320,3 +320,71 @@ Many integrations require specialisation of the FIX Messages, Components and/or 
 ![image info](./src/main/puml/custom_dependencies.png)
 
 ![image info](./src/main/puml/custom_dependencies_fixt11_fixlatest.png)
+
+### Using SNAPSHOTs
+
+The nightly SNAPSHOT releases are available on **GitHub Packages**. 
+GitHub Packages requires authentication - even for public repositories. 
+You need to use a [Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) 
+with `read:packages` permission.
+
+#### Maven Setup:
+
+Add the authentication part to your `settings.xml` file in `servers`:
+
+```xml
+<!--settings.xml-->
+<servers>
+  <server>
+    <id>github-quickfixj</id>
+    <username>USERNAME</username> <!-- Your GitHub username -->
+    <password>GITHUB_PAT</password> <!-- Your GitHub PAT -->
+  </server>
+</servers>
+```
+
+Add the GitHub Packages repository in `repositories` and the desired `SNAPSHOT` version in `dependencies`:
+
+```xml
+<!--pom.xml-->
+<repositories>
+  <repository>
+    <id>github-quickfixj</id>
+    <name>GitHub Packages for quickfixj</name>
+    <url>https://maven.pkg.github.com/quickfixj/quickfixj</url>
+    <snapshots>
+      <enabled>true</enabled>
+    </snapshots>
+  </repository>
+
+  <!-- other repositories-->
+</repositories>
+
+
+<dependencies>
+  <dependency>
+    <groupId>org.quickfixj</groupId>
+    <artifactId>quickfixj-all</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+  </dependency>
+  
+  <!-- other dependencies-->
+</dependencies>
+```
+
+#### Gradle Setup (groovy):
+
+Add the following to your `build.gradle` file:
+
+```groovy
+//build.gradle
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/quickfixj/quickfixj")
+        credentials {
+            username = "USERNAME" // Your GitHub username
+            password = "GITHUB_PAT" // Your GitHub PAT
+        }
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Add the GitHub Packages repository in `repositories` and the desired `SNAPSHOT` 
   <repository>
     <id>github-quickfixj</id>
     <name>GitHub Packages for quickfixj</name>
-    <url>https://maven.pkg.github.com/quickfixj/quickfixj</url>
+    <url>https://maven.pkg.github.com/quickfix-j/quickfixj</url>
     <snapshots>
       <enabled>true</enabled>
     </snapshots>
@@ -380,7 +380,7 @@ Add the following to your `build.gradle` file:
 //build.gradle
 repositories {
     maven {
-        url = uri("https://maven.pkg.github.com/quickfixj/quickfixj")
+        url = uri("https://maven.pkg.github.com/quickfix-j/quickfixj")
         credentials {
             username = "USERNAME" // Your GitHub username
             password = "GITHUB_PAT" // Your GitHub PAT

--- a/pom.xml
+++ b/pom.xml
@@ -604,17 +604,15 @@
 		</profile>
 	</profiles>
 	<distributionManagement>
-		<repository>
-			<id>github</id>
-			<name>GitHub Packages</name>
-			<url>https://maven.pkg.github.com/quickfix-j/quickfixj</url>
-		</repository>
-
 		<snapshotRepository>
 			<id>github</id>
-			<name>GitHub Packages Snapshots</name>
+			<name>GitHub Packages - Snapshots</name>
 			<url>https://maven.pkg.github.com/quickfix-j/quickfixj</url>
 		</snapshotRepository>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
 	</distributionManagement>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -604,14 +604,17 @@
 		</profile>
 	</profiles>
 	<distributionManagement>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
 		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+			<id>github</id>
+			<name>GitHub Packages</name>
+			<url>https://maven.pkg.github.com/quickfix-j/quickfixj</url>
 		</repository>
+
+		<snapshotRepository>
+			<id>github</id>
+			<name>GitHub Packages Snapshots</name>
+			<url>https://maven.pkg.github.com/quickfix-j/quickfixj</url>
+		</snapshotRepository>
 	</distributionManagement>
 
 </project>


### PR DESCRIPTION
Fixes #769 

I came across the discussions under https://github.com/quickfix-j/quickfixj/discussions/941 and the issue https://github.com/quickfix-j/quickfixj/issues/769 and had a look at the snapshot releases.

### Results

- A draft of a GitHub Actions pipeline that **builds with JDK 17** and **publishes to GitHub Packages**
  - The pipeline is set to run on cron (1AM) and on new commits to master
- I tested the publishing to Packages [on my fork](https://github.com/krisbanas?tab=packages&repo_name=quickfixj). .
- The GitHub Packages repo indexes the artifacts as `3.0.0-SNAPSHOT` and keeps them timestamped under the hood.
- I set up a test Gradle project to test resolving the snapshot, it downloads the most recent artifact (upon forcing it to `--refresh-dependencies`).

### Questions/Issues

- The pipeline uses `altDeploymentRepository` flag ([see documentation here](https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html#altDeploymentRepository)) to override the repositories defined in `pom.xml` instead of editing the file itself. The snapshot repo can instead be adjusted in the POM file.
- GitHub Packages seem not to implement any retention policy for snapshots. It means producing new artifacts every day with no clean-up of older ones. GitHub hints at using a [maintenance pipeline](https://github.com/marketplace/actions/delete-package-versions) to handle it.
- Compared to what I've found on the maven central repo, the signatures (`.asc`) files are missing in the Packages.
- Another issue is **lack of support for unauthenticated dependency fetching from the Packages**. You need a PAT to authenticate and GitHub is not likely to change it ([documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#authenticating-to-github-packages)) ([community discussion](https://github.com/orgs/community/discussions/26634)).
- Looking at the CI pipeline, the `./mvnw deploy...` command in the snapshot release pipeline likely misses some parameters.
- I will document the process in README if you decide to go with this solution.

Let me know what you think.