### PR TITLE
Remove unnecessary `IoSession.close()` for session that is already closed

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/mina/AbstractIoHandler.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/AbstractIoHandler.java
@@ -127,7 +127,6 @@ public abstract class AbstractIoHandler extends IoHandlerAdapter {
             throw e;
         } finally {
             ioSession.removeAttribute(SessionConnector.QF_SESSION);
-            ioSession.closeOnFlush();
         }
     }
 

--- a/quickfixj-core/src/main/java/quickfix/mina/initiator/InitiatorProxyIoHandler.java
+++ b/quickfixj-core/src/main/java/quickfix/mina/initiator/InitiatorProxyIoHandler.java
@@ -36,7 +36,7 @@ class InitiatorProxyIoHandler extends AbstractProxyIoHandler {
     }
 
     @Override
-    public void sessionClosed(IoSession ioSession) throws Exception {
+    public void sessionClosed(IoSession ioSession) {
         this.initiatorIoHandler.sessionClosed(ioSession);
     }
 


### PR DESCRIPTION
Close is definitely not required here. At this stage the session is already closed. Close is idempotent so it has no effect.

Call stack.

- `quickfix.mina.AbstractIoHandler#sessionClosed`
- `quickfix.mina.initiator.InitiatorProxyIoHandler#sessionClosed`
- `org.apache.mina.core.filterchain.DefaultIoFilterChain.TailFilter#sessionClosed`

I created additional logging on a different branch to make sure that `org.apache.mina.core.session.IoSession#isClosing` is true every time we get here.

```
@Override
public void sessionClosed(IoSession ioSession) {
    try {
        Session quickFixSession = findQFSession(ioSession);
        if (quickFixSession != null) {
            eventHandlingStrategy.onMessage(quickFixSession, EventHandlingStrategy.END_OF_STREAM);
        }
    } catch (Exception e) {
        throw e;
    } finally {
        Object oldAttribute = ioSession.removeAttribute(SessionConnector.QF_SESSION);
        log.info("test_close [closing={},oldAttribute={}]", ioSession.isClosing(), oldAttribute);
        ioSession.closeOnFlush();
    }
}
```

See build logs in my fork - https://github.com/the-thing/quickfixj/actions/runs/18196717686

Also code https://github.com/apache/mina/blob/04a9b94a3705728f0c805444bf0d54d770fa4b47/mina-core/src/main/java/org/apache/mina/core/session/AbstractIoSession.java#L332