### PR TITLE
Add SelfMatchPreventionID field to FIX50SP2.xml

### DIFF
--- a/quickfixj-messages/quickfixj-messages-fix50sp2/src/main/resources/FIX50SP2.xml
+++ b/quickfixj-messages/quickfixj-messages-fix50sp2/src/main/resources/FIX50SP2.xml
@@ -2061,6 +2061,7 @@
       <component name="TrdRegTimestamps" required="N"/>
       <field name="RefOrderID" required="N"/>
       <field name="RefOrderIDSource" required="N"/>
+      <field name="SelfMatchPreventionID" required="N"/>
     </message>
     <message name="NewOrderList" msgtype="E" msgcat="app">
       <field name="ListID" required="Y"/>
@@ -9937,5 +9938,6 @@
       <value enum="2" description="REJECTED"/>
       <value enum="3" description="TERMINATE_UNASSIGN"/>
     </field>
+    <field number="2362" name="SelfMatchPreventionID" type="STRING"/>
   </fields>
 </fix>


### PR DESCRIPTION
This change introduces the new tag added by Tadawul as part of the PTTP SR3 changes. The tag has been incorporated into the relevant message handling to ensure compatibility with the latest Tadawul specifications and message format requirements.