### PR TITLE
`quickfix.Message#getHeader` subclasses to return Header with respective FIX version header

### DIFF
--- a/quickfixj-base/src/main/java/quickfix/Message.java
+++ b/quickfixj-base/src/main/java/quickfix/Message.java
@@ -432,7 +432,7 @@ public class Message extends FieldMap {
         }
     }
 
-    public final Header getHeader() {
+    public Header getHeader() {
         return header;
     }
 

--- a/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/Message.xsl
+++ b/quickfixj-codegenerator/src/main/resources/org/quickfixj/codegenerator/Message.xsl
@@ -80,6 +80,11 @@ public class Message extends quickfix.Message {
         return new Header(this);
     }
 
+    @Override
+    public Header getHeader() {
+        return (Message.Header)header;
+    }
+
 	public static class Header extends quickfix.Message.Header {
 
 		static final long serialVersionUID = <xsl:value-of select="$serialVersionUID"/>;

--- a/quickfixj-core/src/test/java/quickfix/MessageTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1510,9 +1511,12 @@ public class MessageTest {
     }
 
     @Test
-    public void shouldReturnFixSpecificHeader() {
+    public void shouldReturnFixSpecificHeader() throws FieldNotFound {
         NewOrderSingle order = new NewOrderSingle();
-        assertEquals(quickfix.fix42.Message.Header.class, order.getHeader().getClass());
+        assertSame(quickfix.fix42.Message.Header.class, order.getHeader().getClass());
+
+        order.set(new Signature("foo"));
+        assertEquals(order.getSignature().getValue(), "foo");
     }
 
     private void assertHeaderField(Message message, String expectedValue, int field)

--- a/quickfixj-core/src/test/java/quickfix/MessageTest.java
+++ b/quickfixj-core/src/test/java/quickfix/MessageTest.java
@@ -1509,6 +1509,12 @@ public class MessageTest {
         assertEquals(600, noml5.getGroup(1, 555).delim());
     }
 
+    @Test
+    public void shouldReturnFixSpecificHeader() {
+        NewOrderSingle order = new NewOrderSingle();
+        assertEquals(quickfix.fix42.Message.Header.class, order.getHeader().getClass());
+    }
+
     private void assertHeaderField(Message message, String expectedValue, int field)
             throws FieldNotFound {
         assertEquals(expectedValue, message.getHeader().getString(field));


### PR DESCRIPTION
Fixes https://github.com/quickfix-j/quickfixj/issues/801

The change is backwards compatible since extended message header e.g. `quickfix.fix44.Message.Header` extends `quickfix.Message.Header`.