### PR TITLE
reset disabled session per `SessionSchedule` to avoid message loss on Logon

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -1980,7 +1980,8 @@ public class Session implements Closeable {
             }
         }
 
-        // QFJ-965: allow the session schedule block above to run even when disabled,
+        // https://github.com/quickfix-j/quickfixj/issues/965
+        // allow the session schedule block above to run even when disabled,
         // so that sequence numbers are reset as scheduled and message loss is avoided.
         if (!isEnabled() && !isLoggedOn()) {
             return;

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -1979,8 +1979,8 @@ public class Session implements Closeable {
         }
 
         // https://github.com/quickfix-j/quickfixj/issues/965
-        // allow the session schedule block above to run even when disabled,
-        // so that sequence numbers are reset as scheduled and message loss is avoided.
+        // allow the session schedule block above to run even when session is disabled,
+        // so that sequence numbers are reset as scheduled.
         if (!isEnabled() && !isLoggedOn()) {
             return;
         }

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -1951,12 +1951,10 @@ public class Session implements Closeable {
      */
     public void next() throws IOException {
 
-        if (!isEnabled()) {
-            if (isLoggedOn()) {
-                if (!state.isLogoutSent()) {
-                    getLog().onEvent("Initiated logout request");
-                    generateLogout(state.getLogoutReason());
-                }
+        if (!isEnabled() && isLoggedOn()) {
+            if (!state.isLogoutSent()) {
+                getLog().onEvent("Initiated logout request");
+                generateLogout(state.getLogoutReason());
             }
         }
 

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -1957,8 +1957,6 @@ public class Session implements Closeable {
                     getLog().onEvent("Initiated logout request");
                     generateLogout(state.getLogoutReason());
                 }
-            } else {
-                return;
             }
         }
 
@@ -1980,6 +1978,12 @@ public class Session implements Closeable {
                     resetIfSessionNotCurrent(sessionID, now);
                 }
             }
+        }
+
+        // QFJ-965: allow the session schedule block above to run even when disabled,
+        // so that sequence numbers are reset as scheduled and message loss is avoided.
+        if (!isEnabled() && !isLoggedOn()) {
+            return;
         }
 
         // Return if we are not connected

--- a/quickfixj-core/src/test/java/quickfix/SessionTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionTest.java
@@ -3193,6 +3193,63 @@ public class SessionTest {
     }
 
     /**
+     * https://github.com/quickfix-j/quickfixj/issues/965
+     * Verify that a disabled session is still reset per its SessionSchedule to avoid
+     * message loss when sequence numbers have advanced (e.g. messages queued via
+     * sendToTarget while the session was disconnected).
+     */
+    @Test
+    public void testDisabledSessionIsResetBySchedule() throws Exception {
+        // truncate to seconds, otherwise the session time check in Session.next()
+        // might already reset the session since the session schedule has only precision of seconds
+        final LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+        ZoneOffset offset = ZoneOffset.systemDefault().getRules().getOffset(now);
+        final MockSystemTimeSource systemTimeSource = new MockSystemTimeSource(
+                now.toInstant(offset).toEpochMilli());
+        SystemTime.setTimeSource(systemTimeSource);
+
+        final SessionID sessionID = new SessionID(FixVersions.BEGINSTRING_FIX44, "SENDER", "TARGET");
+        final SessionSettings settings = SessionSettingsTest.setUpSession(null);
+        // session window is in the future so we are currently outside session time
+        settings.setString("StartTime", UtcTimeOnlyConverter.convert(now.toLocalTime().plus(3600000L, ChronoUnit.MILLIS), UtcTimestampPrecision.SECONDS));
+        settings.setString("EndTime", UtcTimeOnlyConverter.convert(now.toLocalTime().plus(7200000L, ChronoUnit.MILLIS), UtcTimestampPrecision.SECONDS));
+        settings.setString("TimeZone", TimeZone.getDefault().getID());
+
+        final SessionSchedule sessionSchedule = new DefaultSessionSchedule(settings, sessionID);
+        final UnitTestApplication application = new UnitTestApplication();
+        try (Session session = new SessionFactoryTestSupport.Builder()
+                .setSessionId(sessionID)
+                .setApplication(application)
+                .setSessionSchedule(sessionSchedule)
+                .setIsInitiator(false)
+                .build()) {
+            session.addStateListener(application);
+            final SessionState state = getSessionState(session);
+
+            assertEquals(1, state.getNextSenderMsgSeqNum());
+            assertEquals(1, state.getNextTargetMsgSeqNum());
+
+            // simulate messages queued via sendToTarget while the session was disabled
+            session.setNextSenderMsgSeqNum(5);
+            session.setNextTargetMsgSeqNum(3);
+            assertTrue(state.isResetNeeded());
+
+            // disable the session (e.g. as a result of calling logout())
+            session.logout();
+            assertFalse(session.isEnabled());
+            assertFalse(session.isLoggedOn());
+
+            // next() should trigger a reset per the session schedule even though
+            // the session is disabled, to avoid message loss (QFJ-965)
+            session.next();
+
+            assertEquals(1, state.getNextSenderMsgSeqNum());
+            assertEquals(1, state.getNextTargetMsgSeqNum());
+            assertEquals(1, application.sessionResets);
+        }
+    }
+
+    /**
      * https://github.com/quickfix-j/quickfixj/issues/646
      * Verify that resend operations abort when send() returns false.
      * When a responder disconnects mid-resend, the resend operation should stop

--- a/quickfixj-core/src/test/java/quickfix/SessionTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionTest.java
@@ -3246,6 +3246,8 @@ public class SessionTest {
             assertEquals(1, state.getNextSenderMsgSeqNum());
             assertEquals(1, state.getNextTargetMsgSeqNum());
             assertEquals(1, application.sessionResets);
+            assertFalse(session.isEnabled());
+            assertFalse(session.isLoggedOn());
         }
     }
 


### PR DESCRIPTION
Fixes #965

When a session is disabled (e.g. after calling logout()) and has no active connection, Session.next() was returning early before it could reach the SessionSchedule check. This meant that even if the session schedule said it was time to reset, the reset never happened.

The problem shows up when messages are sent via sendToTarget() to a disabled session. They get queued in the message store and advance the sequence numbers. When next() is called by the internal timer, it hits the early return and exits without resetting, so those queued messages are never cleared. The next time the session connects, method next() is called by the timer thread within a second, resetting the message store and losing the stored messages.

The fix is straightforward. Instead of returning immediately when the session is disabled and not logged on, we now let execution fall through to the session schedule block first, and return after it. The existing state.isResetNeeded() check already handles @philipwhiuk's suggestion of only resetting when sequence numbers have actually advanced beyond 1, so no extra logic was needed there.

Changes:
- Session.java: removed the early return for the disabled+not-logged-on case in next(), added the guard after the schedule block instead
- SessionTest.java: added testDisabledSessionIsResetBySchedule which reproduces the exact scenario from the bug report

Tests run:
- SessionTest — 72/72 passing (includes the new test)
- Full quickfixj-core test suite — 0 failures, 0 errors