### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "org.apache.mina:mina-core"
+        versions: ["<= 2.2.4"]  # Override the stale PR-comment ignore; allow any 2.2.5+ security fix
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Also see #1216

Added ignore rule for specific dependency version in Maven updates.

Root Cause: In November 2022, https://github.com/dependabot ignore this minor version was used on https://github.com/quickfix-j/quickfixj/pull/509, which blocked all mina-core 2.2.x updates. The repo's mina-core is currently at 2.2.4, and there's now a security advisory requiring a newer 2.2.x patch — but Dependabot's stored ignore rule is still blocking those versions. Since the PR is >2 years old, https://github.com/dependabot unignore on it doesn't work.

Solution: GitHub's docs state that ignore conditions in dependabot.yml completely override any stored PR-comment-based ignores for that dependency.
Once the security PR is created and merged, you can remove this ignore entry entirely.