### PR TITLE
Make `DataDictionaryTest` external DTD error assertion locale-independent

### DIFF
--- a/quickfixj-base/src/test/java/quickfix/DataDictionaryTest.java
+++ b/quickfixj-base/src/test/java/quickfix/DataDictionaryTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Locale;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
@@ -677,11 +678,17 @@ public class DataDictionaryTest {
 
     @Test
     public void shouldFailToLoadDictionaryWhenExternalDTDisDisabled() {
+        Locale originalLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
         try {
-            new DataDictionary("FIX_External_DTD.xml");
-            fail("should fail to load dictionary with external DTD");
-        } catch (ConfigError e) {
-            assertEquals("External DTD: Failed to read external DTD 'mathml.dtd', because 'http' access is not allowed due to restriction set by the accessExternalDTD property.", e.getCause().getCause().getMessage());
+            try {
+                new DataDictionary("FIX_External_DTD.xml");
+                fail("should fail to load dictionary with external DTD");
+            } catch (ConfigError e) {
+                assertEquals("External DTD: Failed to read external DTD 'mathml.dtd', because 'http' access is not allowed due to restriction set by the accessExternalDTD property.", e.getCause().getCause().getMessage());
+            }
+        } finally {
+            Locale.setDefault(originalLocale);
         }
     }
     


### PR DESCRIPTION
Fixes #443.

This test fails on systems where the XML parser returns a localized (non-English) error message.
The test now forces Locale.US and restores the original locale afterward, ensuring consistent behavior across environments.

**Note**: I could not reproduce the localized message in `CH-ZH` on my current setup, but the fix is test-only, low-risk, and directly addresses the issue described.