### PR TITLE
Update `dependabot.yml` to ignore certain dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,15 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "org.junit.jupiter:junit-jupiter-engine"
+        versions: [">=6.a0", "<7"]
+      - dependency-name: "org.junit.jupiter:junit-jupiter-params"
+        versions: [">=6.a0", "<7"]
+      - dependency-name: "org.junit.vintage:junit-vintage-engine"
+        versions: [">=6.a0", "<7"]
+      - dependency-name: "org.mockito:mockito-core"
+        versions: [">=5.a", "<6"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Added ignore rules for specific dependencies in Dependabot configuration.

This was done because dependabot ignore conditions which were applied via PRs cannot be removed without the github support when the PR is very old or the branch has been deleted.

See #1217 or #1258 where it was tried to revert an ignore condition but to no avail.

From now on we should only add ignore conditions to the `dependabot.yml` file.