### PR TITLE
Update build jobs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,8 +19,6 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
-  schedule:
-    - cron: '39 6 * * 0'
 
 jobs:
   analyze:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,8 +5,6 @@ on:
   push:
   pull_request:
     types: [reopened, opened, synchronize]
-  schedule:
-    - cron:  '30 5 * * *'
 
 jobs:
   test:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -5,9 +5,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
   schedule:
     - cron: '0 1 * * *'
 


### PR DESCRIPTION
we do not need the nightly build to run on `push`
we do not need the other builds to build on `schedule`