### PR TITLE
Backport of fix for SSL `server_name` extension value

### DIFF
--- a/quickfixj-core/pom.xml
+++ b/quickfixj-core/pom.xml
@@ -62,6 +62,12 @@
 	    <scope>test</scope>
 	</dependency>
         <dependency>
+            <groupId>org.burningwave</groupId>
+            <artifactId>tools</artifactId>
+            <version>0.27.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
             <version>2.2.4</version>

--- a/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
+++ b/quickfixj-core/src/main/doc/usermanual/usage/configuration.html
@@ -691,6 +691,22 @@
     <TD></TD>
     <TD></TD>
   </TR>
+  <TR ALIGN="left" VALIGN="middle">
+      <TD valign="top"> <I>UseSNI</I></TD>
+      <TD>
+          Enables the SSL engine to use Server Name Indication (SNI). This option is only applicable for initiators.
+          <p>If provided, <i>SNIHostName</i> will be used as the server name. Otherwise, <i>SocketConnectHost</i> or <i>SocketConnectHost&lt;n&gt;</i> will be used.</p>
+          <p>Note: When this option is disabled, the JVM may still implicitly send the SSL <code>server_name</code> extension.</p>
+      </TD>
+      <TD>Y<BR>N</TD>
+      <TD>N</TD>
+  </TR>
+  <TR ALIGN="left" VALIGN="middle">
+      <TD valign="top"> <I>SNIHostName</I></TD>
+      <TD>SNI host name to be used as desired Server Name Indication (SNI) parameter.</TD>
+      <TD></TD>
+      <TD></TD>
+  </TR>
 
   <TR ALIGN="center" VALIGN="middle">
     <TD COLSPAN="4" class="subsection"><A NAME="Security">Socks Proxy Options (Initiator only)</A></TD>

--- a/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/initiator/IoSessionInitiator.java
@@ -38,6 +38,7 @@ import quickfix.mina.NetworkingOptions;
 import quickfix.mina.ProtocolFactory;
 import quickfix.mina.SessionConnector;
 import quickfix.mina.message.FIXProtocolCodecFactory;
+import quickfix.mina.ssl.InitiatorSslFilter;
 import quickfix.mina.ssl.SSLConfig;
 import quickfix.mina.ssl.SSLContextFactory;
 import quickfix.mina.ssl.SSLSupport;
