### PR TITLE
feat: add `SessionStateListener` callback when a PossDup message is discarded

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -1841,6 +1841,7 @@ public class Session implements Closeable {
             // Handle poss dup where msgSeq is as expected
             // FIX 4.4 Vol 2, test case 2f&g
             if (isPossibleDuplicate(msg) && !validatePossDup(msg)) {
+                stateListener.onPossDupMessageDiscarded(sessionID, msg);
                 return false;
             }
 
@@ -1881,7 +1882,9 @@ public class Session implements Closeable {
             generateLogout(text);
             throw new SessionException(text);
         }
-        return validatePossDup(msg);
+        final boolean validPossDup = validatePossDup(msg);
+        stateListener.onPossDupMessageDiscarded(sessionID, msg);
+        return validPossDup;
     }
 
     private void doBadCompID(Message msg) throws IOException, FieldNotFound {

--- a/quickfixj-core/src/main/java/quickfix/Session.java
+++ b/quickfixj-core/src/main/java/quickfix/Session.java
@@ -1834,6 +1834,7 @@ public class Session implements Closeable {
                     return false;
                 } else if (checkTooLow && isTargetTooLow(msgSeqNum)) {
                     doTargetTooLow(msg);
+                    stateListener.onPossDupMessageDiscarded(sessionID, msg);
                     return false;
                 }
             }
@@ -1874,7 +1875,7 @@ public class Session implements Closeable {
         return true;
     }
 
