### PR TITLE
Correct `150/ExecType` for FIX 4.1/4.2 in Executor example

### DIFF
--- a/quickfixj-examples/executor/src/main/java/quickfix/examples/executor/Application.java
+++ b/quickfixj-examples/executor/src/main/java/quickfix/examples/executor/Application.java
@@ -238,7 +238,7 @@ public class Application extends quickfix.MessageCracker implements quickfix.App
         Price price = getPrice(order);
 
         quickfix.fix41.ExecutionReport accept = new quickfix.fix41.ExecutionReport(genOrderID(), genExecID(),
-                new ExecTransType(ExecTransType.NEW), new ExecType(ExecType.TRADE), new OrdStatus(OrdStatus.NEW), order
+                new ExecTransType(ExecTransType.NEW), new ExecType(ExecType.NEW), new OrdStatus(OrdStatus.NEW), order
                         .getSymbol(), order.getSide(), orderQty, new LastShares(0), new LastPx(0), new LeavesQty(0),
                 new CumQty(0), new AvgPx(0));
 
@@ -247,7 +247,7 @@ public class Application extends quickfix.MessageCracker implements quickfix.App
 
         if (isOrderExecutable(order, price)) {
             quickfix.fix41.ExecutionReport executionReport = new quickfix.fix41.ExecutionReport(genOrderID(),
-                    genExecID(), new ExecTransType(ExecTransType.NEW), new ExecType(ExecType.TRADE), new OrdStatus(
+                    genExecID(), new ExecTransType(ExecTransType.NEW), new ExecType(ExecType.FILL), new OrdStatus(
                             OrdStatus.FILLED), order.getSymbol(), order.getSide(), orderQty, new LastShares(orderQty
                             .getValue()), new LastPx(price.getValue()), new LeavesQty(0), new CumQty(orderQty
                             .getValue()), new AvgPx(price.getValue()));
@@ -270,7 +270,7 @@ public class Application extends quickfix.MessageCracker implements quickfix.App
         Price price = getPrice(order);
 
         quickfix.fix42.ExecutionReport accept = new quickfix.fix42.ExecutionReport(genOrderID(), genExecID(),
-                new ExecTransType(ExecTransType.NEW), new ExecType(ExecType.TRADE), new OrdStatus(OrdStatus.NEW), order
+                new ExecTransType(ExecTransType.NEW), new ExecType(ExecType.NEW), new OrdStatus(OrdStatus.NEW), order
                         .getSymbol(), order.getSide(), new LeavesQty(0), new CumQty(0), new AvgPx(0));
 
         accept.set(order.getClOrdID());
@@ -278,7 +278,7 @@ public class Application extends quickfix.MessageCracker implements quickfix.App
 
         if (isOrderExecutable(order, price)) {
             quickfix.fix42.ExecutionReport executionReport = new quickfix.fix42.ExecutionReport(genOrderID(),
-                    genExecID(), new ExecTransType(ExecTransType.NEW), new ExecType(ExecType.TRADE), new OrdStatus(
+                    genExecID(), new ExecTransType(ExecTransType.NEW), new ExecType(ExecType.FILL), new OrdStatus(
                             OrdStatus.FILLED), order.getSymbol(), order.getSide(), new LeavesQty(0), new CumQty(
                             orderQty.getValue()), new AvgPx(price.getValue()));
 


### PR DESCRIPTION
Fixes #968 

## Summary

This PR fixes validation failures in the Executor example when running FIX 4.1
and FIX 4.2 sessions. The previous implementation used `ExecType.TRADE` (value
`F`) for outgoing ExecutionReport messages, but this ExecType is only valid
beginning in FIX 4.3. The FIX 4.1/4.2 data dictionaries reject this value.

