### PR TITLE
Disable running nightly build on forks

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   release-snapshot:
+    if: github.repository == 'quickfix-j/quickfixj'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
This should disable running nightly snapshot builds on forks. Removes the need of disabling actions manually after getting failure emails early morning ;).