### PR TITLE
Update `dependabot.yml` to ignore specific Maven dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,16 @@
 
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "maven"
+    directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "org.apache.mina:mina-core"
+        versions: ["<= 2.2.4"]  # Override the stale PR-comment ignore; allow any 2.2.5+ security fix
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Added ignore rule for specific dependency version in Maven updates.

Root Cause: In November 2022, @dependabot ignore this minor version was used on [PR #509](https://github.com/quickfix-j/quickfixj/pull/509), which blocked all mina-core 2.2.x updates. The repo's mina-core is currently at 2.2.4, and there's now a security advisory requiring a newer 2.2.x patch — but Dependabot's stored ignore rule is still blocking those versions. Since the PR is >2 years old, @dependabot unignore on it doesn't work.

Solution: GitHub's docs state that ignore conditions in dependabot.yml completely override any stored PR-comment-based ignores for that dependency. 
Once the security PR is created and merged, you can remove this ignore entry entirely.