### PR TITLE
completely delete SNAPSHOT packages before deploying new SNAPSHOT version

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -16,6 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Build SNAPSHOT
+        run: ./mvnw clean package -B -V -D"maven.javadoc.skip"="true" -D"java.util.logging.config.file"="${{github.workspace}}/quickfixj-core/src/test/resources/logging.properties" -D"http.keepAlive"="false" -D"maven.wagon.http.pool"="false" -D"maven.wagon.httpconnectionManager.ttlSeconds"="120"
+
       - name: Delete old packages
         continue-on-error: true
         uses: SmartsquareGmbH/delete-old-packages@v0.8.1
@@ -51,14 +61,7 @@ jobs:
             org.quickfixj.quickfixj-parent
             org.quickfixj.quickfixj-perf-test
 
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 21
-          cache: maven
-
-      - name: Build and Publish SNAPSHOT
+      - name: Deploy SNAPSHOT
         run: ./mvnw deploy -B -V -D"maven.javadoc.skip"="true" -D"java.util.logging.config.file"="${{github.workspace}}/quickfixj-core/src/test/resources/logging.properties" -D"http.keepAlive"="false" -D"maven.wagon.http.pool"="false" -D"maven.wagon.httpconnectionManager.ttlSeconds"="120"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - name: Delete old packages
+        continue-on-error: true
         uses: SmartsquareGmbH/delete-old-packages@v0.8.1
         with:
           organization: quickfix-j

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -62,6 +62,6 @@ jobs:
             org.quickfixj.quickfixj-perf-test
 
       - name: Deploy SNAPSHOT
-        run: ./mvnw deploy -B -V -D"maven.javadoc.skip"="true" -D"java.util.logging.config.file"="${{github.workspace}}/quickfixj-core/src/test/resources/logging.properties" -D"http.keepAlive"="false" -D"maven.wagon.http.pool"="false" -D"maven.wagon.httpconnectionManager.ttlSeconds"="120"
+        run: ./mvnw deploy -B -V -DskipTests -D"maven.javadoc.skip"="true" -D"java.util.logging.config.file"="${{github.workspace}}/quickfixj-core/src/test/resources/logging.properties" -D"http.keepAlive"="false" -D"maven.wagon.http.pool"="false" -D"maven.wagon.httpconnectionManager.ttlSeconds"="120"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           organization: quickfix-j
           type: maven
+          keep: 0
           names: |
             org.quickfixj.quickfixj-all
             org.quickfixj.quickfixj-base

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -17,18 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 21
-          cache: maven
-
-      - name: Build and Publish SNAPSHOT
-        run: ./mvnw deploy -B -V -D"maven.javadoc.skip"="true" -D"java.util.logging.config.file"="${{github.workspace}}/quickfixj-core/src/test/resources/logging.properties" -D"http.keepAlive"="false" -D"maven.wagon.http.pool"="false" -D"maven.wagon.httpconnectionManager.ttlSeconds"="120"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Delete old packages
         uses: SmartsquareGmbH/delete-old-packages@v0.8.1
         with:
@@ -62,3 +50,15 @@ jobs:
             org.quickfixj.quickfixj-orchestration
             org.quickfixj.quickfixj-parent
             org.quickfixj.quickfixj-perf-test
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Build and Publish SNAPSHOT
+        run: ./mvnw deploy -B -V -D"maven.javadoc.skip"="true" -D"java.util.logging.config.file"="${{github.workspace}}/quickfixj-core/src/test/resources/logging.properties" -D"http.keepAlive"="false" -D"maven.wagon.http.pool"="false" -D"maven.wagon.httpconnectionManager.ttlSeconds"="120"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Github Packages accumulates packages since each SNAPSHOT version has a new timestamp.
See https://github.com/actions/delete-package-versions/issues/71 or https://stackoverflow.com/questions/68521637/how-to-delete-old-snapshot-artifacts-from-github-packages

SNAPSHOT versions have a distinct timestamp in the repo, but the github action sees all these packages as belonging to the same version, so specifiying a minimum number of versions to keep does not work. So we simply tell the action to keep `0` versions.

To minimize the time in which there is no version available on github packages we will do:
 - build QFJ (this takes about 20 minutes)
 - delete packages
 - deploy packages