-    private boolean doTargetTooLow(Message msg) throws FieldNotFound, IOException {
+    private void doTargetTooLow(Message msg) throws FieldNotFound, IOException {
         if (!isPossibleDuplicate(msg)) {
             final int msgSeqNum = msg.getHeader().getInt(MsgSeqNum.FIELD);
             final String text = "MsgSeqNum too low, expecting " + getExpectedTargetNum()
@@ -1882,9 +1883,7 @@ public class Session implements Closeable {
             generateLogout(text);
             throw new SessionException(text);
         }
-        final boolean validPossDup = validatePossDup(msg);
-        stateListener.onPossDupMessageDiscarded(sessionID, msg);
-        return validPossDup;
+        validatePossDup(msg);
     }
 
     private void doBadCompID(Message msg) throws IOException, FieldNotFound {

--- a/quickfixj-core/src/main/java/quickfix/SessionStateListener.java
+++ b/quickfixj-core/src/main/java/quickfix/SessionStateListener.java
@@ -105,4 +105,18 @@ public interface SessionStateListener {
      */
     default void onResendRequestSatisfied(SessionID sessionID, int beginSeqNo, int endSeqNo) {
     }
+
+    /**
+     * Called when a received PossDupFlag=Y message is discarded before
+     * application processing because it failed sequence number or
+     * OrigSendingTime validation.
+     * <p>
+     * The message is the full inbound message that was discarded. Listener
+     * implementations must treat it as read-only and must not mutate it.
+     *
+     * @param sessionID affected SessionID
+     * @param message discarded message
+     */
+    default void onPossDupMessageDiscarded(SessionID sessionID, Message message) {
+    }
 }

--- a/quickfixj-core/src/test/java/quickfix/SessionTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionTest.java
@@ -342,7 +342,7 @@ public class SessionTest {
             possDupMessage.getHeader().setBoolean(PossDupFlag.FIELD, true);
             session.next(possDupMessage);
 
-            assertEquals(2, session.getExpectedTargetNum());
+            assertEquals(3, session.getExpectedTargetNum());
             assertNull(application.lastFromAppMessage());
             assertEquals(Reject.MSGTYPE, application.lastToAdminMessage()
                     .getHeader().getString(MsgType.FIELD));

--- a/quickfixj-core/src/test/java/quickfix/SessionTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionTest.java
@@ -67,6 +67,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -320,7 +321,7 @@ public class SessionTest {
             assertEquals(1, application.fromAppMessages.size());
 
             final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
-            verify(mockStateListener).onPossDupMessageDiscarded(session.getSessionID(),
+            verify(mockStateListener).onPossDupMessageDiscarded(eq(session.getSessionID()),
                     messageCaptor.capture());
             assertTrue(possDupMessage == messageCaptor.getValue());
             verifyNoMoreInteractions(mockStateListener);
@@ -348,7 +349,7 @@ public class SessionTest {
                     .getHeader().getString(MsgType.FIELD));
 
             final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
-            verify(mockStateListener).onPossDupMessageDiscarded(session.getSessionID(),
+            verify(mockStateListener).onPossDupMessageDiscarded(eq(session.getSessionID()),
                     messageCaptor.capture());
             assertTrue(possDupMessage == messageCaptor.getValue());
             verifyNoMoreInteractions(mockStateListener);

--- a/quickfixj-core/src/test/java/quickfix/SessionTest.java
+++ b/quickfixj-core/src/test/java/quickfix/SessionTest.java
@@ -295,6 +295,105 @@ public class SessionTest {
     }
 
     @Test
+    public void testTooLowPossDupMessageDiscardNotifiesStateListener() throws Exception {
+        final UnitTestApplication application = new UnitTestApplication();
+        try (Session session = setUpSession(application, false,
+                new UnitTestResponder())) {
+            logonTo(session);
+            session.next(createAppMessage(2));
+
+            assertEquals(3, session.getExpectedTargetNum());
+            assertEquals(1, application.fromAppMessages.size());
+
+            session.addStateListener(new SessionStateListener() {
+                @Override
+                public void onMissedHeartBeat(SessionID sessionID) {
+                }
+            });
+            final SessionStateListener mockStateListener = mock(SessionStateListener.class);
+            session.addStateListener(mockStateListener);
+
+            final Message possDupMessage = createPossDupAppMessage(2);
+            session.next(possDupMessage);
+
+            assertEquals(3, session.getExpectedTargetNum());
+            assertEquals(1, application.fromAppMessages.size());
+
+            final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+            verify(mockStateListener).onPossDupMessageDiscarded(session.getSessionID(),
+                    messageCaptor.capture());
+            assertTrue(possDupMessage == messageCaptor.getValue());
+            verifyNoMoreInteractions(mockStateListener);
+        }
+    }
+
+    @Test
+    public void testExpectedSequencePossDupMessageDiscardNotifiesStateListener()
+            throws Exception {
+        final UnitTestApplication application = new UnitTestApplication();
+        try (Session session = setUpSession(application, false,
+                new UnitTestResponder())) {
+            logonTo(session);
+
+            final SessionStateListener mockStateListener = mock(SessionStateListener.class);
+            session.addStateListener(mockStateListener);
+
+            final Message possDupMessage = createAppMessage(2);
+            possDupMessage.getHeader().setBoolean(PossDupFlag.FIELD, true);
+            session.next(possDupMessage);
+
+            assertEquals(2, session.getExpectedTargetNum());
+            assertNull(application.lastFromAppMessage());
+            assertEquals(Reject.MSGTYPE, application.lastToAdminMessage()
+                    .getHeader().getString(MsgType.FIELD));
+
+            final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+            verify(mockStateListener).onPossDupMessageDiscarded(session.getSessionID(),
+                    messageCaptor.capture());
+            assertTrue(possDupMessage == messageCaptor.getValue());
+            verifyNoMoreInteractions(mockStateListener);
+        }
+    }
+
+    @Test
+    public void testTooLowNonPossDupMessageDoesNotNotifyStateListener() throws Exception {
+        final UnitTestApplication application = new UnitTestApplication();
+        try (Session session = setUpSession(application, false,
+                new UnitTestResponder())) {
+            logonTo(session);
+            session.next(createAppMessage(2));
+
+            final SessionStateListener mockStateListener = mock(SessionStateListener.class);
+            session.addStateListener(mockStateListener);
+
+            processMessage(session, createAppMessage(1));
+
+            verify(mockStateListener, times(0)).onPossDupMessageDiscarded(
+                    any(SessionID.class), any(Message.class));
+        }
+    }
+
+    @Test
+    public void testInSequenceMessageDoesNotNotifyPossDupDiscarded() throws Exception {
+        final UnitTestApplication application = new UnitTestApplication();
+        try (Session session = setUpSession(application, false,
+                new UnitTestResponder())) {
+            logonTo(session);
+
+            final SessionStateListener mockStateListener = mock(SessionStateListener.class);
+            session.addStateListener(mockStateListener);
+
+            session.next(createAppMessage(2));
+
+            assertEquals(3, session.getExpectedTargetNum());
+            assertEquals(1, application.fromAppMessages.size());
+            verify(mockStateListener, times(0)).onPossDupMessageDiscarded(
+                    any(SessionID.class), any(Message.class));
+            verifyNoMoreInteractions(mockStateListener);
+        }
+    }
+
+    @Test
     public void testInferResetSeqNumAcceptedWithNonInitialSequenceNumber()
             throws Exception {
 


### PR DESCRIPTION
## Summary

`SessionStateListener` gains an observe-only callback, `onPossDupMessageDiscarded(SessionID, Message)`, fired when a PossDupFlag=Y message is discarded by the session layer. The spec-mandated discard behavior (FIX session-layer test case 4.5.1(e)) is completely unchanged; applications that need to see these messages, like the GPW WATS case in #1254, can now observe them without forking the engine.

## Why this matters

@chrjohn confirmed in #1254 that the discard is spec-correct and will not change, and proposed exactly this: "some kind of handler or callback that is called on reception of a PossDup message ... I have nothing against putting in callbacks for messages that arrive in the engine anyway." The reporter confirmed a callback covers his use case and is currently running a private fork hack. The new method is a default on `SessionStateListener` (all existing methods are defaults; `onResendRequestSatisfied` is precedent for callbacks with context), invoked via the existing `stateListener` multiplexer at the discard sites in `doTargetTooLow()` and the expected-seqnum `validatePossDup` failure branch in `verify()`. The javadoc states the message was not processed by the application and must not be mutated.

## Testing

`SessionTest` gains cases for the too-low PossDup discard (callback fires, message untouched), the expected-seqnum OrigSendingTime failure (callback fires after the session Reject, target sequence advanced accordingly), and the no-callback path for normal messages. No Java runtime was available in the implementation environment, so CI is the verification run for the suite.

Fixes #1254
