### PR TITLE
QFJ-1283 Deduplicate checksum calculation

### DIFF
--- a/quickfixj-base/src/main/java/quickfix/FieldMap.java
+++ b/quickfixj-base/src/main/java/quickfix/FieldMap.java
@@ -572,11 +572,9 @@ public abstract class FieldMap implements Serializable, Iterable<Field<?>> {
             if (!groupList.isEmpty()) {
                 if(IS_STRING_EQUIVALENT) {
                     String value = NumbersCache.get(entry.getKey());
-                    for (int i = value.length(); i-- != 0;)
-                        result += value.charAt(i);
+                    result += MessageUtils.checksum(value, 0, value.length());
                     value = NumbersCache.get(groupList.size());
-                    for (int i = value.length(); i-- != 0;)
-                        result += value.charAt(i);
+                    result += MessageUtils.checksum(value, 0, value.length());
                     result += '=' + 1;
                 } else {
                     final IntField groupField = new IntField(entry.getKey());

--- a/quickfixj-base/src/main/java/quickfix/Message.java
+++ b/quickfixj-base/src/main/java/quickfix/Message.java
@@ -213,10 +213,7 @@ public class Message extends FieldMap {
 
     private static void setChecksum(StringBuilder stringBuilder) {
         int checkSumIndex = stringBuilder.lastIndexOf(CHECKSUM_FIELD);
-        int checkSum = 0;
-        for(int i = checkSumIndex; i-- != 0;)
-            checkSum += stringBuilder.charAt(i);
-        String checkSumValue = NumbersCache.get((checkSum + 1) & 0xFF); // better than sum % 256 since it avoids overflow issues
+        String checkSumValue = NumbersCache.get(MessageUtils.checksum(stringBuilder, 0, checkSumIndex + 1));
         checkSumIndex += CHECKSUM_FIELD.length();
         stringBuilder.replace(checkSumIndex + (3 - checkSumValue.length()), checkSumIndex + 3, checkSumValue);
     }

--- a/quickfixj-base/src/main/java/quickfix/MessageUtils.java
+++ b/quickfixj-base/src/main/java/quickfix/MessageUtils.java
@@ -292,15 +292,19 @@ public class MessageUtils {
      */
     public static int checksum(Charset charset, String data, boolean isEntireMessage) {
         if (CharsetSupport.isStringEquivalent(charset)) { // optimization - skip charset encoding
-            int sum = 0;
             int end = isEntireMessage ? data.lastIndexOf("\00110=") : -1;
             int len = end > -1 ? end + 1 : data.length();
-            for (int i = 0; i < len; i++) {
-                sum += data.charAt(i);
-            }
-            return sum & 0xFF; // better than sum % 256 since it avoids overflow issues
+            return checksum(data, 0, len);
         }
         return checksum(data.getBytes(charset), isEntireMessage);
+    }
+
+    static int checksum(CharSequence data, int start, int end) {
+        int sum = 0;
+        for (int i = start; i < end; i++) {
+            sum += data.charAt(i);
+        }
+        return sum & 0xFF; // better than sum % 256 since it avoids overflow issues
     }
 
     /**

--- a/quickfixj-base/src/test/java/quickfix/FieldMapTest.java
+++ b/quickfixj-base/src/test/java/quickfix/FieldMapTest.java
@@ -78,4 +78,14 @@ public class FieldMapTest {
         map.removeGroup(73);
         assertFalse(map.hasGroup(73));
     }
+
+    @Test
+    public void testGroupChecksumMatchesMessageUtils() {
+        FieldMap map = new Message();
+        Group group = new Group(73, 11);
+        group.setString(11, "A");
+        map.addGroup(group);
+
+        assertEquals(MessageUtils.checksum("73=1\00111=A\001"), map.calculateChecksum());
+    }
 }

--- a/quickfixj-base/src/test/java/quickfix/MessageUtilsTest.java
+++ b/quickfixj-base/src/test/java/quickfix/MessageUtilsTest.java
@@ -26,6 +26,9 @@ import quickfix.field.SenderCompID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+
+import java.nio.charset.StandardCharsets;
+
 import org.junit.Test;
 
 /**
@@ -110,6 +113,24 @@ public class MessageUtilsTest {
         String messageString = "8=FIX.4.0\0019=56\00134=1\00149=TW\001" +
             "52=20060118-16:34:19\00156=ISLD\00198=0\001108=2\00110=223";
         assertNull(MessageUtils.getStringField(messageString, 10));
+    }
+
+    @Test
+    public void testStringEquivalentChecksumMatchesStringBuilderFastPath() {
+        String messageString = "8=FIX.4.2\0019=12\00135=X\001108=30\00110=049\001";
+        int checksumFieldIndex = messageString.lastIndexOf("\00110=");
+        StringBuilder messageBuilder = new StringBuilder(messageString);
+
+        assertEquals(MessageUtils.checksum(messageString), MessageUtils.checksum(messageBuilder, 0,
+                checksumFieldIndex + 1));
+    }
+
+    @Test
+    public void testMultibyteChecksumUsesEncodedBytes() {
+        String messageString = "8=FIX.4.2\0019=18\00135=X\00158=\u6D4B\u9A8C\00110=000\001";
+
+        assertEquals(MessageUtils.checksum(messageString.getBytes(StandardCharsets.UTF_8), true),
+                MessageUtils.checksum(StandardCharsets.UTF_8, messageString, true));
     }
 
 }


### PR DESCRIPTION
## Summary

- centralize the string-equivalent checksum loop in `MessageUtils`
- reuse the allocation-free `CharSequence` path from `Message#setChecksum` and `FieldMap#calculateChecksum`
- preserve byte-based checksum calculation for multibyte charsets
- add regression coverage for the `StringBuilder` fast path, UTF-8 encoded bytes, and repeating-group checksum consistency

## Optimization rationale

The shared helper accepts `CharSequence`, so `Message#setChecksum` operates directly on its existing `StringBuilder` without creating a `String` or `byte[]`. String-equivalent charsets continue to use direct character traversal, while non-string-equivalent charsets continue to calculate the checksum from encoded bytes.

## Testing

- `./mvnw -pl quickfixj-base -Dtest=FieldMapTest,MessageUtilsTest test -Dmaven.javadoc.skip=true -PskipBundlePlugin` (16 tests)
- `./mvnw -pl quickfixj-base test -Dmaven.javadoc.skip=true -PskipBundlePlugin` (170 tests)

Fixes #1283