@@ -185,13 +186,29 @@ public class IoSessionInitiator {
         private void installSslFilter(CompositeIoFilterChainBuilder ioFilterChainBuilder)
                 throws GeneralSecurityException {
             final SSLContext sslContext = SSLContextFactory.getInstance(sslConfig);
-            final SslFilter sslFilter = new SslFilter(sslContext, false);
+            final SslFilter sslFilter = new InitiatorSslFilter(sslContext, getSniHostName(sslConfig));
             sslFilter.setEnabledCipherSuites(sslConfig.getEnabledCipherSuites() != null ? sslConfig.getEnabledCipherSuites()
                     : SSLSupport.getDefaultCipherSuites(sslContext));
             sslFilter.setEnabledProtocols(sslConfig.getEnabledProtocols() != null ? sslConfig.getEnabledProtocols()
                     : SSLSupport.getSupportedProtocols(sslContext));
             sslFilter.setEndpointIdentificationAlgorithm(sslConfig.getEndpointIdentificationAlgorithm());
             ioFilterChainBuilder.addLast(SSLSupport.FILTER_NAME, sslFilter);
+        }
+
+        public String getSniHostName(SSLConfig sslConfig) {
+            if (!sslConfig.isUseSNI()) {
+                return null;
+            }
+
+            if (sslConfig.getSniHostName() != null) {
+                return sslConfig.getSniHostName();
+            }
+
+            if (socketAddresses[nextSocketAddressIndex] instanceof InetSocketAddress) {
+                return ((InetSocketAddress) socketAddresses[nextSocketAddressIndex]).getHostName();
+            }
+
+            return null;
         }
 
         @Override

--- a/quickfixj-core/src/main/java/quickfix/mina/ssl/InitiatorSslFilter.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/ssl/InitiatorSslFilter.java
@@ -1,0 +1,64 @@
+package quickfix.mina.ssl;
+
+import org.apache.mina.core.session.IoSession;
+import org.apache.mina.filter.ssl.SslFilter;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+
+public final class InitiatorSslFilter extends SslFilter {
+
+    private final String sniHostName;
+
+    public InitiatorSslFilter(SSLContext sslContext, String sniHostName) {
+        super(sslContext, false);
+        this.sniHostName = sniHostName;
+    }
+
+    @Override
+    protected SSLEngine createEngine(IoSession session, InetSocketAddress addr) {
+        SSLEngine sslEngine;
+
+        if (addr != null) {
+            sslEngine = sslContext.createSSLEngine(addr.getHostName(), addr.getPort());
+        } else {
+            sslEngine = sslContext.createSSLEngine();
+        }
+
+        if (wantClientAuth) {
+            sslEngine.setWantClientAuth(true);
+        }
+
+        if (needClientAuth) {
+            sslEngine.setNeedClientAuth(true);
+        }
+
+        if (enabledCipherSuites != null) {
+            sslEngine.setEnabledCipherSuites(enabledCipherSuites);
+        }
+
+        if (enabledProtocols != null) {
+            sslEngine.setEnabledProtocols(enabledProtocols);
+        }
+
+        if (getEndpointIdentificationAlgorithm() != null) {
+            SSLParameters sslParameters = sslEngine.getSSLParameters();
+            sslParameters.setEndpointIdentificationAlgorithm(getEndpointIdentificationAlgorithm());
+            sslEngine.setSSLParameters(sslParameters);
+        }
+
+        if (sniHostName != null) {
+            SSLParameters sslParameters = sslEngine.getSSLParameters();
+            sslParameters.setServerNames(Arrays.asList(new SNIHostName(sniHostName)));
+            sslEngine.setSSLParameters(sslParameters);
+        }
+
+        sslEngine.setUseClientMode(!session.isServer());
+
+        return sslEngine;
+    }
+}

--- a/quickfixj-core/src/main/java/quickfix/mina/ssl/SSLConfig.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/ssl/SSLConfig.java
@@ -38,6 +38,8 @@ public class SSLConfig {
 	private String[] enabledCipherSuites;
 	private boolean needClientAuth;
 	private String endpointIdentificationAlgorithm;
+    private boolean useSNI;
+    private String sniHostName;
 
 	public String[] getEnabledCipherSuites() {
 		return enabledCipherSuites;
@@ -87,7 +89,15 @@ public class SSLConfig {
 		return endpointIdentificationAlgorithm;
 	}
 
-	public void setEnabledCipherSuites(String[] enabledCipherSuites) {
+    public boolean isUseSNI() {
+        return useSNI;
+    }
+
+    public String getSniHostName() {
+        return sniHostName;
+    }
+
+    public void setEnabledCipherSuites(String[] enabledCipherSuites) {
 		this.enabledCipherSuites = enabledCipherSuites;
 	}
 
@@ -119,7 +129,15 @@ public class SSLConfig {
 		this.endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
 	}
 
-	public void setTrustManagerFactoryAlgorithm(String trustManagerFactoryAlgorithm) {
+    public void setUseSNI(boolean useSNI) {
+        this.useSNI = useSNI;
+    }
+
+    public void setSniHostName(String sniHostName) {
+        this.sniHostName = sniHostName;
+    }
+
+    public void setTrustManagerFactoryAlgorithm(String trustManagerFactoryAlgorithm) {
 		this.trustManagerFactoryAlgorithm = trustManagerFactoryAlgorithm;
 	}
 
@@ -151,12 +169,14 @@ public class SSLConfig {
 				Objects.equals(trustStoreType, sslConfig.trustStoreType) &&
 				Arrays.equals(enabledProtocols, sslConfig.enabledProtocols) &&
 				Arrays.equals(enabledCipherSuites, sslConfig.enabledCipherSuites) &&
-				Objects.equals(endpointIdentificationAlgorithm, sslConfig.endpointIdentificationAlgorithm);
+				Objects.equals(endpointIdentificationAlgorithm, sslConfig.endpointIdentificationAlgorithm) &&
+                Objects.equals(useSNI, sslConfig.useSNI) &&
+                Objects.equals(sniHostName, sslConfig.sniHostName);
 	}
 
 	@Override
 	public int hashCode() {
-		int result = Objects.hash(keyStoreName, keyManagerFactoryAlgorithm, keyStoreType, trustStoreName, trustManagerFactoryAlgorithm, trustStoreType, needClientAuth, endpointIdentificationAlgorithm);
+        int result = Objects.hash(keyStoreName, keyManagerFactoryAlgorithm, keyStoreType, trustStoreName, trustManagerFactoryAlgorithm, trustStoreType, needClientAuth, endpointIdentificationAlgorithm, useSNI, sniHostName);
 		result = 31 * result + Arrays.hashCode(keyStorePassword);
 		result = 31 * result + Arrays.hashCode(trustStorePassword);
 		result = 31 * result + Arrays.hashCode(enabledProtocols);

--- a/quickfixj-core/src/main/java/quickfix/mina/ssl/SSLSupport.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/ssl/SSLSupport.java
@@ -40,6 +40,8 @@ public class SSLSupport {
     public static final String SETTING_TRUST_STORE_TYPE = "TrustStoreType";
     public static final String SETTING_NEED_CLIENT_AUTH = "NeedClientAuth";
     public static final String SETTING_ENDPOINT_IDENTIFICATION_ALGORITHM = "EndpointIdentificationAlgorithm";
+    public static final String SETTING_USE_SNI = "UseSNI";
+    public static final String SETTING_SNI_HOST_NAME = "SNIHostName";
     public static final String SETTING_ENABLED_PROTOCOLS = "EnabledProtocols";
     public static final String SETTING_CIPHER_SUITES = "CipherSuites";
     static final String DEFAULT_STORE_TYPE = "JKS";
@@ -112,6 +114,8 @@ public class SSLSupport {
         sslConfig.setEnabledProtocols(getEnabledProtocols(sessionSettings, sessionID));
         sslConfig.setNeedClientAuth(isNeedClientAuth(sessionSettings, sessionID));
         sslConfig.setEndpointIdentificationAlgorithm(getEndpointIdentificationAlgorithm(sessionSettings, sessionID));
+        sslConfig.setUseSNI(isUseSNI(sessionSettings, sessionID));
+        sslConfig.setSniHostName(getSNIHostName(sessionSettings, sessionID));
 
         return sslConfig;
     }
@@ -152,5 +156,13 @@ public class SSLSupport {
 
     public static String getEndpointIdentificationAlgorithm(SessionSettings sessionSettings, SessionID sessionID) {
         return getString(sessionSettings, sessionID, SETTING_ENDPOINT_IDENTIFICATION_ALGORITHM, null);
+    }
+
+    public static boolean isUseSNI(SessionSettings sessionSettings, SessionID sessionID) {
+        return "Y".equals(getString(sessionSettings, sessionID, SETTING_USE_SNI, "N"));
+    }
+
+    public static String getSNIHostName(SessionSettings sessionSettings, SessionID sessionID) {
+        return getString(sessionSettings, sessionID, SETTING_SNI_HOST_NAME, null);
     }
 }

--- a/quickfixj-core/src/test/java/quickfix/mina/ssl/SSLCertificateTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/ssl/SSLCertificateTest.java
@@ -24,9 +24,7 @@ import org.apache.mina.core.session.IoSession;
 import org.burningwave.tools.net.DefaultHostResolver;
 import org.burningwave.tools.net.HostResolutionRequestInterceptor;
 import org.burningwave.tools.net.MappedHostResolver;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -68,7 +66,6 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Level;
 import org.apache.mina.util.AvailablePortFinder;
 import org.junit.After;
 import quickfix.mina.SocksProxyServer;
@@ -97,17 +94,12 @@ public class SSLCertificateTest {
         this.enabledProtocols = enabledProtocols;
     }
 
-    @BeforeClass
-    public static void setUpClass() {
+    @Before
+    public void setUp() {
         Map<String, String> hostAliases = new HashMap<>();
         hostAliases.put(LOCALHOST_ALIAS, "127.0.0.1");
 
         HostResolutionRequestInterceptor.INSTANCE.install(new MappedHostResolver(hostAliases), DefaultHostResolver.INSTANCE);
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-        HostResolutionRequestInterceptor.INSTANCE.uninstall();
     }
 
     @After
@@ -116,8 +108,9 @@ public class SSLCertificateTest {
             Thread.sleep(500);
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
-            java.util.logging.Logger.getLogger(SSLCertificateTest.class.getName()).log(Level.SEVERE, null, ex);
         }
+
+        HostResolutionRequestInterceptor.INSTANCE.uninstall();
     }
 
     @Test

--- a/quickfixj-core/src/test/java/quickfix/mina/ssl/SSLSupportTest.java
+++ b/quickfixj-core/src/test/java/quickfix/mina/ssl/SSLSupportTest.java
@@ -1,13 +1,16 @@
 package quickfix.mina.ssl;
 
-import java.util.Arrays;
-
-import org.junit.Assert;
 import org.junit.Test;
-
 import quickfix.FixVersions;
 import quickfix.SessionID;
 import quickfix.SessionSettings;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class SSLSupportTest {
 
@@ -18,15 +21,18 @@ public class SSLSupportTest {
 
 		SSLConfig sslConfig = SSLSupport.getSslConfig(sessionSettings, sessionID);
 
-		Assert.assertNull(sslConfig.getEnabledCipherSuites());
-		Assert.assertNull(sslConfig.getEnabledProtocols());
-		Assert.assertEquals("SunX509", sslConfig.getKeyManagerFactoryAlgorithm());
-		Assert.assertEquals(SSLSupport.QUICKFIXJ_KEY_STORE, sslConfig.getKeyStoreName());
-		Assert.assertTrue(Arrays.equals(SSLSupport.QUICKFIXJ_KEY_STORE_PWD.toCharArray(), sslConfig.getKeyStorePassword()));
-		Assert.assertEquals("JKS", sslConfig.getKeyStoreType());
-		Assert.assertEquals("PKIX", sslConfig.getTrustManagerFactoryAlgorithm());
-		Assert.assertNull(sslConfig.getTrustStoreName());
-		Assert.assertNull(sslConfig.getTrustStorePassword());
-		Assert.assertEquals("JKS", sslConfig.getTrustStoreType());
+		assertNull(sslConfig.getEnabledCipherSuites());
+		assertNull(sslConfig.getEnabledProtocols());
+		assertEquals("SunX509", sslConfig.getKeyManagerFactoryAlgorithm());
+		assertEquals(SSLSupport.QUICKFIXJ_KEY_STORE, sslConfig.getKeyStoreName());
+        assertTrue(Arrays.equals(SSLSupport.QUICKFIXJ_KEY_STORE_PWD.toCharArray(), sslConfig.getKeyStorePassword()));
+		assertEquals("JKS", sslConfig.getKeyStoreType());
+		assertEquals("PKIX", sslConfig.getTrustManagerFactoryAlgorithm());
+		assertNull(sslConfig.getTrustStoreName());
+		assertNull(sslConfig.getTrustStorePassword());
+		assertEquals("JKS", sslConfig.getTrustStoreType());
+        assertNull(sslConfig.getEndpointIdentificationAlgorithm());
+        assertFalse(sslConfig.isUseSNI());
+        assertNull(sslConfig.getSniHostName());
 	}
 }

--- a/quickfixj-core/src/test/java/quickfix/test/util/SSLUtil.java
+++ b/quickfixj-core/src/test/java/quickfix/test/util/SSLUtil.java
@@ -1,0 +1,203 @@
+package quickfix.test.util;
+
+import org.apache.mina.core.filterchain.IoFilterChain;
+import org.apache.mina.core.session.AttributeKey;
+import org.apache.mina.core.session.IoSession;
+import org.apache.mina.filter.ssl.SslFilter;
+import org.apache.mina.filter.ssl.SslHandler;
+import quickfix.Session;
+import quickfix.mina.IoSessionResponder;
+import quickfix.mina.ssl.SSLSupport;
+
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.lang.reflect.Field;
+import java.net.IDN;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.security.Principal;
+import java.security.cert.Certificate;
+import java.util.List;
+
+/**
+ * A utility class for working with SSL/TLS sessions and retrieving SSL-related information from a {@link Session}.
+ * This class provides methods to find the underlying {@link SSLSession}, retrieve peer certificates, and get the peer principal etc.
+ */
+public final class SSLUtil {
+
+    private static final String IO_SESSION_FIELD_NAME = "ioSession";
+    private static final String SSL_ENGINE_FIELD_NAME = "mEngine";
+    private static final AttributeKey SSL_HANDLER_ATTRIBUTE_KEY = new AttributeKey(SslHandler.class, "handler");
+    private static final Field IO_SESSION_FIELD;
+    private static final Field SSL_ENGINE_FIELD;
+    private static final int SNI_HOST_NAME_TYPE = 0;
+
+    static {
+        try {
+            IO_SESSION_FIELD = IoSessionResponder.class.getDeclaredField(IO_SESSION_FIELD_NAME);
+            IO_SESSION_FIELD.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("Unable to get field: " + IO_SESSION_FIELD_NAME, e);
+        }
+
+        try {
+            SSL_ENGINE_FIELD = SslHandler.class.getDeclaredField(SSL_ENGINE_FIELD_NAME);
+            SSL_ENGINE_FIELD.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("Unable to get field: " + SSL_ENGINE_FIELD_NAME, e);
+        }
+    }
+
+    private SSLUtil() {
+    }
+
+    /**
+     * Retrieves the {@link SSLSession} associated with the given {@link Session}.
+     *
+     * @param session the session from which to retrieve the {@link SSLSession}.
+     * @return the {@link SSLSession} if found, or {@code null} if no SSL session is available.
+     */
+    public static SSLSession findSSLSession(Session session) {
+        IoSession ioSession = findIoSession(session);
+
+        if (ioSession == null) {
+            return null;
+        }
+
+        IoFilterChain filterChain = ioSession.getFilterChain();
+        SslFilter sslFilter = (SslFilter) filterChain.get(SSLSupport.FILTER_NAME);
+
+        if (sslFilter == null) {
+            return null;
+        }
+
+        return (SSLSession) ioSession.getAttribute(SslFilter.SSL_SECURED);
+    }
+
+    /**
+     * Retrieves the {@link IoSession} associated with the given {@link Session}.
+     *
+     * @param session the session from which to retrieve the {@link IoSession}.
+     * @return the {@link IoSession} if found, or {@code null} if no underlying session is available.
+     */
+    public static IoSession findIoSession(Session session) {
+        IoSessionResponder ioSessionResponder = (IoSessionResponder) session.getResponder();
+
+        if (ioSessionResponder == null) {
+            return null;
+        }
+
+        try {
+            return (IoSession) IO_SESSION_FIELD.get(ioSessionResponder);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("Failed to get IO session field", e);
+        }
+    }
+
+    /**
+     * Retrieves the {@link SslHandler} associated with the given {@link Session}.
+     * This method first finds the corresponding {@link IoSession} for the provided session,
+     * then retrieves the {@link SslFilter} from the session's filter chain.
+     * If the filter is found, it returns the {@link SslHandler} stored as an attribute in the {@link IoSession}.
+     *
+     * @param session The session for which to retrieve the {@link SslHandler}.
+     * @return The {@link SslHandler} associated with the session, or {@code null} if either
+     *         the {@link IoSession} or the {@link SslFilter} is not found.
+     */
+    public static SslHandler getSSLHandler(Session session) {
+        IoSession ioSession = findIoSession(session);
+
+        if (ioSession == null) {
+            return null;
+        }
+
+        IoFilterChain filterChain = ioSession.getFilterChain();
+        SslFilter sslFilter = (SslFilter) filterChain.get(SSLSupport.FILTER_NAME);
+
+        if (sslFilter == null) {
+            return null;
+        }
+
+        return (SslHandler) ioSession.getAttribute(SSL_HANDLER_ATTRIBUTE_KEY);
+    }
+
+    /**
+     * Retrieves the {@link SSLEngine} associated with the given {@link Session}.
+     * This method first retrieves the {@link SslHandler} using {@link #getSSLHandler(Session)},
+     * and then attempts to access the {@link SSLEngine} stored within the {@link SslHandler}
+     * using reflection.
+     *
+     * @param session The session for which to retrieve the {@link SSLEngine}.
+     * @return The {@link SSLEngine} associated with the session, or {@code null} if the
+     *         {@link SslHandler} is not found.
+     */
+    public static SSLEngine getSSLEngine(Session session) {
+        SslHandler sslHandler = getSSLHandler(session);
+
+        if (sslHandler == null) {
+            return null;
+        }
+
+        try {
+            return (SSLEngine) SSL_ENGINE_FIELD.get(sslHandler);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("Failed to get SSL engine field", e);
+        }
+    }
+
+    /**
+     * Retrieves the peer certificates from the given {@link SSLSession}.
+     *
+     * @param sslSession the SSL session from which to retrieve the peer certificates.
+     * @return an array of {@link Certificate} objects representing the peer certificates, or {@code null} if the peer is unverified.
+     */
+    public static Certificate[] getPeerCertificates(SSLSession sslSession) {
+        try {
+            return sslSession.getPeerCertificates();
+        } catch (SSLPeerUnverifiedException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Retrieves the peer principal from the given {@link SSLSession}.
+     *
+     * @param sslSession the SSL session from which to retrieve the peer principal.
+     * @return the {@link Principal} representing the peer, or {@code null} if the peer is unverified.
+     */
+    public static Principal getPeerPrincipal(SSLSession sslSession) {
+        try {
+            return sslSession.getPeerPrincipal();
+        } catch (SSLPeerUnverifiedException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Retrieves the first SNI Server Name that is SNI Host Name (type=0) provided in ClientHello.
+     *
+     * @param sslSession the SSL session from which to retrieve SNI Host Name
+     * @return the SNI Host Name SSL extensions value, or {@code null} if extension neither compatible nor available
+     */
+    public static String getSniHostName(SSLSession sslSession) {
+        if (!(sslSession instanceof ExtendedSSLSession)) {
+            return null;
+        }
+
+        ExtendedSSLSession extendedSSLSession = (ExtendedSSLSession) sslSession;
+        List<SNIServerName> requestedServerNames = extendedSSLSession.getRequestedServerNames();
+
+        for (SNIServerName serverName : requestedServerNames) {
+            if (serverName.getType() == SNI_HOST_NAME_TYPE) {
+                String asciiServerName = new String(serverName.getEncoded(), StandardCharsets.US_ASCII);
+                return IDN.toUnicode(asciiServerName, IDN.USE_STD3_ASCII_RULES);
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
This is a backport of the fix for [#1036 ](https://github.com/quickfix-j/quickfixj/issues/1036) for QFJ 2.3.x