### PR TITLE
Fixed Replace Order UI functionality in Banzai Example

### DIFF
--- a/quickfixj-examples/banzai/src/main/java/quickfix/examples/banzai/BanzaiApplication.java
+++ b/quickfixj-examples/banzai/src/main/java/quickfix/examples/banzai/BanzaiApplication.java
@@ -223,17 +223,34 @@ public class BanzaiApplication implements Application {
         }
 
         OrdStatus ordStatus = (OrdStatus) message.getField(new OrdStatus());
-
+            //handles reject
         if (ordStatus.valueEquals(OrdStatus.REJECTED)) {
             order.setRejected(true);
             order.setOpen(0);
+            //handles cancel
         } else if (ordStatus.valueEquals(OrdStatus.CANCELED)
                 || ordStatus.valueEquals(OrdStatus.DONE_FOR_DAY)) {
             order.setCanceled(true);
             order.setOpen(0);
+            //handles new
         } else if (ordStatus.valueEquals(OrdStatus.NEW)) {
             if (order.isNew()) {
                 order.setNew(false);
+            }
+            // handles replace
+        } else if (ordStatus.valueEquals(OrdStatus.REPLACED)) {
+            OrderQty orderQty = new OrderQty();
+            message.getField(orderQty);
+            order.setQuantity((int) orderQty.getValue());
+            if (message.isSetField(Price.FIELD)) {
+                Price price = new Price();
+                message.getField(price);
+                order.setLimit(price.getValue());
+            }
+            if (message.isSetField(StopPx.FIELD)) {
+                StopPx stopPx = new StopPx();
+                message.getField(stopPx);
+                order.setStop(stopPx.getValue());
             }
         }
 

--- a/quickfixj-examples/banzai/src/main/java/quickfix/examples/banzai/BanzaiApplication.java
+++ b/quickfixj-examples/banzai/src/main/java/quickfix/examples/banzai/BanzaiApplication.java
@@ -223,21 +223,17 @@ public class BanzaiApplication implements Application {
         }
 
         OrdStatus ordStatus = (OrdStatus) message.getField(new OrdStatus());
-            //handles reject
         if (ordStatus.valueEquals(OrdStatus.REJECTED)) {
             order.setRejected(true);
             order.setOpen(0);
-            //handles cancel
         } else if (ordStatus.valueEquals(OrdStatus.CANCELED)
                 || ordStatus.valueEquals(OrdStatus.DONE_FOR_DAY)) {
             order.setCanceled(true);
             order.setOpen(0);
-            //handles new
         } else if (ordStatus.valueEquals(OrdStatus.NEW)) {
             if (order.isNew()) {
                 order.setNew(false);
             }
-            // handles replace
         } else if (ordStatus.valueEquals(OrdStatus.REPLACED)) {
             OrderQty orderQty = new OrderQty();
             message.getField(orderQty);

--- a/quickfixj-examples/banzai/src/main/java/quickfix/examples/banzai/BanzaiApplication.java
+++ b/quickfixj-examples/banzai/src/main/java/quickfix/examples/banzai/BanzaiApplication.java
@@ -241,13 +241,22 @@ public class BanzaiApplication implements Application {
         } else if (ordStatus.valueEquals(OrdStatus.REPLACED)) {
             OrderQty orderQty = new OrderQty();
             message.getField(orderQty);
-            order.setQuantity((int) orderQty.getValue());
-            if (message.isSetField(Price.FIELD)) {
+            order.setQuantity((int)orderQty.getValue());
+
+            LeavesQty leavesQty = new LeavesQty();
+            message.getField(leavesQty);
+            order.setOpen((int)leavesQty.getValue());
+
+            CumQty cumQty = new CumQty();
+            message.getField(cumQty);
+            order.setExecuted((int)cumQty.getValue());
+
+            if (message.isSetField(Price.FIELD)){
                 Price price = new Price();
                 message.getField(price);
                 order.setLimit(price.getValue());
             }
-            if (message.isSetField(StopPx.FIELD)) {
+            if (message.isSetField(StopPx.FIELD)){
                 StopPx stopPx = new StopPx();
                 message.getField(stopPx);
                 order.setStop(stopPx.getValue());


### PR DESCRIPTION
When I was testing the example, Banzai, I found an issue where it wouldn't update the new values in the UI when it receives a REPLACE ExecutionReport. It would retain its previous value. The new version handles and updates the order with the updated value. 