### PR TITLE
Update macOS and JDK distribution for CI job

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
+          distribution: 'corretto'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Test with Maven
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Windows JDK
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
+          distribution: 'corretto'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Test with Maven on Windows


### PR DESCRIPTION
macos-13 will be removed and macos-15 seems to be slow: https://github.com/actions/runner-images/issues/12545